### PR TITLE
Update description to AllSourceMailboxes(New-MailboxSearch.md)

### DIFF
--- a/exchange/exchange-ps/exchange/policy-and-compliance-content-search/New-MailboxSearch.md
+++ b/exchange/exchange-ps/exchange/policy-and-compliance-content-search/New-MailboxSearch.md
@@ -598,7 +598,7 @@ The AllSourceMailboxes parameter specifies whether to include all mailboxes in t
 Type: $true | $false
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2013, Exchange Server 2016
+Applicable: Exchange Server 2016
 Required: False
 Position: Named
 Default value: None


### PR DESCRIPTION
Parameter named AllSourceMailboxes is not applicable to Exchange 2013 per customer feedback as well as our test.

New-MailboxSearch(New-MailboxSearch.md):exchange/exchange-ps/exchange/policy-and-compliance-content-search/New-MailboxSearch.md