### PR TITLE
Update Stop-SPDistributedCacheServiceInstance.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -72,7 +72,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -19,15 +19,15 @@ Stop-SPDistributedCacheServiceInstance [-Graceful] [-AssignmentCollection <SPAss
 ```
 
 ## DESCRIPTION
-Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of the Distributed Cache service on a local server. While a `-Graceful` switch does exist, this cmdlet is not capable of properly transferring cached items to another Distributed Cache host within the farm. Follow the guidance available at [Manage the Distributed Cache service in SharePoint Server 2013](https://technet.microsoft.com/en-us/library/jj219613.aspx#graceful) to properly issue a graceful shutdown of the Distributed Cache service.
+Use the Stop-SPDistributedCacheServiceInstance cmdlet to stop an instance of the Distributed Cache service on a local server. While a -Graceful switch does exist, this cmdlet is not capable of properly transferring cached items to another Distributed Cache host within the farm. Follow the guidance available at [Manage the Distributed Cache service in SharePoint Server 2013](https://technet.microsoft.com/en-us/library/jj219613.aspx) to properly issue a graceful shutdown of the Distributed Cache service.
 
-For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831.
+For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at [http://go.microsoft.com/fwlink/p/?LinkId=251831](http://go.microsoft.com/fwlink/p/?LinkId=251831).
 
 ## EXAMPLES
 
 ### Example 1 
 
-{insert example}
+Please see referenced article instead of using this cmdlet directly.
 
 ## PARAMETERS
 

--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Stop-SPDistributedCacheServiceInstance
 
 ## SYNOPSIS
-Stops an instance of the distributed cache service on a local server.
+Stops an instance of the Distributed Cache service on a local server.
 
 
 ## SYNTAX
@@ -19,28 +19,18 @@ Stop-SPDistributedCacheServiceInstance [-Graceful] [-AssignmentCollection <SPAss
 ```
 
 ## DESCRIPTION
-Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of the distributed cache service on a local server.
+Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of the Distributed Cache service on a local server. While a `-Graceful` switch does exist, this cmdlet is not capable of properly transferring cached items to another Distributed Cache host within the farm. Follow the guidance available at https://technet.microsoft.com/en-us/library/jj219613.aspx#graceful to properly issue a graceful shutdown of the Distributed Cache service.
 
-Execution of this cmdlet moves cached items to another server to preserve them.
-If you stop the distributed service before you stop each instance, cached items are lost.
-To prevent cached items from being lost, use the Graceful parameter.
-
-For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831 (http://go.microsoft.com/fwlink/p/?LinkId=251831).
+For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831.
 
 ## EXAMPLES
 
-### ------------EXAMPLE----------
-```
-C:\PS>Stop-SPDistributedCacheServiceInstance -Graceful
-```
-
-This example gracefully stops an instance of a distributed cache service on a local server.
-
+### 
 
 ## PARAMETERS
 
 ### -Graceful
-Specifies whether to gracefully stop an instance of the distributed cache service.
+Specifies whether to gracefully stop an instance of the Distributed Cache service.
 
 ```yaml
 Type: SwitchParameter

--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -25,8 +25,10 @@ For permissions and the most current information about Windows PowerShell for Sh
 
 ## EXAMPLES
 
-### Example 1 
-
+### ------------ Example 1 ----------
+```
+C:\PS>
+```
 Please see referenced article instead of using this cmdlet directly.
 
 ## PARAMETERS

--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -19,7 +19,7 @@ Stop-SPDistributedCacheServiceInstance [-Graceful] [-AssignmentCollection <SPAss
 ```
 
 ## DESCRIPTION
-Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of the Distributed Cache service on a local server. While a `-Graceful` switch does exist, this cmdlet is not capable of properly transferring cached items to another Distributed Cache host within the farm. Follow the guidance available at https://technet.microsoft.com/en-us/library/jj219613.aspx#graceful to properly issue a graceful shutdown of the Distributed Cache service.
+Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of the Distributed Cache service on a local server. While a `-Graceful` switch does exist, this cmdlet is not capable of properly transferring cached items to another Distributed Cache host within the farm. Follow the guidance available at [Manage the Distributed Cache service in SharePoint Server 2013](https://technet.microsoft.com/en-us/library/jj219613.aspx#graceful) to properly issue a graceful shutdown of the Distributed Cache service.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831.
 

--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -24,8 +24,19 @@ Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of t
 For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831.
 
 ## EXAMPLES
+// for every example
+    ### {Example Name}
 
-### 
+    {{Example introduction text}}
+    
+    // one or more times, codesnippet
+    // it's useful to put the ```powershell code
+    // before the plain text command exectution output
+        ```{Syntax language, i.e. PowerShell or nothing for plain text}
+        {{Example body}}
+        ```
+    
+    {{Example remarks}} // not a mandatory, i.e. TechNet articles don't use remarks
 
 ## PARAMETERS
 

--- a/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Stop-SPDistributedCacheServiceInstance.md
@@ -24,19 +24,10 @@ Use the `Stop-SPDistributedCacheServiceInstance` cmdlet to stop an instance of t
 For permissions and the most current information about Windows PowerShell for SharePoint Products, see the online documentation at http://go.microsoft.com/fwlink/p/?LinkId=251831.
 
 ## EXAMPLES
-// for every example
-    ### {Example Name}
 
-    {{Example introduction text}}
-    
-    // one or more times, codesnippet
-    // it's useful to put the ```powershell code
-    // before the plain text command exectution output
-        ```{Syntax language, i.e. PowerShell or nothing for plain text}
-        {{Example body}}
-        ```
-    
-    {{Example remarks}} // not a mandatory, i.e. TechNet articles don't use remarks
+### Example 1 
+
+{insert example}
 
 ## PARAMETERS
 


### PR DESCRIPTION
Update guidance on usage of the `-Graceful` switch. This switch does not facilitate a graceful shutdown of the App Fabric service and a PowerShell script on the referenced link should be used instead.