### PR TITLE
Update New-SPWorkManagementServiceApplication.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-server/New-SPWorkManagementServiceApplication.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/New-SPWorkManagementServiceApplication.md
@@ -1,6 +1,6 @@
 ---
 external help file: 
-applicable: SharePoint Server 2013, SharePoint Server 2016
+applicable: SharePoint Server 2013
 title: New-SPWorkManagementServiceApplication
 schema: 2.0.0
 ---
@@ -29,12 +29,10 @@ Note: This functionality has been removed from SharePoint Server 2016, but the c
 
 ### ------------------EXAMPLE-----------------------
 ```
-C:\PS>$appPool = Get-SPServiceApplicationPool "SharePoint Web Services System Default"
-
-C:\PS>New-SPWorkManagementServiceApplication -Name "WM Service App" -ApplicationPool $appPool
+PS C:\>New-SPWorkManagementServiceApplication -Name 'Work Management Service Application' -ApplicationPool 'SharePoint Web Services Default'
 ```
 
-This example creates a new Work Management Service Application using the "SharePoint Web Services System Default" App Pool.
+This example creates a new Work Management Service Application using the Application Pool named SharePoint Web Services Default.
 
 
 ## PARAMETERS
@@ -47,7 +45,7 @@ If no value is specified, the default application pool is used.
 Type: SPIisWebServiceApplicationPoolPipeBind
 Parameter Sets: (All)
 Aliases: 
-Applicable: SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013
 
 Required: True
 Position: Named
@@ -63,7 +61,7 @@ Specifies the name of the Work Management Service application to be created.
 Type: String
 Parameter Sets: (All)
 Aliases: 
-Applicable: SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013
 
 Required: True
 Position: Named
@@ -73,19 +71,15 @@ Accept wildcard characters: False
 ```
 
 ### -AssignmentCollection
-Manages objects for the purpose of proper disposal.
-Use of objects, such as SPWeb or SPSite, can use large amounts of memory and use of these objects in Windows PowerShell scripts requires proper memory management.
-Using the SPAssignment object, you can assign objects to a variable and dispose of the objects after they are needed to free up memory.
-When SPWeb, SPSite, or SPSiteAdministration objects are used, the objects are automatically disposed of if an assignment collection or the Global parameter is not used.
+Manages objects for the purpose of proper disposal. Use of objects, such as SPWeb or SPSite, can use large amounts of memory and use of these objects in Windows PowerShell scripts requires proper memory management. Using the SPAssignment object, you can assign objects to a variable and dispose of the objects after they are needed to free up memory. When SPWeb, SPSite, or SPSiteAdministration objects are used, the objects are automatically disposed of if an assignment collection or the Global parameter is not used.
 
-When the Global parameter is used, all objects are contained in the global store.
-If objects are not immediately used, or disposed of by using the `Stop-SPAssignment` command, an out-of-memory scenario can occur.
+When the Global parameter is used, all objects are contained in the global store. If objects are not immediately used, or disposed of by using the Stop-SPAssignment command, an out-of-memory scenario can occur.
 
 ```yaml
 Type: SPAssignmentCollection
 Parameter Sets: (All)
 Aliases: 
-Applicable: SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013
 
 Required: False
 Position: Named
@@ -96,13 +90,14 @@ Accept wildcard characters: False
 
 ### -Confirm
 Prompts you for confirmation before executing the command.
+
 For more information, type the following command: `get-help about_commonparameters`
 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
-Applicable: SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013
 
 Required: False
 Position: Named
@@ -118,7 +113,7 @@ Specifies whether to add the Work Management Service application to the proxy gr
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: 
-Applicable: SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013
 
 Required: False
 Position: Named
@@ -135,7 +130,7 @@ For more information, type the following command: `get-help about_commonparamete
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-Applicable: SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013
 
 Required: False
 Position: Named


### PR DESCRIPTION
Kirk, should SharePoint Server 2016 be 'applicable' here even if the cmdlet exists (similar to the SPEdu cmdlets)? The Description of this cmdlet notes that it is no longer usable in the product... I removed 2016 applicability but can put it back if needed.

Updated example.