### PR TITLE
Update Set-TransportConfig.md

### DIFF
--- a/exchange/exchange-ps/exchange/mail-flow/Set-TransportConfig.md
+++ b/exchange/exchange-ps/exchange/mail-flow/Set-TransportConfig.md
@@ -259,7 +259,7 @@ The valid input range for this parameter is from 0 through 2147483647 bytes. If 
 Type: ByteQuantifiedSize
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Online
+Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016 
 Required: False
 Position: Named
 Default value: None
@@ -442,7 +442,7 @@ The valid input range for this parameter is from 0 through 2147483647 bytes. If 
 Type: ByteQuantifiedSize
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Online
+Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016
 Required: False
 Position: Named
 Default value: None

--- a/exchange/exchange-ps/exchange/mail-flow/Set-TransportConfig.md
+++ b/exchange/exchange-ps/exchange/mail-flow/Set-TransportConfig.md
@@ -237,6 +237,8 @@ Accept wildcard characters: False
 ```
 
 ### -ExternalDsnMaxMessageAttachSize
+This parameter is available only in on-premises Exchange.
+
 The ExternalDsnMaxMessageAttachSize parameter specifies the maximum size of the original message attached to an external DSN message. If the original message exceeds this size, only the headers of the original message are included in the DSN message. The default value is 10 megabytes (MB).
 
 When you enter a value, qualify the value with one of the following units:
@@ -420,6 +422,8 @@ Accept wildcard characters: False
 ```
 
 ### -InternalDsnMaxMessageAttachSize
+This parameter is available only in on-premises Exchange.
+
 The InternalDsnMaxMessageAttachSize parameter specifies the maximum size of the original message that generated an internal DSN message. If the original message exceeds this size, only the headers of the original message are included in the DSN message. The default value is 10 MB.
 
 When you enter a value, qualify the value with one of the following units:


### PR DESCRIPTION
This request is via Content Idea 78803: 
The parameters, InternalDSNMaxMessageAttachSize and ExternalDSNMaxMessageAttachSize cannot be applied to ExO tenants.
We get the error "A parameter cannot be found that matches parameter name 'ExternalDsnMaxMessageAttachSize'." when we run it to online tenant.
According to the existing bug, these parameters don't work with online tenants: https://o365exchange.visualstudio.com/DefaultCollection/IP%20Engineering/_workitems/edit/119182
Please update the content to say those parameters are only for on-prem.