### PR TITLE
Update New-SPEnterpriseSearchSiteHitRule.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-server/New-SPEnterpriseSearchSiteHitRule.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/New-SPEnterpriseSearchSiteHitRule.md
@@ -30,8 +30,7 @@ For permissions and the most current information about Windows PowerShell for Sh
 
 ### ----------------EXAMPLE------------------
 ```
-C:\PS>New-SPEnterpriseSearchSiteHitRule -Identity myHost -Behavior 0 
--HitRate 40
+PS C:\>New-SPEnterpriseSearchSiteHitRule -Name myHost -Behavior 0 -HitRate 40
 ```
 
 This example creates a new site hit rule on the myHost host that limits to 40 the number of simultaneous requests.
@@ -39,10 +38,26 @@ This example creates a new site hit rule on the myHost host that limits to 40 th
 
 ## PARAMETERS
 
+### -Name
+The name of the host to which the site hit rule should be applied.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+Applicable: SharePoint Server 2010, SharePoint Server 2013, SharePoint Server 2016
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Behavior
 Defines a rule to be followed when the farm's search service crawls the given site.
-If a value of zero is specified, the hit rate is the maximum number of simultaneous requests.
-If a value of 1 is specified, then hit rate is the number of seconds to delay between requests to the server.
+
+If a value of zero is specified, the hit rate is the maximum number of simultaneous requests. If a value of 1 is specified, then hit rate is the number of seconds to delay between requests to the server.
 
 ```yaml
 Type: String
@@ -74,13 +89,9 @@ Accept wildcard characters: False
 ```
 
 ### -AssignmentCollection
-Manages objects for the purpose of proper disposal.
-Use of objects, such as SPWeb or SPSite, can use large amounts of memory and use of these objects in Windows PowerShell scripts requires proper memory management.
-Using the SPAssignment object, you can assign objects to a variable and dispose of the objects after they are needed to free up memory.
-When SPWeb, SPSite, or SPSiteAdministration objects are used, the objects are automatically disposed of if an assignment collection or the Global parameter is not used.
+Manages objects for the purpose of proper disposal. Use of objects, such as SPWeb or SPSite, can use large amounts of memory and use of these objects in Windows PowerShell scripts requires proper memory management. Using the SPAssignment object, you can assign objects to a variable and dispose of the objects after they are needed to free up memory. When SPWeb, SPSite, or SPSiteAdministration objects are used, the objects are automatically disposed of if an assignment collection or the Global parameter is not used.
 
-When the Global parameter is used, all objects are contained in the global store.
-If objects are not immediately used, or disposed of by using the `Stop-SPAssignment` command, an out-of-memory scenario can occur.
+When the Global parameter is used, all objects are contained in the global store. If objects are not immediately used, or disposed of by using the Stop-SPAssignment command, an out-of-memory scenario can occur.
 
 ```yaml
 Type: SPAssignmentCollection
@@ -141,22 +152,6 @@ Aliases: wi
 Applicable: SharePoint Server 2010, SharePoint Server 2013, SharePoint Server 2016
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Name
-{{Fill Name Description}}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-Applicable: SharePoint Server 2010, SharePoint Server 2013, SharePoint Server 2016
-
-Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Updated example. While the cmdlet officially has -Identity listed as the parameter, -Name is the correct parameter as -Identity does not exist. Filled in placeholder text on -Name with the info from the -Identity parameter from the man page of the cmdlet.