### PR TITLE
Update Search-AdminAuditLog.md

### DIFF
--- a/exchange/exchange-ps/exchange/policy-and-compliance-audit/Search-AdminAuditLog.md
+++ b/exchange/exchange-ps/exchange/policy-and-compliance-audit/Search-AdminAuditLog.md
@@ -177,7 +177,8 @@ Accept wildcard characters: False
 ```
 
 ### -ResultSize
-The ResultSize parameter specifies the maximum number of results to return. If you want to return all requests that match the query, use unlimited for the value of this parameter. The default value is 1000.
+The ResultSize parameter specifies the maximum number of results to return. The default value is 1000.
+The maximum results to return is 250.000.
 
 ```yaml
 Type: Int32

--- a/exchange/exchange-ps/exchange/policy-and-compliance-audit/Search-AdminAuditLog.md
+++ b/exchange/exchange-ps/exchange/policy-and-compliance-audit/Search-AdminAuditLog.md
@@ -178,7 +178,7 @@ Accept wildcard characters: False
 
 ### -ResultSize
 The ResultSize parameter specifies the maximum number of results to return. The default value is 1000.
-The maximum results to return is 250.000.
+The maximum results to return is 250,000.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
"Unlimited" does throw an error when attempted to use.
Per source code we limit the number of results to 250k.