### PR TITLE
Update Get-MigrationEndpoint.md

### DIFF
--- a/exchange/exchange-ps/exchange/move-and-migration/Get-MigrationEndpoint.md
+++ b/exchange/exchange-ps/exchange/move-and-migration/Get-MigrationEndpoint.md
@@ -140,6 +140,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -DiagnosticInfo
+This parameter is available only in Exchange Online.
+
+The DiagnosticInfo parameter modifies the results that are returned by using the Diagnostic switch. You don't need to specify a value with this switch.
+
+Typically, you use the DiagnosticInfo parameter only at the request of Microsoft Customer Service and Support to troubleshoot problems.
+
+```yaml
+Type:	String
+Position:	Named
+Default value:	None
+Accept pipeline input:	False
+Accept wildcard characters:	False
+Applicable:	Exchange Online
+```
+
 ### -DomainController
 This parameter is available only in on-premises Exchange.
 


### PR DESCRIPTION
Please note that both parameters "Diagnostic" and "DiagnosticArgument" were consolidated by "DiagnosticInfo" and are now available only for the on-premises versions of Exchange server.
Adding description for DiagnosticInfo parameter