### PR TITLE
Update Set-CsMobilityPolicy.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsMobilityPolicy.md
+++ b/skype/skype-ps/skype/Set-CsMobilityPolicy.md
@@ -44,7 +44,7 @@ Set-CsMobilityPolicy [[-Identity] <Object>] [-AllowAutomaticPstnFallback <Object
  [-AllowExchangeConnectivity <Object>] [-AllowSaveCallLogs <Object>] [-AllowSaveCredentials <Object>]
  [-AllowSaveIMHistory <Object>] [-BypassDualWrite <Object>] [-Confirm] [-Description <Object>]
  [-EnableIPAudioVideo <Object>] [-EnableMobility <Object>] [-EnableOutsideVoice <Object>]
- [-EnablePushNotifications <Object>] [-EncryptAppData <Object>] [-Force] [-Instance <Object>]
+ [-EnablePushNotifications <Object>] [-Force] [-Instance <Object>]
  [-RequireIntune <Object>] [-RequireWIFIForIPVideo <Object>] [-RequireWiFiForSharing <Object>]
  [-Tenant <Object>] [-VoiceSettings <Object>] [-WhatIf] [-AsJob] [<CommonParameters>]
 ```
@@ -73,7 +73,7 @@ In turn, that means that the user will not be able to use Call via Work, regardl
 
 To use Call via Work, users must be managed by a voice policy that allows simultaneous ringing.
 
-The following parameters are not applicable to Skype for Business Online: AllowAutomaticPstnFallback, AllowCustomerExperienceImprovementProgram, AllowExchangeConnectivity, AllowSaveCallLogs, AsJob, Description, EncryptAppData, Force, Identity, Instance, PipelineVariable, RequireIntune, Tenant, VoiceSettings
+The following parameters are not applicable to Skype for Business Online: AllowAutomaticPstnFallback, AllowCustomerExperienceImprovementProgram, AllowExchangeConnectivity, AllowSaveCallLogs, AsJob, Description, Force, Identity, Instance, PipelineVariable, RequireIntune, Tenant, VoiceSettings
 
 ## EXAMPLES
 
@@ -489,22 +489,6 @@ Accept wildcard characters: False
 
 ### -EnablePushNotifications
 {{Fill EnablePushNotifications Description}}
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EncryptAppData
-{{Fill EncryptAppData Description}}
 
 ```yaml
 Type: Object


### PR DESCRIPTION
Removed all instances of EncryptAppData based on Content Idea request 78817 approved by SME Premal Gandhi: The documentation for the cmdlet Set-CsMobilityPolicy contains the parameter '-EncryptAppData', which is not used at all. As agreed with Premal, this parameter should be removed from the documentation.