### PR TITLE
StartTime should be last 30 days

### DIFF
--- a/skype/skype-ps/skype/Get-CsUserSession.md
+++ b/skype/skype-ps/skype/Get-CsUserSession.md
@@ -36,6 +36,7 @@ This example returns user session information for Ken Myer from "02/22/2016 07:3
 
 ### -StartTime
 PARAMVALUE: DateTimeOffset
+StartTime should be last 30 days.
 
 ```yaml
 Type: Object


### PR DESCRIPTION
I cannot get data if I set the date more than 30 days ago as StartTime. Seems I can get data for  last 30 days. I found the following report.
If we changes the design to provide user session date only for last 30 days, please mention that in public content. 

-GDPR: Set retention to 30 days for get-csusersession related Baja tables​​​​​​​
https://skype.visualstudio.com/SBS/_workitems/edit/1319303