### PR TITLE
Update Remove-SPOUserProfile.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOUserProfile.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOUserProfile.md
@@ -19,6 +19,9 @@ Remove-SPOUserProfile -LoginName <String> [<CommonParameters>]
 ## DESCRIPTION
 Can be used to remove the SharePoint user profile from the tenant.
 
+> [!NOTE]
+> The User must be first be deleted from AAD before the user profile can be deleted. You can use the Azure AD cmdlet Remove-AzureADUser for this action
+
 ## EXAMPLES
 
 ###   ------------ Example 1 --------------------


### PR DESCRIPTION
I was getting the following error when removing a SPO User Profile:
Remove-SPOUserProfile : Error: -1, System.Exception, User i:0#.f|membership|miaf@contoso.onmicrosoft.com must be
first be deleted from AAD before the user profile can be deleted.

Added a note section for this prerequisite.