### PR TITLE
AppDesktopSharingMode parameter cannot set with New-Cs​Teams​Meeting​…

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 ## SYNTAX
 
 ```
-New-CsTeamsMeetingPolicy [-AppDesktopSharingMode <Object>] [-Description <Object>] [[-Identity] <Object>]
+New-CsTeamsMeetingPolicy [-Description <Object>] [[-Identity] <Object>]
  [-InMemory] [-Confirm] [-AllowSharedNotes <Object>] [-AutoAdmittedUsers <Object>]
  [-AllowOutlookAddIn <Object>] [-Force] [-AllowTranscription <Object>]
  [-AllowPrivateMeetingScheduling <Object>] [-Tenant <Object>] [-MediaBitRateKb <Object>]


### PR DESCRIPTION
…Policy

When we tried to set the parameter with New-Cs​Teams​Meeting​Policy, the error "A parameter cannot be found that matches parameter name 'AppDesktopSharingMode'." occurred.