### PR TITLE
50 Hub Site Limitation

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Register-SPOHubSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Register-SPOHubSite.md
@@ -23,6 +23,9 @@ Use this cmdlet to register an existing site collection as a hub site.
 > [!IMPORTANT]
 > This cmdlet is currently in preview and is subject to change. It is not currently supported for use in production environments.
 
+> [!IMPORTANT]
+> A maximum of 50 hub sites may be created per tenant.
+
 ## EXAMPLES
 
 ### Example 1


### PR DESCRIPTION
Added Important note detailing 50 hub site limitation. This is documented on the [Overview of Programming SharePoint Hub Sites](https://docs.microsoft.com/en-us/sharepoint/dev/features/hub-site/hub-site-overview). Alternatively, if this limitation is not correct on the overview, it should be removed and this pull request cancelled.