### PR TITLE
Update Get-SPOAppInfo.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
@@ -48,7 +48,7 @@ Get-SPOAppInfo -Name " " | Sort Name
 ```
 Example 3 returns the installed application that have a space in the name and sorts the in ascending order. 
 
-## REQUIRED PARAMETERS
+## PARAMETERS
 
 ### -Name
 Specifies the application’s name.

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
@@ -42,8 +42,13 @@ Get-SPOAppInfo -ProductId 6751729b-e017-409d-681a-66f1dd18f0ff
 ```
 Example 2 returns the installed application that has the GUID 6751729b-e017-409d-681a-66f1dd18f0ff. 
 
+###   ------------ Example 3 --------------------
+```
+Get-SPOAppInfo -Name " " | Sort Name
+```
+Example 3 returns the installed application that have a space in the name and sorts the in ascending order. 
 
-## PARAMETERS
+## REQUIRED PARAMETERS
 
 ### -Name
 Specifies the application’s name.


### PR DESCRIPTION
Added an extra example and changed the heading for parameters to required. On docs.microsoft.com the name and productid parameters where descriped as optional instead of required.

I didn't noticed these where required until I saw this text in the description: 
Either ProductId or Name must be given. Name is ignored if ProductId is specified.