### PR TITLE
CloudRecordingServiceSupport cannot set with Set-CsConferencingPolicy

### DIFF
--- a/skype/skype-ps/skype/Set-CsConferencingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsConferencingPolicy.md
@@ -68,7 +68,7 @@ Set-CsConferencingPolicy [[-Identity] <Object>] [-AllowAnnotations <Object>]
  [-AllowOfficeContent <Object>] [-AllowParticipantControl <Object>] [-AllowPolls <Object>]
  [-AllowQandA <Object>] [-AllowSharedNotes <Object>] [-AllowUserToScheduleMeetingsWithAppSharing <Object>]
  [-ApplicationSharingMode <Object>] [-AppSharingBitRateKb <Object>] [-AudioBitRateKb <Object>]
- [-BypassDualWrite <Object>] [-CloudRecordingServiceSupport <Object>] [-Confirm] [-Description <Object>]
+ [-BypassDualWrite <Object>] [-Confirm] [-Description <Object>]
  [-DisablePowerPointAnnotations <Object>] [-EnableAppDesktopSharing <Object>]
  [-EnableDataCollaboration <Object>] [-EnableDialInConferencing <Object>] [-EnableFileTransfer <Object>]
  [-EnableMultiViewJoin <Object>] [-EnableOnlineMeetingPromptForLyncResources <Object>]
@@ -1014,21 +1014,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -CloudRecordingServiceSupport
-PARAMVALUE: NotSupported | Supported | Required
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -EnableOnlineMeetingPromptForLyncResources
 When set to True, users will be prompted any time they schedule a meeting in Outlook that includes invitees (such as a meeting room) that would benefit from having the meeting held online.


### PR DESCRIPTION
I requested content update when this page was on public in TechNet, Content Idea Request 64449.
When the content moves to doc.microsoft.com and updated part seems reverted. 

Based on following bug, it seems the parameter, -CloudRecordingServiceSupport has been removed from Get-CsConferencingPolicy and no longer works.
  Bug: Office15 3491382 - CloudRecordingServiceSupport parameter in LYO Conference Policy

When we set -CloudRecordingServiceSupport parameter with  Set-CsConferencingPolicy command, we don't get any error but cannot get the value of this parameter from running Get-CsConferencingPolicy.