### PR TITLE
Update New-ClientAccessRule.md

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/New-ClientAccessRule.md
+++ b/exchange/exchange-ps/exchange/client-access/New-ClientAccessRule.md
@@ -421,7 +421,7 @@ Accept wildcard characters: False
 ### -UsernameMatchesAnyOfPatterns
 This parameter is available only in the cloud-based service.
 
-The UsernameMatchesAnyOfPatterns parameter specifies a condition for the client access rule that's based on the user's account name in the format \<Domain\>\\\<UserName\> (for example, contoso.com\\jeff). This parameter accepts text and the wildcard character (\*) (for example, \*jeff\*, but not jeff\*). Non-alphanumeric characters don't require an escape character.
+The UsernameMatchesAnyOfPatterns parameter specifies a condition for the client access rule that's based on the user's account name in the format \<Domain\>\\\<UserName\> (for example, contoso.com\\jeff). This parameter accepts text and the wildcard character (\*) (for example, \*jeff\*, but not jeff\*). Non-alphanumeric characters don't require an escape character. This parameter does not work with the -AnyOfProtocols UniversalOutlook parameter.
 
 You can enter multiple values separated by commas.
 


### PR DESCRIPTION
I modified the page to account for the fact that it doesn’t work to specify a user with the “-UsernameMatchesAnyOfPatterns” parameter when you are denying access with the “-AnyOfProtocols UniversalOutlook” parameter.  I've tested this and worked with the PG on it, and it does not work.
