### PR TITLE
For EOP, malware quarantine related updates

### DIFF
--- a/exchange/exchange-ps/exchange/antispam-antimalware/Set-MalwareFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/antispam-antimalware/Set-MalwareFilterPolicy.md
@@ -94,9 +94,8 @@ The Action parameter specifies the action to take when malware is detected in a 
 - DeleteAttachmentAndUseDefaultAlert: Delivers the message, but replaces the message contents with the default alert text.
 
 - DeleteAttachmentAndUseCustomAlert: Delivers the message, but replaces the message contents with the custom alert text specified by the AlertText parameter.
-Note: 
 
-Note: For Exchange Online Protection, any of the above actions results in the message any any attachments being routed to quarantine. For more information about quarantined mail messages, refer to https://go.microsoft.com/fwlink/?linkid=874388.
+Note: For Exchange Online Protection, any of these actions results in the message any any attachments being routed to quarantine. For more information about quarantined messages, see https://go.microsoft.com/fwlink/p/?linkid=874388.
 
 
 ```yaml

--- a/exchange/exchange-ps/exchange/antispam-antimalware/Set-MalwareFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/antispam-antimalware/Set-MalwareFilterPolicy.md
@@ -93,7 +93,11 @@ The Action parameter specifies the action to take when malware is detected in a 
 
 - DeleteAttachmentAndUseDefaultAlert: Delivers the message, but replaces the message contents with the default alert text.
 
-- DeleteAttachmentAndUseCustomAlert: Delivers the message, but replaces the message contents with the custom alert text specified by the AlertText parameter .
+- DeleteAttachmentAndUseCustomAlert: Delivers the message, but replaces the message contents with the custom alert text specified by the AlertText parameter.
+Note: 
+
+Note: For Exchange Online Protection, any of the above actions results in the message any any attachments being routed to quarantine. For more information about quarantined mail messages, refer to https://go.microsoft.com/fwlink/?linkid=874388.
+
 
 ```yaml
 Type: DeleteMessage | DeleteAttachmentAndUseDefaultAlertText | DeleteAttachmentAndUseCustomAlertText


### PR DESCRIPTION
For EOP customers, any of the actions in the malware filter policy result in the messages being routed to quarantine.