### PR TITLE
Unable to use AllowAutomaticPstnFallback in SfBO

### DIFF
--- a/skype/skype-ps/skype/Set-CsMobilityPolicy.md
+++ b/skype/skype-ps/skype/Set-CsMobilityPolicy.md
@@ -358,7 +358,7 @@ Accept wildcard characters: False
 Type: Object
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online
+Applicable: 
 
 Required: False
 Position: Named


### PR DESCRIPTION
[The following parameters are not applicable to Skype for Business Online:] section has AllowAutomaticPstnFallback. However description of AllowAutomaticPstnFallback says the parameter applies to Skype for Business Online.
We confirmed AllowAutomaticPstnFallback did not work with SfB Online.  So I deleted SfB Online from "applies to" section.
We don't know if the parameter works with Onpremise server. If it works with OnPremise server, please add it to "applies to" section.