### PR TITLE
Update Get-MoveRequestStatistics.md

### DIFF
--- a/exchange/exchange-ps/exchange/move-and-migration/Get-MoveRequestStatistics.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Get-MoveRequestStatistics.md
@@ -257,7 +257,7 @@ Position:	Named
 Default value:	None
 Accept pipeline input:	False
 Accept wildcard characters:	False
-Applies to:	Exchange Online
+Applicable:	Exchange Online
 ```
 
 ### -ProxyToMailbox

--- a/exchange/exchange-ps/exchange/move-and-migration/Get-MoveRequestStatistics.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Get-MoveRequestStatistics.md
@@ -244,6 +244,21 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+### -DiagnosticInfo
+This parameter is available only in Exchange Online.
+
+The DiagnosticInfo parameter modifies the results that are returned by using the Diagnostic switch. You don't need to specify a value with this switch.
+
+Typically, you use the DiagnosticInfo parameter only at the request of Microsoft Customer Service and Support to troubleshoot problems.
+
+```yaml
+Type:	String
+Position:	Named
+Default value:	None
+Accept pipeline input:	False
+Accept wildcard characters:	False
+Applies to:	Exchange Online
+```
 
 ### -ProxyToMailbox
 This parameter is available only in the cloud-based service.


### PR DESCRIPTION
Please note that both parameters for Get-MoveRequestStatistics "Diagnostic" and "DiagnosticArgument" were consolidated by "DiagnosticInfo" and are now available only for the on-premises versions of Exchange server.
Adding description for DiagnosticInfo parameter