### PR TITLE
Clarify parameters that are not present in SP2010

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-server/Install-SPSolution.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/Install-SPSolution.md
@@ -162,7 +162,7 @@ Accept wildcard characters: False
 Type: String
 Parameter Sets: Deploy
 Aliases: 
-Applicable: SharePoint Server 2010, SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013, SharePoint Server 2016
 
 Required: False
 Position: Named
@@ -216,7 +216,7 @@ For additional information about bin assembly, see Assembly Element
 Type: SwitchParameter
 Parameter Sets: Deploy
 Aliases: 
-Applicable: SharePoint Server 2010, SharePoint Server 2013, SharePoint Server 2016
+Applicable: SharePoint Server 2013, SharePoint Server 2016
 
 Required: False
 Position: Named


### PR DESCRIPTION
The parameters FullTrustBinDeployment and CompatibilityLevel are not present in SharePoint Server 2010, however both docs for these parameters mentioned that they were present in this version of the product.

In summary, for parameters FullTrustBinDeployment and CompatibilityLevel, removed the 'SharePoint Server 2010 from the 'Applicable' product versions.