### PR TITLE
EnableDialinConferencing not applicable to SfBO

### DIFF
--- a/skype/skype-ps/skype/New-CsConferencingPolicy.md
+++ b/skype/skype-ps/skype/New-CsConferencingPolicy.md
@@ -59,7 +59,7 @@ The New-CsConferencingPolicy cmdlet enables you to create new conferencing polic
 You cannot create a new global policy because the global policy already exists.
 However, you can modify the property values of the global policy by using the Set-CsConferencingPolicy cmdlet.
 
-The following parameters are not applicable to Skype for Business Online: ApplicationSharingMode, AsJob, AudioBitRateKb, Description, EnableMultiViewJoin, EnableOnlineMeetingPromptForLyncResources, EnableReliableConferenceDeletion, FileTransferBitRateKb, Force, Identity, InMemory, MaxMeetingSize, MaxVideoConferenceResolution, PipelineVariable, Tenant, and TotalReceiveVideoBitRateKb.
+The following parameters are not applicable to Skype for Business Online: ApplicationSharingMode, AsJob, AudioBitRateKb, Description, EnableDialinConferencing, EnableMultiViewJoin, EnableOnlineMeetingPromptForLyncResources, EnableReliableConferenceDeletion, FileTransferBitRateKb, Force, Identity, InMemory, MaxMeetingSize, MaxVideoConferenceResolution, PipelineVariable, Tenant, and TotalReceiveVideoBitRateKb.
 
 
 


### PR DESCRIPTION
Based on the following work item, 1451047, EnableDialinConferencing is not applicable to SfB Online. 
So I added EnableDialinConferencing to the section "The following parameters are not applicable to Skype for Business Online: ".

Title: 1451047 Remove EnableDialinConferencing as a MeetingPolicy knob that can be customized by tenant admins
URL: https://skype.visualstudio.com/SBS/_workitems/edit/1451047