### PR TITLE
Update Set-CsConferencingPolicy.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsConferencingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsConferencingPolicy.md
@@ -632,6 +632,8 @@ VGA has a resolution of 640 pixels by 480 pixels.
 
 The default value is VGA.
 
+Note: The Skype for Business client and Skype for Business 2015 AVMCU will offer H.264
+
 ```yaml
 Type: MaxVideoConferenceResolution
 Parameter Sets: (All)


### PR DESCRIPTION
When -MaxVideoConferenceResolution is set to CIF or VGA, the Skype for Business client and Skype for Business 2015 AVMCU offers H.264