### PR TITLE
Host-named site collection inconsistencies

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-server/Copy-SPSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Copy-SPSite.md
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 ```
 
 ### -HostHeaderWebApplication
-Use when the site collection is a host header named site collection that allows the site to land on the correct web application.
+Use when the site collection is a host-named site collection that allows the site to land on the correct web application.
 
 ```yaml
 Type: String

--- a/sharepoint/sharepoint-ps/sharepoint-server/Get-SPManagedPath.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Get-SPManagedPath.md
@@ -32,11 +32,11 @@ This cmdlet contains more than one parameter set.
 You may only use parameters from one parameter set, and you may not combine parameters from different parameter sets.
 For more information about how to use parameter sets, see Cmdlet Parameter Sets (http://go.microsoft.com/fwlink/?LinkID=187810).
 
-The Get-SPManagedPath cmdlet returns the SharePoint managed path that matches the provided Identity for either a Web application, site collection or for all HostHeader site collections. 
+The Get-SPManagedPath cmdlet returns the SharePoint managed path that matches the provided Identity for either a Web application, site collection or for all host-named site collections. 
 If an Identity parameter is not provided, all managed paths for the given scope are returned.
 
-HostHeader sites (no matter the Web application in which they are contained) share a single set of managed paths.
-Use the HostHeader parameter to return host header managed paths.
+Host-named sites (no matter the Web application in which they are contained) share a single set of managed paths.
+Use the HostHeader parameter to return host-named scoped managed paths.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831 (http://go.microsoft.com/fwlink/p/?LinkId=251831).
 
@@ -54,7 +54,7 @@ This example returns all managed paths for the specified Web application.
 C:\PS>Get-SPManagedPath -identity "Sites" -HostHeader
 ```
 
-This example gets the Sites managed path from the HostHeader managed paths.
+This example gets the Sites managed path from the host-named scoped managed paths.
 
 ## PARAMETERS
 
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -HostHeader
-If provided, the managed paths returned are for the HostHeader sites in the farm.
+If provided, the managed paths returned are for the host-named sites in the farm.
 
 ```yaml
 Type: SwitchParameter

--- a/sharepoint/sharepoint-ps/sharepoint-server/Get-SPManagedPath.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Get-SPManagedPath.md
@@ -36,7 +36,7 @@ The Get-SPManagedPath cmdlet returns the SharePoint managed path that matches th
 If an Identity parameter is not provided, all managed paths for the given scope are returned.
 
 Host-named sites (no matter the Web application in which they are contained) share a single set of managed paths.
-Use the HostHeader parameter to return host-named scoped managed paths.
+Use the HostHeader parameter to return host-named site collections-scoped managed paths.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831 (http://go.microsoft.com/fwlink/p/?LinkId=251831).
 
@@ -54,7 +54,7 @@ This example returns all managed paths for the specified Web application.
 C:\PS>Get-SPManagedPath -identity "Sites" -HostHeader
 ```
 
-This example gets the Sites managed path from the host-named scoped managed paths.
+This example gets the Sites managed path from the host-named site collections-scoped managed paths.
 
 ## PARAMETERS
 

--- a/sharepoint/sharepoint-ps/sharepoint-server/New-SPManagedPath.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/New-SPManagedPath.md
@@ -31,7 +31,7 @@ You may only use parameters from one parameter set and you may not combine param
 For more information about how to use parameter sets, see Cmdlet Parameter Sets (http://go.microsoft.com/fwlink/?LinkID=187810).
 
 The `New-SPManagedPath` cmdlet adds a new managed path to a given Web application or for use with all host header site collections.
-If the HostHeader switch is provided, the managed path is shared among all host header site collections; otherwise, a Web application must be specified to create this managed path within.
+If the HostHeader switch is provided, the managed path is shared among all host-named site collections; otherwise, a Web application must be specified to create this managed path within.
 The relative URL is a partial URL that represents the managed path.
 When the slash mark (/) is used, the root is defined.
 If the Explicit parameter is not provided, the new managed path is a wildcard path.

--- a/sharepoint/sharepoint-ps/sharepoint-server/New-SPSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/New-SPSite.md
@@ -48,7 +48,7 @@ C:\PS>$w = Get-SPWebApplication http://<site name>
 C:\PS>New-SPSite http://www.contoso.com -OwnerAlias "DOMAIN\jdow" -HostHeaderWebApplication $w -Name "Contoso" -Template "STS#0"
 ```
 
-This example creates a host header site collection.
+This example creates a host-named site collection.
 Because the template is provided, the root web of this site collection will be created.
 
 
@@ -219,7 +219,7 @@ Accept wildcard characters: False
 ```
 
 ### -HostHeaderWebApplication
-Specifies that if the URL provided is a host header, the HostHeaderWebApplication parameter must be the name, URL, GUID, or SPWebApplication object for the web application in which this site collection is created.
+Specifies that if the URL provided is to be a host-named site collection, the HostHeaderWebApplication parameter must be the name, URL, GUID, or SPWebApplication object for the web application in which this site collection is created.
 If no value is specified, the value is left blank.
 
 The type must be a valid name in one of the following forms:

--- a/sharepoint/sharepoint-ps/sharepoint-server/Remove-SPManagedPath.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Remove-SPManagedPath.md
@@ -33,8 +33,8 @@ For more information about how to use parameter sets, see Cmdlet Parameter Sets 
 The `Remove-SPManagedPath` cmdlet deletes the managed path specified by the Identity parameter from the host header or the Web application.
 The Identity must be the partial URL of the managed path to be deleted.
 
-If you are using host headers, specify the HostHeader parameter.
-To delete a HostHeader managed path, provide the HostHeader switch.
+If you are using host-named site collections, specify the HostHeader parameter.
+To delete a host-named site collection managed path, provide the HostHeader switch.
 Otherwise, you must specify the Web application that contains the managed path to be deleted.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831 (http://go.microsoft.com/fwlink/p/?LinkId=251831).
@@ -47,7 +47,7 @@ For permissions and the most current information about Windows PowerShell for Sh
 C:\PS>Remove-SPManagedPath "sites" -HostHeader
 ```
 
-This example removes the sites managed path from the list of HostHeader managed paths.
+This example removes the sites managed path from the list of host-named site collection managed paths.
 
 Depending on the confirmation level of the local system, the preceding example can prompt prior to execution.
 


### PR DESCRIPTION
Host-named site collections have been around for already a long time. In the past, documentation referred to them as being "hostheader site collections", which is not correct. In fact, if there's one thing that is incompatible to host-named site collections, it's hostheaders. Unfortunately, the cmdlet parameters often use the parameter name "HostHeader" - and of course these cannot be changed. The documentation around these parameters can be changed, however. This pull request aims to use the correct terminology where appropriate to avoid confusion. More recent cmdlets like Copy-SPSite already incorporate the correct terminology in their help files, but older cmdlets didn't.