### PR TITLE
Update Grant-SPOSiteDesignRights.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Grant-SPOSiteDesignRights.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Grant-SPOSiteDesignRights.md
@@ -37,7 +37,8 @@ Grant-SPOSiteDesignRights `
          -Principals "SiteCreators@contoso.onmicrosoft.com" `
          -Rights View
 ```
-or if adding a specific user (a user at the fictional Contoso site).
+
+or, if adding a specific user (a user at the fictional Contoso site).
 
 ```powershell
 Grant-SPOSiteDesignRights `


### PR DESCRIPTION
If you are setting to a security group then you need the name only, doesn't work when FQDN is used. When adding a specific user a FQDN works correctly as shown.
