### PR TITLE
Update Set-CsClientPolicy

### DIFF
--- a/skype/skype-ps/skype/Set-CsClientPolicy.md
+++ b/skype/skype-ps/skype/Set-CsClientPolicy.md
@@ -263,7 +263,7 @@ FileDownloadOnly
 Type: AddressBookAvailability
 Parameter Sets: (All)
 Aliases: 
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015
 
 Required: False
 Position: Named


### PR DESCRIPTION
The -AddressBookAvailability parameter does not apply to Skype for Business Online. As indicated earlier in the article (see https://docs.microsoft.com/en-us/powershell/module/skype/set-csclientpolicy?view=skype-ps#description) and through error messages when attempting to run on 365 tenant. Error reads: 'you are not permitted to invoke set-csclientpolicy with the following parameters: addressbookavailability'. Ran as a GA.