### PR TITLE
Added hint of equivalent SfBO cmdlet for Get-CsUser

### DIFF
--- a/skype/skype-ps/skype/Get-CsUser.md
+++ b/skype/skype-ps/skype/Get-CsUser.md
@@ -44,6 +44,7 @@ For example, if you don't want to return all your Skype for Business Server user
 (These parameters are mutually exclusive: if you use Filter in a command you cannot use LdapFilter in that same command, and vice-versa.) The Filter parameter enables you to limit the returned data to users who meet the specified Skype for Business Server criteria; for example, you might decide to return only users with accounts on the specified Registrar pool, or only users who have been enabled for Enterprise Voice.
 The LdapFilter parameter enables you to limit the returned data to users who fit other Active Directory-based criteria; for example, users who work in a specified state or province, users who do or do not have a pager, or users with a designated job title.
 
+**Note: the equivalent command for Skype for Business Online is [Get-CsOnlineUser](Get-CsOnlineUser.md)**.
 
 
 ## EXAMPLES


### PR DESCRIPTION
I recently realized that I was not the only one confused with `Get-CsUser` and `Get-CsOnlineUser` (first used for on-premises users, second for the same but in SfB Online) - example [here](https://stackoverflow.com/questions/50765207/get-csuser-error-powershell). I think that'd be useful to include this as a hint.