### PR TITLE
Patch 5

### DIFF
--- a/skype/skype-ps/skype/Get-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Get-CsExternalUserCommunicationPolicy.md
@@ -14,7 +14,7 @@ Returns information about one or more external user communication policies confi
 ## SYNTAX
 
 ```
-Get-CsExternalUserCommunicationPolicy [[-Identity] <Object>] [-BypassDualWrite <Object>] [-Filter <Object>] [-LocalStore] [-Tenant <Object>] [-AsJob] [<CommonParameters>]
+Get-CsExternalUserCommunicationPolicy [[-Identity] <XdsIdentity>] [-Filter <String>] [-LocalStore] [-Tenant <Guid>] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -52,27 +52,11 @@ This example uses the Filter parameter to retrieve all the external user communi
 
 ## PARAMETERS
 
-### -BypassDualWrite
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Filter
 This parameter accepts a wildcard string and returns all external user communication policies with identities matching that string. For example, a Filter value of tag:* will return all external user communication policies excluding Global policy.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -88,7 +72,7 @@ Accept wildcard characters: False
 Unique identifier for the external user communication policy to be created.
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -127,7 +111,7 @@ Get-CsTenant | Select-Object DisplayName, TenantID
 If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Get-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Get-CsExternalUserCommunicationPolicy.md
@@ -53,7 +53,7 @@ This example uses the Filter parameter to retrieve all the external user communi
 ## PARAMETERS
 
 ### -BypassDualWrite
-{{Fill BypassDualWrite Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -100,7 +100,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 ### -LocalStore
-{{Fill LocalStore Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/Get-CsHybridApplicationEndpoint.md
+++ b/skype/skype-ps/skype/Get-CsHybridApplicationEndpoint.md
@@ -14,9 +14,7 @@ This cmdlet was introduced in the July 2017 cumulative update for the Lync Serve
 
 ## SYNTAX
 ```
