### PR TITLE
Document new Start-MigrationUser parameters

### DIFF
--- a/exchange/exchange-ps/exchange/move-and-migration/Complete-MigrationBatch.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Complete-MigrationBatch.md
@@ -32,6 +32,8 @@ After a migration batch for a local or cross-forest move has successfully run an
 
 - Converts the source mailbox to a mail-enabled user in the source domain.
 
+In the cloud-based service, this cmdlet sets the value of CompleteAfter to the current time.  It is important to remember that any CompleteAfter setting that has been applied to the individual users within the batch will override the setting on the batch, so some users may still delay completion until their configured time.
+
 When the finalization process is complete, you can remove the batch by using the Remove-MigrationBatch cmdlet.
 
 If a migration batch has a status of Completed with Errors, you can re-attempt to finalize the failed users. In Exchange Online, use the Start-MigrationBatch cmdlet to retry migration for failed users. In Exchange 2013 or Exchange 2016, use the Complete-MigrationBatch to retry these failed users.

--- a/exchange/exchange-ps/exchange/move-and-migration/Complete-MigrationBatch.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Complete-MigrationBatch.md
@@ -32,7 +32,7 @@ After a migration batch for a local or cross-forest move has successfully run an
 
 - Converts the source mailbox to a mail-enabled user in the source domain.
 
-In the cloud-based service, this cmdlet sets the value of CompleteAfter to the current time.  It is important to remember that any CompleteAfter setting that has been applied to the individual users within the batch will override the setting on the batch, so some users may still delay completion until their configured time.
+In the cloud-based service, this cmdlet sets the value of CompleteAfter to the current time.  It is important to remember that any CompleteAfter setting that has been applied to the individual users within the batch will override the setting on the batch, so the completion for some users may be delayed until their configured time.
 
 When the finalization process is complete, you can remove the batch by using the Remove-MigrationBatch cmdlet.
 

--- a/exchange/exchange-ps/exchange/move-and-migration/New-MigrationBatch.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/New-MigrationBatch.md
@@ -433,7 +433,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompleteAfter
-The CompleteAfter parameter specifies a delay before the batch is completed. Data migration for the batch will start, but won't completed until the date/time you specify with this parameter.
+The CompleteAfter parameter specifies a delay before the batch is completed. Data migration for the batch will start, but won't complete until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 
@@ -713,7 +713,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartAfter
-The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The migration will be prepared, but the actual data migration for the user isn't started until the date/time you specify with this parameter.
+The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The migration will be prepared, but the actual data migration for the user won't start until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 

--- a/exchange/exchange-ps/exchange/move-and-migration/New-MigrationBatch.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/New-MigrationBatch.md
@@ -433,7 +433,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompleteAfter
-The CompleteAfter parameter specifies a delay before the batch is completed. The batch is started, but not completed until the date/time you specify with this parameter.
+The CompleteAfter parameter specifies a delay before the batch is completed. Data migration for the batch will start, but won't completed until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 
@@ -713,7 +713,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartAfter
-The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The batch is started, but the data migration for users within the batch isn't started until the date/time you specify with this parameter.
+The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The migration will be prepared, but the actual data migration for the user isn't started until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 

--- a/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationBatch.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationBatch.md
@@ -42,6 +42,8 @@ The Set-MigrationBatch cmdlet configures your existing migration batches to migr
 
 - IMAP migration
 
+Some settings can be applied both to the batch as well as to individual users within the batch. It is important to note that when a setting is applied to a user it will override any corresponding setting on the batch.
+
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 
 ## EXAMPLES
@@ -145,7 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompleteAfter
-The CompleteAfter parameter specifies a delay before the batch is completed. The batch is started, but not completed until the date/time you specify with this parameter.
+The CompleteAfter parameter specifies a delay before the batch is completed. Data migration for the batch will start, but won't completed until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 
@@ -303,7 +305,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartAfter
-The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The batch is started, but the data migration for users within the batch isn't started until the date/time you specify with this parameter.
+The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The migration will be prepared, but the actual data migration for users within the batch isn't started until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 
@@ -442,6 +444,8 @@ Accept wildcard characters: False
 
 ### -Update
 The Update switch sets the Update flag on the migration batch. You don't need to specify a value with this switch.
+
+The Update flag triggers the Migration Service to reapply all of the settings from the endpoint, batch, and user to the migration process.
 
 ```yaml
 Type: SwitchParameter

--- a/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationBatch.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationBatch.md
@@ -147,7 +147,7 @@ Accept wildcard characters: False
 ```
 
 ### -CompleteAfter
