### PR TITLE
Update Set-OWAMailboxPolicy for 3rd party file providers parameters

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
@@ -60,14 +60,14 @@ Set-OwaMailboxPolicy [-Identity] <MailboxPolicyIdParameter>
  [-WacExternalServicesEnabled <$true | $false>] [-WacOMEXEnabled <$true | $false>]
  [-WacViewingOnPrivateComputersEnabled <$true | $false>] [-WacViewingOnPublicComputersEnabled <$true | $false>]
  [-WeatherEnabled <$true | $false>] [-WebPartsFrameOptionsType <Deny | AllowFrom | None | SameOrigin>]
- [-BoxAttachmentsEnabled <$true | $false>] [-ClassicAttachmentsEnabled <$true | $false>]
- [-DropboxAttachmentsEnabled <$true | $false>] [-ExternalSPMySiteHostURL <String>]
- [-FreCardsEnabled <$true | $false>] [-GoogleDriveAttachmentsEnabled <$true | $false>]
+ [-ClassicAttachmentsEnabled <$true | $false>]
+ [-ExternalSPMySiteHostURL <String>]
+ [-FreCardsEnabled <$true | $false>]
  [-InterestingCalendarsEnabled <$true | $false>] [-InternalSPMySiteHostURL <String>]
  [-LocalEventsEnabled <$true | $false>] [-OneDriveAttachmentsEnabled <$true | $false>]
  [-OnSendAddinsEnabled <$true | $false>] [-ReferenceAttachmentsEnabled <$true | $false>]
  [-SatisfactionEnabled <$true | $false>] [-SaveAttachmentsToCloudEnabled <$true | $false>]
- [-ThirdPartyAttachmentsEnabled <$true | $false>] [-UserVoiceEnabled <$true | $false>]
+ [-ThirdPartyFileProvidersEnabled <$true | $false>] [-UserVoiceEnabled <$true | $false>]
  [-WacEditingEnabled <$true | $false>] [-OutlookBetaToggleEnabled <$true | $false>] [<CommonParameters>]
 ```
 
@@ -1505,25 +1505,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BoxAttachmentsEnabled
-This parameter is available only in the cloud-based service.
-
-This parameter has been deprecated and is no longer used.
-
-To enable or disable Box attachments in Outlook on the web, use the ThirdPartyAttachmentsEnabled parameter.
-
-```yaml
-Type: $true | $false
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ClassicAttachmentsEnabled
 The ClassicAttachmentsEnabled parameter specifies whether users can attach local files as regular email attachments. Valid values are:
 
@@ -1536,25 +1517,6 @@ Type: $true | $false
 Parameter Sets: (All)
 Aliases:
 Applicable: Exchange Server 2016, Exchange Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DropboxAttachmentsEnabled
-This parameter is available only in the cloud-based service.
-
-This parameter has been deprecated and is no longer used.
-
-To enable or disable Dropbox attachments in Outlook on the web, use the ThirdPartyAttachmentsEnabled parameter.
-
-```yaml
-Type: $true | $false
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
 Required: False
 Position: Named
 Default value: None
@@ -1587,25 +1549,6 @@ The FreCardsEnabled parameter specifies whether to enable or disable the theme, 
 - $true: The theme, signature, and phone cards are visible in Outlook on the web. This is the default value.
 
 - $false: The theme, signature, and phone cards aren't visible in Outlook on the web. Only the introduction, time zone, and final cards are visible.
-
-```yaml
-Type: $true | $false
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -GoogleDriveAttachmentsEnabled
-This parameter is available only in the cloud-based service.
-
-This parameter has been deprecated and is no longer used.
-
-To enable or disable Google Drive attachments in Outlook on the web, use the ThirdPartyAttachmentsEnabled parameter.
 
 ```yaml
 Type: $true | $false
@@ -1778,7 +1721,26 @@ Accept wildcard characters: False
 ### -ThirdPartyAttachmentsEnabled
 This parameter is available only in the cloud-based service.
 
-The ThirdPartyAttachmentsEnabled parameter specifies whether to allow third-party (for example, Box, Dropbox, and Google Drive) attachments in Outlook on the web. Valid values are:
+This parameter has been deprecated and is no longer used.
+
+To enable or disable third party attachments in Outlook on the web, use the ThirdPartyFileProvidersEnabled parameter.
+
+```yaml
+Type: $true | $false
+Parameter Sets: (All)
+Aliases:
+Applicable: Exchange Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThirdPartyAttachmentsEnabled
+This parameter is available only in the cloud-based service.
+
+The ThirdPartyFileProvidersEnabled parameter specifies whether to allow third-party (for example, Box, Dropbox, and Egnyte) attachments in Outlook on the web. Valid values are:
 
 - $true: Third-party attachments are enabled. Users can connect their third-party file sharing accounts and share files over email.
 


### PR DESCRIPTION
Update Set-OWAMailboxPolicy for 3rd party file providers parameters:

- Remove GoogleDriveAttachmentsEnabled, DropboxAttachmentsEnabled, and BoxAttachmentsEnabled parameters.  These no longer control functionality available (or available to external users).

- Updated ThirdPartyAttachmentsEnabled to reflect deprecation in lieu of ThirdPartyFileProvidersEnabled

- Added entry for ThirdPartyFileProvidersEnabled