### PR TITLE
Adding UserList max size

### DIFF
--- a/exchange/exchange-ps/exchange/mailboxes/Set-App.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-App.md
@@ -217,7 +217,7 @@ For example:
 
 - User ID or user principal name (UPN)
 
-To enter multiple values, use the following syntax: \<value1\>,\<value2\>,...\<valueX\>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "\<value1\>","\<value2\>",..."\<valueX\>".
+To enter multiple values, use the following syntax: \<value1\>,\<value2\>,...\<valueX\>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "\<value1\>","\<value2\>",..."\<valueX\>". Maximum size of the list is 1000 recipients.
 
 You use this parameter with the OrganizationApp switch.
 


### PR DESCRIPTION
I found that UserList parameter is limited to 1000 recipients so I think it's worth adding to the documentation.