### PR TITLE
Update New-OfficeWebAppsFarm.md

### DIFF
--- a/officewebapps/officewebapps-ps/officewebapps/New-OfficeWebAppsFarm.md
+++ b/officewebapps/officewebapps-ps/officewebapps/New-OfficeWebAppsFarm.md
@@ -41,12 +41,10 @@ You run this cmdlet on the first server in the Office Online Server farm and the
 
 ### ------------------EXAMPLE 1---------------------
 ```
-New-OfficeWebAppsFarm -InternalUrl "https://server.corp.contoso.com" -ExternalUrl "https://server.external.contoso.com" -EditingEnabled:$true -SSLOffloaded
+New-OfficeWebAppsFarm -ExternalUrl "https://office.contoso.com" -CertificateName "Office Server Cert" -EditingEnabled:$true
 ```
 
-This example creates an Office Online Server farm on the local server that has editing enabled for Office Online.
-The farm is configured for load balancing by enabling SSLOffloaded, which automatically enables AllowHttp.
-If you are not using a load balancer, make sure that you set CertificateName.
+This example creates an Office Online Server farm on the local server that has editing enabled for Office Online. With this example, only a single URL is used for both internal and external users. The Certificate Name value is the Friendly Name of the certificate as it appears in the Computer's certificate store.
 
 ## PARAMETERS
 


### PR DESCRIPTION
The current example introduces a potential security vulnerability by using SSL Offloading and I don't believe this should be encouraged. Rather we should be encouraging a secure state by default. This example also updates a typical issue I see where both internal and external URLs are specified. Generally it is easier to use a single URL rather than specify both provided DNS is correctly configured.