-The CompleteAfter parameter specifies a delay before the batch is completed. Data migration for the batch will start, but won't completed until the date/time you specify with this parameter.
+The CompleteAfter parameter specifies a delay before the batch is completed. Data migration for the batch will start, but won't complete until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 
@@ -305,7 +305,7 @@ Accept wildcard characters: False
 ```
 
 ### -StartAfter
-The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The migration will be prepared, but the actual data migration for users within the batch isn't started until the date/time you specify with this parameter.
+The StartAfter parameter specifies a delay before the data migration for the users within the batch is started. The migration will be prepared, but the actual data migration for users within the batch won't start until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 

--- a/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationUser.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationUser.md
@@ -18,12 +18,14 @@ For information about the parameter sets in the Syntax section below, see Exchan
 ## SYNTAX
 
 ```
-Set-MigrationUser [-Identity] <MigrationUserIdParameter> [-BadItemLimit <Unlimited>] [-Confirm]
- [-DomainController <Fqdn>] [-LargeItemLimit <Unlimited>] [-Partition <MailboxIdParameter>] [-SyncNow]
- [-WhatIf] [<CommonParameters>]
+Set-MigrationUser [-Identity] <MigrationUserIdParameter> [-BadItemLimit <Unlimited>]
+ [-CompleteAfter <DateTime>] [-Confirm] [-DomainController <Fqdn>] [-LargeItemLimit <Unlimited>]
+ [-Partition <MailboxIdParameter>] [-StartAfter <DateTime>] [-SyncNow] [-WhatIf] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+Some settings can be applied both to the batch as well as to individual users within the batch. It is important to note that when a setting is applied to a user it will override any corresponding setting on the batch.
+
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 
 ## EXAMPLES
@@ -61,6 +63,33 @@ Valid input for this parameter is an integer or the value unlimited. The default
 
 ```yaml
 Type: Unlimited
+Parameter Sets: (All)
+Aliases:
+Applicable: Exchange Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompleteAfter
+This parameter is available only in the cloud-based service.
+
+The CompleteAfter parameter specifies a delay before the user is completed. Data migration for the user will start, but won't completed until the date/time you specify with this parameter.
+
+Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
+
+In Exchange Online, if you specify a date/time value without a time zone, the value is in Coordinated Universal Time (UTC).
+
+To specify a date/time value for this parameter, use either of the following options:
+
+- Specify the date/time value in UTC: For example, "2016-05-06 14:30:00z".
+
+- Specify the date/time value as a formula that converts the date/time in your local time zone to UTC: For example, (Get-Date "5/6/2016 9:30 AM").ToUniversalTime(). For more information, see Get-Date (https://go.microsoft.com/fwlink/p/?LinkID=113313).
+
+```yaml
+Type: DateTime
 Parameter Sets: (All)
 Aliases:
 Applicable: Exchange Online
@@ -133,6 +162,33 @@ This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: MailboxIdParameter
+Parameter Sets: (All)
+Aliases:
+Applicable: Exchange Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartAfter
+This parameter is available only in the cloud-based service.
+
+The StartAfter parameter specifies a delay before the data migration for the user is started. The migration will be prepared, but the actual data migration for the user isn't started until the date/time you specify with this parameter.
+
+Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
+
+In Exchange Online, if you specify a date/time value without a time zone, the value is in Coordinated Universal Time (UTC).
+
+To specify a date/time value for this parameter, use either of the following options:
+
+- Specify the date/time value in UTC: For example, "2016-05-06 14:30:00z".
+
+- Specify the date/time value as a formula that converts the date/time in your local time zone to UTC: For example, (Get-Date "5/6/2016 9:30 AM").ToUniversalTime(). For more information, see Get-Date (https://go.microsoft.com/fwlink/p/?LinkID=113313).
+
+```yaml
+Type: DateTime
 Parameter Sets: (All)
 Aliases:
 Applicable: Exchange Online

--- a/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationUser.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Set-MigrationUser.md
@@ -76,7 +76,7 @@ Accept wildcard characters: False
 ### -CompleteAfter
 This parameter is available only in the cloud-based service.
 
-The CompleteAfter parameter specifies a delay before the user is completed. Data migration for the user will start, but won't completed until the date/time you specify with this parameter.
+The CompleteAfter parameter specifies a delay before the user is completed. Data migration for the user will start, but won't complete until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 
@@ -175,7 +175,7 @@ Accept wildcard characters: False
 ### -StartAfter
 This parameter is available only in the cloud-based service.
 
-The StartAfter parameter specifies a delay before the data migration for the user is started. The migration will be prepared, but the actual data migration for the user isn't started until the date/time you specify with this parameter.
+The StartAfter parameter specifies a delay before the data migration for the user is started. The migration will be prepared, but the actual data migration for the user won't start until the date/time you specify with this parameter.
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2015 to specify September 1, 2015. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2015 5:00 PM".
 


### PR DESCRIPTION
Providing documentation for the new CompleteAfter and StartAfter parameters for the Set-MigrationUser cmdlet.  Also, this PR contains improvements to the CompleteAfter/StartAfter description in other files (Set-MigrationBatch and New-MigrationBatch), adds a description of what the Update flag does (for Set-MigrationBatch), and adds a note about the relationship between settings that are applied to a MigrationUser versus settings that are applied to the MigrationBatch that contains them.