### PR TITLE
Update SearchResolveExactEmailOrUPN description

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -315,7 +315,7 @@ Accept wildcard characters: False
 ```
 
 ### -SearchResolveExactEmailOrUPN
-Removes the search capability from People Picker. Note, recently resolved names will still appear in the list until browser cache is cleared or expired.
+Removes the search capability from People Picker. Note, recently resolved names will still appear in the list until browser cache is cleared or expired. This also does not allow SharePoint users to search for security groups or SharePoint groups.
 
 SharePoint Administrators will still be able to use starts with or partial name matching when enabled.
 


### PR DESCRIPTION
A customer has asked to update the documentation for 'SearchResolveExactEmailOrUPN', as an escalation occurred where they did not realize site users cannot search for SharePoint groups. 

Link to the escalation: https://icm.ad.msft.net/imp/v3/incidents/details/67399283/home