### PR TITLE
Update Set-Mailbox.md

### DIFF
--- a/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
@@ -4221,7 +4221,7 @@ Accept wildcard characters: False
 ```
 
 ### -MessageCopyForSendOnBehalfEnabled
-The MessageCopyForSendOnBehalfEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send on behalf of" permission. Valid values are:
+The MessageCopyForSendOnBehalfEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send on behalf of" permission. This parameter is available only for shared mailboxes. Valid values are:
 
 - $true: When a user sends a message from the mailbox by using the "send on behalf of" permission, a copy of the message is sent to the sender's mailbox.
 
@@ -4242,7 +4242,7 @@ Accept wildcard characters: False
 ```
 
 ### -MessageCopyForSentAsEnabled
-The MessageCopyForSentAsEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send as" permission. Valid values are:
+The MessageCopyForSentAsEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send as" permission. This parameter is available only for shared mailboxes. Valid values are:
 
 - $true: When a user sends a message from the mailbox by using the "send as" permission, a copy of the message is sent to the sender's mailbox.
 

--- a/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
@@ -4221,11 +4221,13 @@ Accept wildcard characters: False
 ```
 
 ### -MessageCopyForSendOnBehalfEnabled
-The MessageCopyForSendOnBehalfEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send on behalf of" permission. This parameter is available only for shared mailboxes. Valid values are:
+**Note**: This parameter is available only for shared mailboxes.
 
-- $true: When a user sends a message from the mailbox by using the "send on behalf of" permission, a copy of the message is sent to the sender's mailbox.
+The MessageCopyForSendOnBehalfEnabled parameter specifies whether to copy the sender for messages that are sent from a shared mailbox by users that have the "send on behalf of" permission. Valid values are:
 
-- $false: When a user sends a message from the mailbox by using the "send on behalf of" permission, a copy of the message isn't sent to the sender's mailbox. This is the default value.
+- $true: When a user sends a message from the shared mailbox by using the "send on behalf of" permission, a copy of the message is sent to the sender's mailbox.
+
+- $false: When a user sends a message from the shared mailbox by using the "send on behalf of" permission, a copy of the message isn't sent to the sender's mailbox. This is the default value.
 
 You give users permission to send on behalf of a mailbox by using the GrantSendOnBehalfTo parameter on the mailbox.
 
@@ -4242,15 +4244,17 @@ Accept wildcard characters: False
 ```
 
 ### -MessageCopyForSentAsEnabled
-The MessageCopyForSentAsEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send as" permission. This parameter is available only for shared mailboxes. Valid values are:
+**Note**: This parameter is available only for shared mailboxes.
 
-- $true: When a user sends a message from the mailbox by using the "send as" permission, a copy of the message is sent to the sender's mailbox.
+The MessageCopyForSentAsEnabled parameter specifies whether to copy the sender for messages that are sent from a shared mailbox by users that have the "send as" permission. Valid values are:
 
-- $false: When a user sends a message from the mailbox by using the "send as" permission, a copy of the message isn't sent to the sender's mailbox. This is the default value.
+- $true: When a user sends a message from the shared mailbox by using the "send as" permission, a copy of the message is sent to the sender's mailbox.
 
-In Exchange Online, you give a user permission to send as a mailbox by running this command: Add-RecipientPermission \<Mailbox\> -AccessRights SendAs -Trustee \<User\>.
+- $false: When a user sends a message from the shared mailbox by using the "send as" permission, a copy of the message isn't sent to the sender's mailbox. This is the default value.
 
-In on-premises Exchange, you give a user permission to send as a mailbox by running this command: Add-ADPermission \<Mailbox\> -ExtendedRights "Send As" -User \<User\>.
+In Exchange Online, you give a user permission to send as a mailbox by running this command: `Add-RecipientPermission <Mailbox> -AccessRights SendAs -Trustee <User>`.
+
+In on-premises Exchange, you give a user permission to send as a mailbox by running this command: `Add-ADPermission <Mailbox> -ExtendedRights "Send As" -User <User>`.
 
 ```yaml
 Type: $true | $false


### PR DESCRIPTION
The parameters "MessageCopyForSendOnBehalfOfEnabled" and "MessageCopyForSentAsEnabled" currently do not specify that they are available on for Shared Mailboxes, misleading customers and engineers when they're trying to manipulate this behavior.