### PR TITLE
Update Set-DynamicDistributionGroup.md

### DIFF
--- a/exchange/exchange-ps/exchange/users-and-groups/Set-DynamicDistributionGroup.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/Set-DynamicDistributionGroup.md
@@ -1625,7 +1625,7 @@ The RecipientFilter parameter specifies an OPath filter that's based on the valu
 
 - Include a hyphen before all operators.
 
-- In cloud-based environments, you can't use a wildcard as the first character. For example, Sales\* is allowed, but \*Sales isn't allowed.
+- In cloud-based environments, you can't use a wildcard as the first character. For example, Sales\* is allowed, but \*Sales isn't allowed. Wildcards are valid only at the end for cloud-based environments and only at the front or back of words for on-prem environments. 
 
 For more information, see Filterable properties for the -RecipientFilter parameter (https://technet.microsoft.com/library/bb738157.aspx).
 


### PR DESCRIPTION
This is via content request 80273: 
The documentation doesn't specify that using a wildcard in the middle of the string will resolve it as a literal. However wildcards can be used in the middle of strings like in ad user. To make this documentation more complete, we should specify exactly how these are to be used, and no only how they can't be used in the cloud. 
I worked on a case for weeks with a customer where we went back and forth on the documentation, as it doesn't say anywhere that wildcards can't be used in the middle of the string, but they can be in other products. To show this as proof to those attempting to do this in the future, this update would be helpful.