### PR TITLE
Update Set-MailboxCalendarConfiguration.md

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-MailboxCalendarConfiguration.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-MailboxCalendarConfiguration.md
@@ -764,7 +764,7 @@ Aliases:
 Applicable: Exchange Server 2016, Exchange Online
 Required: False
 Position: Named
-Default value: None
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
A bit ambiguous here, we state that '**True**' is the default value, and then we state that it is '**None**'.
I checked the actual attribute and can confirm the real default value is indeed '**True**'.