### PR TITLE
Doc changes to make modern authentication easier

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
@@ -243,7 +243,7 @@ If no credentials have been specified, and the CurrentCredentials parameter has 
 
 *For SharePoint Online*: If legacy authentication protocols have been disabled (i.e. When ```powershell(Get-PnPTenant).LegacyAuthProtocolsEnabled``` returns False), the connection attempt will fail with a message such as the following when using a generic credential object (such as that created by ```powershellGet-Credential```) or when using the default options, which prompts for a username and password within the shell:
 
->Failed to connect to (site), Exception calling "ExecuteQuery" with "0" argument(s): "Cannot contact web site (site) or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'. The response headers are 'X-SharePointHealthScore=0, X-MSDAVEXT_Error=917656; Access+denied.+Before+opening+files+in+this+location%2c+you+must+first+browse+to+the+web+site+and+select+the+option+to+login+automatically.
+Failed to connect to (site), Exception calling "ExecuteQuery" with "0" argument(s): "Cannot contact web site (site) or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'. The response headers are 'X-SharePointHealthScore=0, X-MSDAVEXT_Error=917656; Access+denied.+Before+opening+files+in+this+location%2c+you+must+first+browse+to+the+web+site+and+select+the+option+to+login+automatically.
 
 Instead, ensure that you specify the appropriate options that support modern authentication, such as connections with the "-UseWebLogin" or "-PnPO365ManagementShell" parameters or certificate based authentication.
 

--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
@@ -3,6 +3,7 @@ external help file:
 applicable: SharePoint Server 2013, SharePoint Server 2016, SharePoint Online
 schema: 2.0.0
 ---
+
 # Connect-PnPOnline
 
 ## SYNOPSIS
@@ -243,7 +244,7 @@ If no credentials have been specified, and the CurrentCredentials parameter has 
 
 *For SharePoint Online*: If legacy authentication protocols have been disabled (i.e. When ```powershell(Get-PnPTenant).LegacyAuthProtocolsEnabled``` returns False), the connection attempt will fail with a message such as the following when using a generic credential object (such as that created by ```powershellGet-Credential```) or when using the default options, which prompts for a username and password within the shell:
 
-Failed to connect to (site), Exception calling "ExecuteQuery" with "0" argument(s): "Cannot contact web site (site) or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'. The response headers are 'X-SharePointHealthScore=0, X-MSDAVEXT_Error=917656; Access+denied.+Before+opening+files+in+this+location%2c+you+must+first+browse+to+the+web+site+and+select+the+option+to+login+automatically.
+>Failed to connect to (site), Exception calling "ExecuteQuery" with "0" argument(s): "Cannot contact web site (site) or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'. The response headers are 'X-SharePointHealthScore=0, X-MSDAVEXT_Error=917656; Access+denied.+Before+opening+files+in+this+location%2c+you+must+first+browse+to+the+web+site+and+select+the+option+to+login+automatically.
 
 Instead, ensure that you specify the appropriate options that support modern authentication, such as connections with the "-UseWebLogin" or "-PnPO365ManagementShell" parameters or certificate based authentication.
 

--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
@@ -241,6 +241,12 @@ Connect-PnPOnline -Url <String>
 ## DESCRIPTION
 If no credentials have been specified, and the CurrentCredentials parameter has not been specified, you will be prompted for credentials.
 
+*For SharePoint Online*: If legacy authentication protocols have been disabled (i.e. When ```powershell(Get-PnPTenant).LegacyAuthProtocolsEnabled``` returns False), the connection attempt will fail with a message such as the following when using a generic credential object (such as that created by ```powershellGet-Credential```) or when using the default options, which prompts for a username and password within the shell:
+
+>Failed to connect to (site), Exception calling "ExecuteQuery" with "0" argument(s): "Cannot contact web site (site) or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'. The response headers are 'X-SharePointHealthScore=0, X-MSDAVEXT_Error=917656; Access+denied.+Before+opening+files+in+this+location%2c+you+must+first+browse+to+the+web+site+and+select+the+option+to+login+automatically.
+
+Instead, ensure that you specify the appropriate options that support modern authentication, such as connections with the "-UseWebLogin" or "-PnPO365ManagementShell" parameters or certificate based authentication.
+
 ## EXAMPLES
 
 ### ------------------EXAMPLE 1------------------

--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
@@ -242,7 +242,7 @@ Connect-PnPOnline -Url <String>
 ## DESCRIPTION
 If no credentials have been specified, and the CurrentCredentials parameter has not been specified, you will be prompted for credentials.
 
-*For SharePoint Online*: If legacy authentication protocols have been disabled (i.e. When ```powershell(Get-PnPTenant).LegacyAuthProtocolsEnabled``` returns False), the connection attempt will fail with a message such as the following when using a generic credential object (such as that created by ```powershellGet-Credential```) or when using the default options, which prompts for a username and password within the shell:
+*For SharePoint Online*: If legacy authentication protocols have been disabled (i.e. When `powershell(Get-PnPTenant).LegacyAuthProtocolsEnabled` returns False), the connection attempt will fail with a message such as the following when using a generic credential object (such as that created by `powershellGet-Credential`) or when using the default options, which prompts for a username and password within the shell:
 
 >Failed to connect to (site), Exception calling "ExecuteQuery" with "0" argument(s): "Cannot contact web site (site) or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'. The response headers are 'X-SharePointHealthScore=0, X-MSDAVEXT_Error=917656; Access+denied.+Before+opening+files+in+this+location%2c+you+must+first+browse+to+the+web+site+and+select+the+option+to+login+automatically.
 

--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Connect-PnPOnline.md
@@ -60,7 +60,7 @@ Connect-PnPOnline -Scopes <String[]>
                   [-NoTelemetry [<SwitchParameter>]]
 ```
 
-### WebLogin
+### WebLogin 
 ```powershell
 Connect-PnPOnline -Url <String>
                   -UseWebLogin [<SwitchParameter>]


### PR DESCRIPTION
The first 6 or 7 examples rely on legacy authentication. I would request moving those options lower (to deprioritize their usage) and to move the modern authentication options higher. Plus, in the text, I added more verbiage to help folks get past the errors received when legacy authentication has been disabled ...and a nudge towards the options that do support modern auth.