### PR TITLE
EOP admin quarantine update

### DIFF
--- a/exchange/exchange-ps/exchange/antispam-antimalware/New-MalwareFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/antispam-antimalware/New-MalwareFilterPolicy.md
@@ -77,7 +77,7 @@ The Action parameter specifies the action to take when malware is detected in a 
 
 - DeleteAttachmentAndUseCustomAlert: Delivers the message, but replaces the message contents with the custom alert text specified by the AlertText parameter.
 
-Note: For Exchange Online Protection, any of the above actions result in the message and any attachments being routed to  quarantine. For more information on quarantined messages, refer to https://go.microsoft.com/fwlink/?linkid=874388.
+Note: For Exchange Online Protection, any of these actions result in the message and any attachments being routed to quarantine. For more information about quarantined messages, see https://go.microsoft.com/fwlink/p/?linkid=874388.
 
 ```yaml
 Type: DeleteMessage | DeleteAttachmentAndUseDefaultAlertText | DeleteAttachmentAndUseCustomAlertText

--- a/exchange/exchange-ps/exchange/antispam-antimalware/New-MalwareFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/antispam-antimalware/New-MalwareFilterPolicy.md
@@ -71,11 +71,13 @@ Accept wildcard characters: False
 ### -Action
 The Action parameter specifies the action to take when malware is detected in a message. Valid values are:
 
-- DeleteMessage: Deletes the message. This is the default value.
+- DeleteMessage: Deletes the message. This is the default value. 
 
 - DeleteAttachmentAndUseDefaultAlert: Delivers the message, but replaces the message contents with the default alert text.
 
 - DeleteAttachmentAndUseCustomAlert: Delivers the message, but replaces the message contents with the custom alert text specified by the AlertText parameter.
+
+Note: For Exchange Online Protection, any of the above actions result in the message and any attachments being routed to  quarantine. For more information on quarantined messages, refer to https://go.microsoft.com/fwlink/?linkid=874388.
 
 ```yaml
 Type: DeleteMessage | DeleteAttachmentAndUseDefaultAlertText | DeleteAttachmentAndUseCustomAlertText


### PR DESCRIPTION
For exchange online protection customers, any of the actions above result in the message and/or attachments being routed to quarantine.