### PR TITLE
Include note regarding 10000 item limit if the -SearchQuery param is used

### DIFF
--- a/exchange/exchange-ps/exchange/mailboxes/Search-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Search-Mailbox.md
@@ -368,6 +368,8 @@ The SearchQuery parameter specifies a search string or a query formatted using K
 
 If this parameter is empty, all messages are returned.
 
+**Note**: The Search-Mailbox cmdlet returns up to 10000 results per mailbox if a search query is specified.
+
 ```yaml
 Type: String
 Parameter Sets: (All)


### PR DESCRIPTION
Although the command itself does output a warning regarding the 10000 item limit, it would be useful if this was in the documentation somewhere.