### PR TITLE
Update Get-MessageTrace.md

### DIFF
--- a/exchange/exchange-ps/exchange/mail-flow/Get-MessageTrace.md
+++ b/exchange/exchange-ps/exchange/mail-flow/Get-MessageTrace.md
@@ -25,7 +25,7 @@ Get-MessageTrace [-EndDate <DateTime>] [-Expression <Expression>] [-FromIP <Stri
 ```
 
 ## DESCRIPTION
-You can use this cmdlet to search message data for the last 7 days. If you run this cmdlet without any parameters, only data from the last 48 hours is returned.
+You can use this cmdlet to search message data for the last 10 days. If you run this cmdlet without any parameters, only data from the last 48 hours is returned.
 
 This cmdlet returns a maximum of 1000000 results, and will timeout on very large queries. If your query returns too many results, consider splitting it up using smaller StartDate and EndDate intervals.
 


### PR DESCRIPTION
From testing I see that this limit has been increased to 10 days:
`[PS] Get-MessageTrace -StartDate (get-Date).AddDays(-10) -EndDate (Get-Date)`
 
Returns results between May 21 and 31, for example.