-Get-CsHybridApplicationEndpoint [-Filter <String>] [-LdapFilter <String>] [-OU <OUIdParameter>]
- [-DomainController <Fqdn>] [-Credential <PSCredential>] [[-Identity] <UserIdParameter>]
- [-ResultSize <Microsoft.Rtc.Management.ADConnect.Core.Unlimited`1[System.UInt32]>] [<CommonParameters>]
+Get-CsHybridApplicationEndpoint [-Filter <String>] [-LdapFilter <String>] [-OU <OUIdParameter>] [-DomainController <Fqdn>] [-Credential <PSCredential>] [[-Identity] <UserIdParameter>] [-ResultSize <Microsoft.Rtc.Management.ADConnect.Core.Unlimited`1[System.UInt32]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
@@ -13,7 +13,7 @@ Use the Get-CsIPPhonePolicy cmdlet to get all the settings of the Skype for Busi
 ## SYNTAX
 
 ```
-Get-CsIPPhonePolicy [[-Identity] <Object>] [-BypassDualWrite <Object>] [-Filter <Object>] [-LocalStore] [-Tenant <Object>] [-AsJob] [<CommonParameters>]
+Get-CsIPPhonePolicy [[-Identity] <XdsIdentity>] [-BypassDualWrite <Object>] [-Filter <String>] [-LocalStore] [-Tenant <Guid>] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,7 +50,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -63,12 +63,10 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Microsoft.Rtc.Management.Xds.XdsIdentity
-
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -97,12 +95,10 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-System.Guid
-
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
@@ -47,7 +47,11 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-{{Fill Filter Description}}
+Enables you to limit the returned data by filtering on Skype for Business Server 2015-specific attributes. For example, you can limit returned data to endpoints with specific word in their DisplayName attribute.
+
+The Filter parameter uses the same Windows PowerShell filtering syntax that is used by the Where-Object cmdlet. For example, a filter that returns only endpoints with a value in their LineURI attribute would look like this, with LineURI representing the Active Directory attribute, -ne representing the comparison operator (not equal to), and $null (a built-in Windows PowerShell variable) representing the filter value:
+
+{LineURI -ne $null}
 
 ```yaml
 Type: Object

--- a/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
@@ -26,7 +26,7 @@ IP phone policies are applied each time a user accesses the system via an IP pho
 PS C:\> Get-CsIPPhonePolicy
 ```
 
-This example returns the global IP phone policy along with all their settings..
+This example returns the global IP phone policy along with all their settings.
 
 ## PARAMETERS
 
@@ -47,11 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-Enables you to limit the returned data by filtering on Skype for Business Server 2015-specific attributes. For example, you can limit returned data to endpoints with specific word in their DisplayName attribute.
-
-The Filter parameter uses the same Windows PowerShell filtering syntax that is used by the Where-Object cmdlet. For example, a filter that returns only endpoints with a value in their LineURI attribute would look like this, with LineURI representing the Active Directory attribute, -ne representing the comparison operator (not equal to), and $null (a built-in Windows PowerShell variable) representing the filter value:
-
-{LineURI -ne $null}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object

--- a/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
@@ -13,7 +13,7 @@ Use the Get-CsIPPhonePolicy cmdlet to get all the settings of the Skype for Busi
 ## SYNTAX
 
 ```
-Get-CsIPPhonePolicy [[-Identity] <XdsIdentity>] [-BypassDualWrite <Object>] [-Filter <String>] [-LocalStore] [-Tenant <Guid>] [-AsJob] [<CommonParameters>]
+Get-CsIPPhonePolicy [[-Identity] <XdsIdentity>] [-Filter <String>] [-LocalStore] [-Tenant <Guid>] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,22 +29,6 @@ PS C:\> Get-CsIPPhonePolicy
 This example returns the global IP phone policy along with all their settings.
 
 ## PARAMETERS
-
-### -BypassDualWrite
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Filter
 This parameter is reserved for internal Microsoft use.

--- a/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Get-CsIPPhonePolicy.md
@@ -31,7 +31,7 @@ This example returns the global IP phone policy along with all their settings..
 ## PARAMETERS
 
 ### -BypassDualWrite
-{{Fill BypassDualWrite Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 ```
 
 ### -LocalStore
-{{Fill LocalStore Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/Grant-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsExternalUserCommunicationPolicy.md
@@ -25,7 +25,7 @@ You can check whether a user has been granted an external user communication pol
 
 ## EXAMPLES
 
-### Example 1 
+### -------------------------- Example 1 -------------------------- 
 
 ```
 PS C:\> Grant-CsExternalUserCommunicationPolicy -Identity "Ken Myer" -PolicyName BlockExternalP2PFileTransfer
@@ -40,13 +40,11 @@ PS C:\> Get-CsOnlineUser -Filter {City -eq "Redmond"} | Grant-CsExternalUserComm
 
 This example assigns the external user communication policy with the Identity BlockExternalP2PFileTransfer to all users in the city of Redmond. The first part of the command calls the Get-CsOnlineUser cmdlet to retrieve all users enabled for Skype for Business Online from the specified city. This collection of users is then piped to the Grant-CsExternalUserCommunicationPolicy cmdlet, which assigns the policy BlockExternalP2PFileTransfer to each of these users.
 
-
 ## PARAMETERS
 
 ### -PolicyName
 
 The name (Identity) of the external user communication policy to be assigned to the user. (Note that this includes only the name portion of the Identity. Per-user policy identities include a prefix of tag: that should not be included with the PolicyName.)
-
 
 ```yaml
 Type: Object
@@ -78,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -DomainController
-PARAMVALUE: Fqdn
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object

--- a/skype/skype-ps/skype/Grant-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsExternalUserCommunicationPolicy.md
@@ -15,7 +15,7 @@ Assigns an external user communication policy to one or more users or groups.
 ## SYNTAX
 
 ```
-Grant-CsExternalUserCommunicationPolicy [[-Identity] <Object>] [[-PolicyName] <Object>] [-Confirm] [-DomainController <Object>] [-PassThru] [-Tenant <Object>] [-WhatIf] [-AsJob] [<CommonParameters>]
+Grant-CsExternalUserCommunicationPolicy [[-Identity] <UserIdParameter>] [[-PolicyName] <String>] [-Confirm] [-DomainController <Fqdn>] [-PassThru] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,7 +47,7 @@ This example assigns the external user communication policy with the Identity Bl
 The name (Identity) of the external user communication policy to be assigned to the user. (Note that this includes only the name portion of the Identity. Per-user policy identities include a prefix of tag: that should not be included with the PolicyName.)
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -79,7 +79,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Fqdn
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -97,7 +97,7 @@ Indicates the Identity of the user account to be retrieved. User Identities can 
 You can use the asterisk (*) wildcard character when using the display name as the user Identity. For example, the Identity "*Smith" returns all the users who have a display name that ends with the string value "Smith".
 
 ```yaml
-Type: Object
+Type: UserIdParameter
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -137,7 +137,7 @@ Get-CsTenant | Select-Object DisplayName, TenantID
 If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Grant-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsExternalUserCommunicationPolicy.md
@@ -15,7 +15,7 @@ Assigns an external user communication policy to one or more users or groups.
 ## SYNTAX
 
 ```
-Grant-CsExternalUserCommunicationPolicy [[-Identity] <UserIdParameter>] [[-PolicyName] <String>] [-Confirm] [-DomainController <Fqdn>] [-PassThru] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
+Grant-CsExternalUserCommunicationPolicy [[-Identity] <UserIdParameter>] [[-PolicyName] <String>] [-Confirm] [-DomainController <Fqdn>] [-PassThru] [-Global] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -177,6 +177,21 @@ Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Global
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/Grant-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Grant-CsIPPhonePolicy.md
@@ -15,8 +15,8 @@ For example, you might enable the Better Together Over Ethernet feature for some
 ## SYNTAX
 
 ```
-Grant-CsIPPhonePolicy [[-Identity] <Object>] [[-PolicyName] <Object>] [-Confirm] [-DomainController <Object>]
- [-PassThru] [-Tenant <Object>] [-WhatIf] [-AsJob] [<CommonParameters>]
+Grant-CsIPPhonePolicy [[-Identity] <UserIdParameter>] [[-PolicyName] <XdsIdentity>] [-Confirm] [-DomainController <Fqdn>]
+ [-PassThru] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,7 +55,7 @@ If you set PolicyName to a null value, then the command will unassign any per-us
 For example: `Grant-CsIPPhonePolicy -Identity "Ken Myer" -PolicyName $Null`
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -87,7 +87,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Fqdn
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -110,7 +110,7 @@ Example: sip:jphillips@contoso.com
 Example: 98403f08-577c-46dd-851a-f0460a13b03d
 
 ```yaml
-Type: Object
+Type: UserIdParameter
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -140,10 +140,19 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-This parameter is reserved for internal Microsoft use.
+-Tenant
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Grant-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Grant-CsIPPhonePolicy.md
@@ -173,7 +173,11 @@ Accept wildcard characters: False
 ```
 
 ### -AsJob
-{{Fill AsJob Description}}
+Indicates that this cmdlet runs as a background job.
+
+When you specify the AsJob parameter, the command immediately returns an object that represents the background job. You can continue to work in the session while the job finishes. The job is created on the local computer and the results from the Skype for Business Online session are automatically returned to the local computer. To get the job results, use the Receive-Job cmdlet.
+
+For more information about Windows PowerShell background jobs, see [about_Jobs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_jobs?view=powershell-6) and [about_Remote_Jobs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_remote_jobs?view=powershell-6).
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/Grant-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Grant-CsIPPhonePolicy.md
@@ -15,7 +15,7 @@ For example, you might enable the Better Together Over Ethernet feature for some
 ## SYNTAX
 
 ```
-Grant-CsIPPhonePolicy [[-Identity] <UserIdParameter>] [[-PolicyName] <XdsIdentity>] [-Confirm] [-DomainController <Fqdn>]
+Grant-CsIPPhonePolicy [[-Identity] <UserIdParameter>] [[-PolicyName] <String>] [-Confirm] [-DomainController <Fqdn>]
  [-PassThru] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
 
@@ -55,7 +55,7 @@ If you set PolicyName to a null value, then the command will unassign any per-us
 For example: `Grant-CsIPPhonePolicy -Identity "Ken Myer" -PolicyName $Null`
 
 ```yaml
-Type: XdsIdentity
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/New-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/New-CsExternalUserCommunicationPolicy.md
@@ -33,7 +33,7 @@ This example creates a new policy to block external file transfer. Then you can 
 ## PARAMETERS
 
 ### -AllowPresenceVisibility
-{{Fill AllowPresenceVisibility Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -49,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowTitleVisibility
-{{Fill AllowTitleVisibility Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -BypassDualWrite
-{{Fill BypassDualWrite Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableFileTransfer
-Indicates whether file transfers to Federated partners are allowed. The default value is True.
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -129,7 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{Fill Force Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: SwitchParameter
@@ -161,7 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -InMemory
-{{Fill InMemory Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/New-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/New-CsExternalUserCommunicationPolicy.md
@@ -13,7 +13,7 @@ Creates a new external user communication policy for use in your organization to
 ## SYNTAX
 
 ```
-New-CsExternalUserCommunicationPolicy [[-Identity] <Object>] [-AllowPresenceVisibility <Object>] [-AllowTitleVisibility <Object>] [-BypassDualWrite <Object>] [-Confirm] [-EnableFileTransfer <Object>] [-EnableP2PFileTransfer <Object>] [-Force] [-InMemory] [-Tenant <Object>] [-WhatIf] [-AsJob] [<CommonParameters>]
+New-CsExternalUserCommunicationPolicy [[-Identity] <XdsIdentity>] [-AllowPresenceVisibility <Boolean>] [-AllowTitleVisibility <Boolean>] [-Confirm] [-EnableFileTransfer <Boolean>] [-EnableP2PFileTransfer <Boolean>] [-Force] [-InMemory] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ This example creates a new policy to block external file transfer. Then you can 
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -52,23 +52,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BypassDualWrite
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -100,7 +84,7 @@ Accept wildcard characters: False
 Indicates whether file transfers to Federated partners are allowed. The default value is True.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -116,7 +100,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -148,7 +132,7 @@ Accept wildcard characters: False
 Unique identifier for the external user communication policy to be created.
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -188,7 +172,7 @@ You can return your tenant ID by running this command:
 If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Remove-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsExternalUserCommunicationPolicy.md
@@ -13,7 +13,7 @@ Removes the specified external user communication policy.
 ## SYNTAX
 
 ```
-Remove-CsExternalUserCommunicationPolicy [[-Identity] <Object>] [-BypassDualWrite <Object>] [-Confirm] [-Force] [-Tenant <Object>] [-WhatIf] [-AsJob] [<CommonParameters>]
+Remove-CsExternalUserCommunicationPolicy [[-Identity] <XdsIdentity>] [-Confirm] [-Force] [-Tenant <Guid>] [-WhatIf] [-AsJob] [<CommonParameters>]
 
 ```
 
@@ -37,22 +37,6 @@ PS C:\> Get-CsExternalUserCommunicationPolicy -Filter tag* | Remove-CsExternalUs
 This example removes all the external user communication policies that can be assigned to specific users. First the `Get-CsExternalUserCommunicationPolicy` cmdlet is called with a Filter of tag*, which retrieves all the per-user policies excluding Global policy. That collection of policies is then piped to the `Remove-CsExternalUserCommunicationPolicy` cmdlet to be removed.
 
 ## PARAMETERS
-
-### -BypassDualWrite
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Confirm
 Prompts you for confirmation before executing the command.
@@ -90,7 +74,7 @@ Accept wildcard characters: False
 Unique identifier for the external user communication policy to be created.
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -114,7 +98,7 @@ Get-CsTenant | Select-Object DisplayName, TenantID
 If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Remove-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsExternalUserCommunicationPolicy.md
@@ -39,7 +39,7 @@ This example removes all the external user communication policies that can be as
 ## PARAMETERS
 
 ### -BypassDualWrite
-{{Fill BypassDualWrite Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object

--- a/skype/skype-ps/skype/Set-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Set-CsExternalUserCommunicationPolicy.md
@@ -13,7 +13,7 @@ Modifies the property values of an existing external user communication policy.
 ## SYNTAX
 
 ```
-Set-CsExternalUserCommunicationPolicy [-EnableFileTransfer <Object>] [-AllowTitleVisibility <Object>]  [-Confirm] [-AllowPresenceVisibility <Object>] [-EnableP2PFileTransfer <Object>] [[-Identity] <Object>] [-Tenant <Object>] [-WhatIf] [-Force] [-Instance <Object>] [-AsJob]
+Set-CsExternalUserCommunicationPolicy [-EnableFileTransfer <Boolean>] [-AllowTitleVisibility <Boolean>]  [-Confirm] [-AllowPresenceVisibility <Boolean>] [-EnableP2PFileTransfer <Boolean>] [[-Identity] <XdsIdentity>] [-Tenant <Guid>] [-WhatIf] [-Force] [-Instance <PSObject>] [-AsJob]
 ```
 
 ## DESCRIPTION
@@ -41,7 +41,7 @@ This example sets the EnableP2PFileTransfer property to False for the Global pol
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -57,23 +57,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BypassDualWrite
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -105,7 +89,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -121,7 +105,7 @@ Accept wildcard characters: False
 Indicates whether file transfers to Federated partners are allowed. The default value is True.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -152,7 +136,7 @@ Accept wildcard characters: False
 Unique identifier for the external user communication policy to be created.
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -192,7 +176,7 @@ Get-CsTenant | Select-Object DisplayName, TenantID
 If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online

--- a/skype/skype-ps/skype/Set-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Set-CsExternalUserCommunicationPolicy.md
@@ -165,12 +165,13 @@ Accept wildcard characters: False
 ```
 
 ### -Instance
-This parameter is reserved for internal Microsoft use.
+Allows you to pass a reference to an object to the cmdlet rather than set individual parameter values.
 
 ```yaml
-Type: Object
+Type: PSObject
 Parameter Sets: (All)
-Aliases:
+Aliases: 
+Applicable: Skype for Business Online
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/Set-CsExternalUserCommunicationPolicy.md
+++ b/skype/skype-ps/skype/Set-CsExternalUserCommunicationPolicy.md
@@ -13,7 +13,7 @@ Modifies the property values of an existing external user communication policy.
 ## SYNTAX
 
 ```
-Set-CsExternalUserCommunicationPolicy [[-Identity] <Object>] [-AllowPresenceVisibility <Object>] [-AllowTitleVisibility <Object>] [-BypassDualWrite <Object>] [-Confirm] [-EnableFileTransfer <Object>] [-EnableP2PFileTransfer <Object>] [-Force] [-Instance <Object>] [-Tenant <Object>] [-WhatIf] [-AsJob]
+Set-CsExternalUserCommunicationPolicy [-EnableFileTransfer <Object>] [-AllowTitleVisibility <Object>]  [-Confirm] [-AllowPresenceVisibility <Object>] [-EnableP2PFileTransfer <Object>] [[-Identity] <Object>] [-Tenant <Object>] [-WhatIf] [-Force] [-Instance <Object>] [-AsJob]
 ```
 
 ## DESCRIPTION
@@ -38,7 +38,7 @@ This example sets the EnableP2PFileTransfer property to False for the Global pol
 ## PARAMETERS
 
 ### -AllowPresenceVisibility
-{{Fill AllowPresenceVisibility Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -54,7 +54,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowTitleVisibility
-{{Fill AllowTitleVisibility Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -BypassDualWrite
-{{Fill BypassDualWrite Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableFileTransfer
-{{Fill EnableFileTransfer Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -133,6 +133,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Identity
 Unique identifier for the external user communication policy to be created.
 
@@ -144,6 +159,21 @@ Applicable: Skype for Business Online
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Instance
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
@@ -415,7 +415,11 @@ Accept wildcard characters: False
 ```
 
 ### -AsJob
-{{Fill AsJob Description}}
+Indicates that this cmdlet runs as a background job.
+
+When you specify the AsJob parameter, the command immediately returns an object that represents the background job. You can continue to work in the session while the job finishes. The job is created on the local computer and the results from the Skype for Business Online session are automatically returned to the local computer. To get the job results, use the Receive-Job cmdlet.
+
+For more information about Windows PowerShell background jobs, see [about_Jobs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_jobs?view=powershell-6) and [about_Remote_Jobs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_remote_jobs?view=powershell-6).
 
 ```yaml
 Type: SwitchParameter
@@ -448,4 +452,6 @@ By default, the Grant-CsIPPhonePolicy cmdlet returns no objects or values. Howev
 ## NOTES
 
 ## RELATED LINKS
+[Grant-CsIPPhonePolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csipphonepolicy?view=skype-ps)
 
+[Get-CsIPPhonePolicy](https://docs.microsoft.com/en-us/powershell/module/skype/get-csipphonepolicy?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
@@ -13,15 +13,9 @@ Use the Set-CsIPPhonePolicy cmdlet to modify the settings of the Skype for Busin
 ## SYNTAX
 
 ```
-Set-CsIPPhonePolicy [[-Identity] <XdsIdentity>] [-BetterTogetherOverEthernetPairingMode <String>]
- [-BypassDualWrite <Object>] [-Confirm] [-DateTimeFormat <Int>] [-EnableBetterTogetherOverEthernet <Boolean>]
- [-EnableDeviceUpdate <Boolean>] [-EnableExchangeCalendaring <Boolean>] [-EnableOneTouchVoicemail <Boolean>]
- [-EnablePowerSaveMode <Boolean>] [-Force] [-Instance <PSObject>] [-KeyboardLockMaxPinRetry <UInt64>]
- [-LocalProvisioningServerAddress <String>] [-LocalProvisioningServerPassword <String>]
- [-LocalProvisioningServerType <String>] [-LocalProvisioningServerUser <String>]
- [-PowerSaveDuringOfficeHoursTimeoutMS <UInt64>] [-PowerSavePostOfficeHoursTimeoutMS <UInt64>]
- [-PrioritizedCodecsList <String>] [-Tenant <Guid>] [-UserDialTimeoutMS <UInt64>] [-WhatIf] [-AsJob]
- [<CommonParameters>]
+Set-CsIPPhonePolicy [[-Identity] <XdsIdentity>] [-BetterTogetherOverEthernetPairingMode <String>] [-Confirm] [-DateTimeFormat <Int>] [-EnableBetterTogetherOverEthernet <Boolean>] [-EnableDeviceUpdate <Boolean>] [-EnableExchangeCalendaring <Boolean>] [-EnableOneTouchVoicemail <Boolean>] [-EnablePowerSaveMode <Boolean>] [-Force] [-Instance <PSObject>] [-KeyboardLockMaxPinRetry <UInt64>]
+ [-LocalProvisioningServerAddress <String>] [-LocalProvisioningServerPassword <String>] [-LocalProvisioningServerType <String>] [-LocalProvisioningServerUser <String>] [-PowerSaveDuringOfficeHoursTimeoutMS <UInt64>] [-PowerSavePostOfficeHoursTimeoutMS <UInt64>]
+ [-PrioritizedCodecsList <String>] [-Tenant <Guid>] [-UserDialTimeoutMS <UInt64>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,22 +45,6 @@ Auto – The phone will get paired with BTOE app Automatically and no need for t
 
 ```yaml
 Type: String
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BypassDualWrite
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: Object
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -447,7 +425,7 @@ Microsoft.Rtc.Management.ADConnect.Schema.ADUser
 ## OUTPUTS
 
 ### System.Object
-By default, the Grant-CsIPPhonePolicy cmdlet returns no objects or values. However, if you include the PassThru parameter, the cmdlet will return instances of the Microsoft.Rtc.Management.ADConnect.Schema.OCSUserOrAppContact object.
+By default, the Set-CsIPPhonePolicy cmdlet returns no objects or values. However, if you include the PassThru parameter, the cmdlet will return instances of the Microsoft.Rtc.Management.ADConnect.Schema.OCSUserOrAppContact object.
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
@@ -47,12 +47,10 @@ This example sets the EnablePowerSaveModeproperty, EnableOneTouchVoicemailvalues
 ## PARAMETERS
 
 ### -BetterTogetherOverEthernetPairingMode
-System.String
-
 Auto – The phone will get paired with BTOE app Automatically and no need for the user to enter the pairing code. Manual – The user needs to enter the pairing code manually to pair with the BTOE app. 
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -65,7 +63,7 @@ Accept wildcard characters: False
 ```
 
 ### -BypassDualWrite
-{{Fill BypassDualWrite Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Object
@@ -81,8 +79,6 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-System.Management.Automation.SwitchParameter
-
 Prompts you for confirmation before executing the command.
 
 ```yaml
@@ -99,12 +95,10 @@ Accept wildcard characters: False
 ```
 
 ### -DateTimeFormat
-System.Int32
-
 Specifies the time format to be used. The acceptable values are "24" for a 24 hour time format, or "12" for a 12 hour format. The default is "24".
 
 ```yaml
-Type: Object
+Type: Int32
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -117,12 +111,10 @@ Accept wildcard characters: False
 ```
 
 ### -EnableBetterTogetherOverEthernet
-System.Boolean
-
 Specifies whether the Better Together Over Ethernet (BTOE) feature is enabled for users. If $true, and if the BTOE plugin is installed on the IP device, the user can tether the device to a PC and sign in to Skype for Business Online. The default is $true.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -135,12 +127,10 @@ Accept wildcard characters: False
 ```
 
 ### -EnableDeviceUpdate
-System.Boolean
-
 Specifies whether the IP device will be updated by the Skype for Business Online service. If set to $true, IP devices will get firmware updates from the service, if $false the device will not be updated. The default is $true.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -153,12 +143,10 @@ Accept wildcard characters: False
 ```
 
 ### -EnableExchangeCalendaring
-System.Boolean
-
 Specifies whether an IP device is enabled to connect to the Exchange Online calendaring service. If $true, users are able to connect to their Exchange calendars. If $false, users will not be enabled to connect to their calendars. The default is $true.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -171,12 +159,10 @@ Accept wildcard characters: False
 ```
 
 ### -EnableOneTouchVoicemail
-System.Boolean
-
 Specifies whether the Visual Voicemail feature in Skype for Business Online is enabled. If set to $true, the feature is enabled, otherwise $false.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -189,12 +175,10 @@ Accept wildcard characters: False
 ```
 
 ### -EnablePowerSaveMode
-System.Boolean
-
 If enabled, phone goes to power savings mode (display turns off) based on values of the PowerSaveDuringOfficeHoursTimeoutMS and PowerSavePostOfficeHoursTimeoutMS parameters.
 
 ```yaml
-Type: Object
+Type: Boolean
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -207,8 +191,6 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-System.Management.Automation.SwitchParameter
-
 The Force switch specifies whether to suppress warning and confirmation messages. It can be useful in scripting to suppress interactive prompts. If the Force switch isn't provided in the command, you're prompted for administrative input if required.
 
 ```yaml
@@ -225,12 +207,10 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Microsoft.Rtc.Management.Xds.XdsIdentity
-
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: XdsIdentity
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -243,12 +223,10 @@ Accept wildcard characters: False
 ```
 
 ### -Instance
-System.Management.Automation.PSObject
-
 Allows you to pass a reference to an object to the cmdlet rather than set individual parameter values.
 
 ```yaml
-Type: Object
+Type: PSObject
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -261,12 +239,10 @@ Accept wildcard characters: False
 ```
 
 ### -KeyboardLockMaxPinRetry
-System.UInt64
-
 Specifies the maximum number of retries allowed for phone unlock. The default is 5.
 
 ```yaml
-Type: Object
+Type: UInt64
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -279,12 +255,10 @@ Accept wildcard characters: False
 ```
 
 ### -LocalProvisioningServerAddress
-System.String
-
 Specifies the address of the provisioning server for your organization. 
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -297,12 +271,10 @@ Accept wildcard characters: False
 ```
 
 ### -LocalProvisioningServerPassword
-System.String
-
 Specifies the password for the provisioning server. 
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -315,12 +287,10 @@ Accept wildcard characters: False
 ```
 
 ### -LocalProvisioningServerType
-System.String
-
 Specifies the server type for the phone. The default is FTP.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -333,12 +303,10 @@ Accept wildcard characters: False
 ```
 
 ### -LocalProvisioningServerUser
-System.String
-
 Specifies a username for the provisioning server.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -351,12 +319,10 @@ Accept wildcard characters: False
 ```
 
 ### -PowerSaveDuringOfficeHoursTimeoutMS
-System.UInt64
-
 Specifies the time in milliseconds to wait during office hours before turning on Power Save mode. The default is 900,000.
 
 ```yaml
-Type: Object
+Type: UInt64
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -369,12 +335,10 @@ Accept wildcard characters: False
 ```
 
 ### -PowerSavePostOfficeHoursTimeoutMS
-System.UInt64
-
 Specifies the time in milliseconds to wait after office hours before turning on Power Save mode. The default is 300,000.
 
 ```yaml
-Type: Object
+Type: UInt64
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -387,12 +351,10 @@ Accept wildcard characters: False
 ```
 
 ### -PrioritizedCodecsList
-System.String
-
 Specifies the order in which to prioritize codecs. The default is: "G722_8000;PCMU;PCMA;G729"
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -405,12 +367,10 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-System.Guid
-
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: Object
+Type: Guid
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -423,12 +383,10 @@ Accept wildcard characters: False
 ```
 
 ### -UserDialTimeoutMS
-System.UInt64
-
 Specifies the time in milliseconds to wait in On-Hook mode before dialing out automatically. If a user enters a phone number and does not click dial, the system will dial the number after the number of milliseconds specified. The default is 5000. 
 
 ```yaml
-Type: Object
+Type: UInt64
 Parameter Sets: (All)
 Aliases: 
 Applicable: Skype for Business Online
@@ -441,8 +399,6 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-System.Management.Automation.SwitchParameter
-
 The WhatIf switch causes the command to simulate its results. By using this switch, you can view what changes would occur without having to commit those changes.
 
 ```yaml

--- a/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
+++ b/skype/skype-ps/skype/Set-CsIPPhonePolicy.md
@@ -13,14 +13,14 @@ Use the Set-CsIPPhonePolicy cmdlet to modify the settings of the Skype for Busin
 ## SYNTAX
 
 ```
-Set-CsIPPhonePolicy [[-Identity] <Object>] [-BetterTogetherOverEthernetPairingMode <Object>]
- [-BypassDualWrite <Object>] [-Confirm] [-DateTimeFormat <Object>] [-EnableBetterTogetherOverEthernet <Object>]
- [-EnableDeviceUpdate <Object>] [-EnableExchangeCalendaring <Object>] [-EnableOneTouchVoicemail <Object>]
- [-EnablePowerSaveMode <Object>] [-Force] [-Instance <Object>] [-KeyboardLockMaxPinRetry <Object>]
- [-LocalProvisioningServerAddress <Object>] [-LocalProvisioningServerPassword <Object>]
- [-LocalProvisioningServerType <Object>] [-LocalProvisioningServerUser <Object>]
- [-PowerSaveDuringOfficeHoursTimeoutMS <Object>] [-PowerSavePostOfficeHoursTimeoutMS <Object>]
- [-PrioritizedCodecsList <Object>] [-Tenant <Object>] [-UserDialTimeoutMS <Object>] [-WhatIf] [-AsJob]
+Set-CsIPPhonePolicy [[-Identity] <XdsIdentity>] [-BetterTogetherOverEthernetPairingMode <String>]
+ [-BypassDualWrite <Object>] [-Confirm] [-DateTimeFormat <Int>] [-EnableBetterTogetherOverEthernet <Boolean>]
+ [-EnableDeviceUpdate <Boolean>] [-EnableExchangeCalendaring <Boolean>] [-EnableOneTouchVoicemail <Boolean>]
+ [-EnablePowerSaveMode <Boolean>] [-Force] [-Instance <PSObject>] [-KeyboardLockMaxPinRetry <UInt64>]
+ [-LocalProvisioningServerAddress <String>] [-LocalProvisioningServerPassword <String>]
+ [-LocalProvisioningServerType <String>] [-LocalProvisioningServerUser <String>]
+ [-PowerSaveDuringOfficeHoursTimeoutMS <UInt64>] [-PowerSavePostOfficeHoursTimeoutMS <UInt64>]
+ [-PrioritizedCodecsList <String>] [-Tenant <Guid>] [-UserDialTimeoutMS <UInt64>] [-WhatIf] [-AsJob]
  [<CommonParameters>]
 ```
 


### PR DESCRIPTION
I see -DomainController parameter in Set-CsHybridApplicationEndpoint and Get-CsHybridApplicationEndpoint but not in New-CsHybridApplicationEndpoint and Remove-CsHybridApplicationEndpoint. They are SfB Server cmdlets so I think it should be useful if all of them have this parameter.
I don't understand why we have Grant-CsIPPhonePolicy if we don't have the cmdlet New-CsIPPhonePolicy to create new policies, so we don't need Grant- because Global Policy will apply to all users.
Why some SfBO cmdlets have -DomainController parameter? I leave it with "This parameter is reserved for internal Microsoft use.".
I see with PlatyPS that Grant-CsExternalUserCommunicationPolicy have the parameter -Global but I could see it originally in Github.
I see the parameter -BypassDualWrite in some cmdlets but not with PlatyPS and SfBO PowerShell.
I see that SfB Online cmdlets -CsIPPhonePolicy and -CsExternalUserCommunicationPolicy doesn't have parameter type so I have added them.


