### PR TITLE
Update New-UnifiedGroup.md

### DIFF
--- a/exchange/exchange-ps/exchange/users-and-groups/New-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/New-UnifiedGroup.md
@@ -452,9 +452,8 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-The Name parameter specifies the name of the Office 365 Group. The maximum length is 64 characters. If the value contains spaces, enclose the value in quotation marks (").
-
-The value that you use for this is parameter is appended with an underscore character (\_) and a short GUID value.
+The Name parameter is no more honored.
+Earlier it was the name property was set to “Name_<RandomGuid>”. Now the recent change was “Alias_<ExternalDirectoryObjectId>”. 
 
 ```yaml
 Type: String

--- a/exchange/exchange-ps/exchange/users-and-groups/New-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/New-UnifiedGroup.md
@@ -136,11 +136,13 @@ Accept wildcard characters: False
 ### -Alias
 The Alias parameter specifies the Exchange alias (also known as the mail nickname) for the Office 365 Group. This value identifies the recipient as a mail-enabled object, and shouldn't be confused with multiple email addresses for the same recipient (also known as proxy addresses). A recipient can have only one Alias value.
 
-The value of Alias can contain letters, numbers and the characters !, #, $, %, &, ', \*, +, -, /, =, ?, ^, \_, `, {, |, } and ~. Periods (.) are allowed, but each period must be surrounded by other valid characters (for example, help.desk). Unicode characters from U+00A1 to U+00FF are also allowed. The maximum length of the Alias value is 64 characters.
+The value of Alias can contain letters, numbers and the characters !, #, $, %, &, ', \*, +, -, /, =, ?, ^, \_, \`, {, |, } and ~. Periods (.) are allowed, but each period must be surrounded by other valid characters (for example, help.desk). Unicode characters from U+00A1 to U+00FF are also allowed. The maximum length of the Alias value is 64 characters.
 
 When you create an Office 365 Group without using the EmailAddresses parameter, the Alias value you specify is used to generate the primary email address (\<alias\>@\<domain\>). Supported Unicode characters are mapped to best-fit US-ASCII text characters. For example, U+00F6 (ö) is changed to oe in the primary email address.
 
 If you don't use the Alias parameter when you create an Office 365 Group, the value of the DisplayName parameter is used. Spaces are removed, unsupported characters are converted to question marks (?), and numbers may be added to maintain the uniqueness of the Alias value.
+
+The Alias value is appended with the ExternalDirectoryObjectId property value and used as the Name property value for the Office 365 group ("Alias\_\<ExternalDirectoryObjectId\>"\).
 
 ```yaml
 Type: String
@@ -452,8 +454,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-The Name parameter is no more honored.
-Earlier it was the name property was set to “Name_<RandomGuid>”. Now the recent change was “Alias_<ExternalDirectoryObjectId>”. 
+This parameter has been deprecated and is no longer used.
+
+Previously, if you specified a value for this parameter, a random GUID value was added and used as the Name property value for the Office 365 group \("Name\_\<RandomGUID\>"\). Now, the value of the Name property is populated by the Alias parameter value and the ExternalDirectoryObjectId property value ("Alias\_\<ExternalDirectoryObjectId\>"\). 
 
 ```yaml
 Type: String


### PR DESCRIPTION
The -name parameter is no longer relevant. we got an update from product engineering team that this was the recent change made to change the name to "“Alias_<ExternalDirectoryObjectId>”. Submitting the request to update the document according to new changes