### PR TITLE
Unable to use some of parameters in SfBO

### DIFF
--- a/skype/skype-ps/skype/Set-CsMobilityPolicy.md
+++ b/skype/skype-ps/skype/Set-CsMobilityPolicy.md
@@ -375,7 +375,7 @@ When set to True (the default value) mobile users will be allowed to participate
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -408,7 +408,7 @@ When set to True (the default value) users will be allowed to connect to Exchang
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -427,7 +427,7 @@ Note that this setting does not apply to Android devices.
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -510,7 +510,7 @@ Accept wildcard characters: False
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online
+Applicable: 
 
 Required: False
 Position: Named
@@ -526,7 +526,7 @@ Accept wildcard characters: False
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online
+Applicable: 
 
 Required: False
 Position: Named
@@ -593,7 +593,7 @@ Controls how audio is connected by a mobile device joining a meeting or a peer-t
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online
+Applicable: 
 
 Required: False
 Position: Named


### PR DESCRIPTION
[The following parameters are not applicable to Skype for Business Online:] section has the follwoing parameters.

-AllowCustomerExperienceImprovementProgram
-AllowExchangeConnectivity
-AllowSaveCallLogs
-EncryptAppData
-RequireIntune
-VoiceSettings

However description of them says the parameter applies to Skype for Business Online.
We confirmed those parameters did not work with SfB Online.  So I deleted SfB Online from "applies to" section.