### PR TITLE
Patch 9

### DIFF
--- a/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
@@ -23,7 +23,9 @@ Get-CsOnlinePstnUsage [-Tenant <Guid>] [-Filter <String>] [-LocalStore] [<Common
 ```
 
 ## DESCRIPTION
-PSTN usages are string values that are used for call authorization. A PSTN usage links a voice policy to a route. The `Get-CsOnlinePstnUsage` cmdlet retrieves the list of all PSTN usages available within a tenant.
+Online PSTN usages are string values that are used for call authorization. An online PSTN usage links an online voice policy to a route. The `Get-CsOnlinePstnUsage` cmdlet retrieves the list of all online PSTN usages available within a tenant.
+
+This cmdlet is used when configuring Microsoft Phone System Direct Routing.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
@@ -120,4 +120,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
-[Set-CsPstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/set-cspstnusage?view=skype-ps)
+[Set-CsOnlinePstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinepstnusage?view=skype-ps)

--- a/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
@@ -8,30 +8,33 @@ schema: 2.0.0
 # Get-CsOnlinePstnUsage
 
 ## SYNOPSIS
+Returns information about the PSTN Usages in your organization. 
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Get-CsOnlinePstnUsage [-Tenant <System.Guid>] [[-Identity] <XdsIdentity>] [-LocalStore] [<CommonParameters>]
+Get-CsOnlinePstnUsage [-Tenant <Guid>] [[-Identity] <XdsIdentity>] [-LocalStore] [<CommonParameters>]
 ```
 
 ### Filter
 ```
-Get-CsOnlinePstnUsage [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+Get-CsOnlinePstnUsage [-Tenant <Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+A PSTN Usage is a container for Voice Routes; can be shared in different Voice Routing Policies.
+
+The `Get-CsOnlineUser` cmdlet returns information about the PSTN Usages in your organization.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Get-CSOnlinePSTNUsage
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 returns information for all the PSTN Usages in your tenant.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-CsOnlinePstnUsage
 
 ## SYNOPSIS
-Returns information about public switched telephone network (PSTN) usage records used in your tenant.
+Returns information about online public switched telephone network (PSTN) usage records used in your tenant.
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
@@ -1,14 +1,14 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/8d95ff3e-b6e2-4a33-b567-e77352e4d7ed(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Get-CsOnlinePstnUsage
 
 ## SYNOPSIS
-Returns information about the PSTN Usages in your organization. 
+Returns information about public switched telephone network (PSTN) usage records used in your tenant.
 
 ## SYNTAX
 
@@ -23,9 +23,7 @@ Get-CsOnlinePstnUsage [-Tenant <Guid>] [-Filter <String>] [-LocalStore] [<Common
 ```
 
 ## DESCRIPTION
-A PSTN Usage is a container for Voice Routes; can be shared in different Voice Routing Policies.
-
-The `Get-CsOnlineUser` cmdlet returns information about the PSTN Usages in your organization.
+PSTN usages are string values that are used for call authorization. A PSTN usage links a voice policy to a route. The `Get-CsOnlinePstnUsage` cmdlet retrieves the list of all PSTN usages available within a tenant.
 
 ## EXAMPLES
 
@@ -34,12 +32,12 @@ The `Get-CsOnlineUser` cmdlet returns information about the PSTN Usages in your 
 PS C:\> Get-CSOnlinePSTNUsage
 ```
 
-The command shown in Example 1 returns information for all the PSTN Usages in your tenant.
+This command returns the list of global PSTN usages available within the tenant.
 
 ## PARAMETERS
 
 ### -Filter
-{{Fill Filter Description}}
+The Filter parameter allows you to retrieve only those PSTN usages with an Identity matching a particular wildcard string. However, the only Identity available to PSTN usages is Global, so this parameter is not useful for this cmdlet.
 
 ```yaml
 Type: String
@@ -54,7 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+The level at which these settings are applied. The only identity that can be applied to PSTN usages is Global.
 
 ```yaml
 Type: XdsIdentity
@@ -69,7 +67,7 @@ Accept wildcard characters: False
 ```
 
 ### -LocalStore
-{{Fill LocalStore Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: SwitchParameter
@@ -84,7 +82,15 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
@@ -114,3 +120,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[Set-CsPstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/set-cspstnusage?view=skype-ps)

--- a/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Get-CsOnlinePstnUsage.md
@@ -1,0 +1,113 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/8d95ff3e-b6e2-4a33-b567-e77352e4d7ed(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Get-CsOnlinePstnUsage
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsOnlinePstnUsage [-Tenant <System.Guid>] [[-Identity] <XdsIdentity>] [-LocalStore] [<CommonParameters>]
+```
+
+### Filter
+```
+Get-CsOnlinePstnUsage [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Filter
+{{Fill Filter Description}}
+
+```yaml
+Type: String
+Parameter Sets: Filter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocalStore
+{{Fill LocalStore Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Get-CsOnlineUser.md
+++ b/skype/skype-ps/skype/Get-CsOnlineUser.md
@@ -144,11 +144,9 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Indicates the Identity of the user account to be retrieved.
-User Identities can be specified using one of the following formats: 1) the user's SIP address; 2) the user's user principal name (UPN); or, 3) the user's Active Directory display name (for example, Ken Myer).
+Indicates the Identity of the user account to be assigned the per-user online voice routing policy. User Identities can be specified using one of the following formats: 1) the user's SIP address; 2) the user's user principal name (UPN); or, 3) the user's Active Directory display name (for example, Ken Myer).
 
-You can use the asterisk (*) wildcard character when using the Display Name as the user Identity.
-For example, the Identity "* Smith" returns all the users who have a display name that ends with the string value " Smith".
+You can use the asterisk (\*) wildcard character when using the Display Name as the user Identity. For example, the Identity "\*Smith" returns all the users who have a display name that ends with the string value "Smith".
 
 ```yaml
 Type: Object

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Returns information about the online voice routes configured for use in your tenant. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Returns information about the online voice routes configured for use in your tenant. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Office 365 users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 
@@ -24,9 +24,11 @@ Get-CsOnlineVoiceRoute [-Tenant <Guid>] [-Filter <String>] [-LocalStore] [<Commo
 ```
 
 ## DESCRIPTION
-Use this cmdlet to retrieve one or more existing voice routes in your tenant. Voices routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Use this cmdlet to retrieve one or more existing online voice routes in your tenant. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Office 365 users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 This cmdlet can be used to retrieve voice route information such as which online PSTN gateways the route is associated with (if any), which online PSTN usages are associated with the route, the pattern (in the form of a regular expression) that identifies the phone numbers to which the route applies, and caller ID settings. The PSTN usage associates the voice route to a online voice policy.
+
+This cmdlet is used when configuring Microsoft Phone System Direct Routing.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Returns information about the voice routes configured for use in your tenant.
+Returns information about the online voice routes configured for use in your tenant. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
@@ -1,43 +1,67 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/d42b10a0-9199-41d9-b505-3eee144fdf88(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Get-CsOnlineVoiceRoute
 
 ## SYNOPSIS
+Returns information about the voice routes configured for use in your tenant.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Get-CsOnlineVoiceRoute [-Tenant <System.Guid>] [[-Identity] <XdsGlobalRelativeIdentity>] [-LocalStore]
+Get-CsOnlineVoiceRoute [-Tenant <Guid>] [[-Identity] <XdsGlobalRelativeIdentity>] [-LocalStore]
  [<CommonParameters>]
 ```
 
 ### Filter
 ```
-Get-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+Get-CsOnlineVoiceRoute [-Tenant <Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Use this cmdlet to retrieve one or more existing voice routes in your tenant. Voices routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+
+This cmdlet can be used to retrieve voice route information such as which online PSTN gateways the route is associated with (if any), which online PSTN usages are associated with the route, the pattern (in the form of a regular expression) that identifies the phone numbers to which the route applies, and caller ID settings. The PSTN usage associates the voice route to a online voice policy.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoute
 ```
 
-{{ Add example description here }}
+Retrieves the properties for all voice routes defined within the tenant.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoute -Identity Route1
+```
+
+Retrieves the properties for the Route1 voice route.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoute -Filter *test*
+```
+
+This command displays voice route settings where the Identity contains the string "test" anywhere within the value. To find the string test only at the end of the Identity, use the value \*test. Similarly, to find the string test only if it occurs at the beginning of the Identity, specify the value test\*.
+
+### -------------------------- Example 4 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoute | Where-Object {$_.PstnGatewayList.Count -eq 0}
+```
+
+This command retrieves all voice routes that have not had any PSTN gateways assigned. First all voice routes are retrieved using the Get-CsOnlineVoiceRoute cmdlet. These voice routes are then piped to the Where-Object cmdlet. The Where-Object cmdlet narrows down the results of the Get operation. In this case we look at each voice route (that's what the $_ represents) and check the Count property of the PstnGatewayList property. If the count of PSTN gateways is 0, the list is empty and no gateways have been defined for the route.
 
 ## PARAMETERS
 
 ### -Filter
-{{Fill Filter Description}}
+This parameter filters the results of the Get operation based on the wildcard value passed to this parameter.
 
 ```yaml
 Type: String
@@ -52,7 +76,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+A string that uniquely identifies the voice route. If no identity is provided, all voice routes for the organization are returned.
 
 ```yaml
 Type: XdsGlobalRelativeIdentity
@@ -67,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -LocalStore
-{{Fill LocalStore Description}}
+This parameter is reserved for internal Microsoft use
 
 ```yaml
 Type: SwitchParameter
@@ -82,10 +106,18 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: System.Guid
+Type: Guid
 Parameter Sets: (All)
 Aliases:
 
@@ -112,3 +144,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[New-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroute?view=skype-ps)
+
+[Set-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroute?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroute?view=skype-ps)

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
@@ -53,7 +53,7 @@ This command displays voice route settings where the Identity contains the strin
 
 ### -------------------------- Example 4 --------------------------
 ```
-PS C:\> Get-CsOnlineVoiceRoute | Where-Object {$_.PstnGatewayList.Count -eq 0}
+PS C:\> Get-CsOnlineVoiceRoute | Where-Object {$_.OnlinePstnGatewayList.Count -eq 0}
 ```
 
 This command retrieves all voice routes that have not had any PSTN gateways assigned. First all voice routes are retrieved using the Get-CsOnlineVoiceRoute cmdlet. These voice routes are then piped to the Where-Object cmdlet. The Where-Object cmdlet narrows down the results of the Get operation. In this case we look at each voice route (that's what the $_ represents) and check the Count property of the PstnGatewayList property. If the count of PSTN gateways is 0, the list is empty and no gateways have been defined for the route.

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoute.md
@@ -1,0 +1,114 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/d42b10a0-9199-41d9-b505-3eee144fdf88(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Get-CsOnlineVoiceRoute
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsOnlineVoiceRoute [-Tenant <System.Guid>] [[-Identity] <XdsGlobalRelativeIdentity>] [-LocalStore]
+ [<CommonParameters>]
+```
+
+### Filter
+```
+Get-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Filter
+{{Fill Filter Description}}
+
+```yaml
+Type: String
+Parameter Sets: Filter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsGlobalRelativeIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocalStore
+{{Fill LocalStore Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoutingPolicy.md
@@ -1,43 +1,75 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/d42b10a0-9199-41d9-b505-3eee144fdf88(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Get-CsOnlineVoiceRoutingPolicy
 
 ## SYNOPSIS
+Returns information about the online voice routing policies configured for use in your tenant. Online voice routing policies manage online PSTN usages for users of Phone System.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Get-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [[-Identity] <XdsIdentity>] [-LocalStore]
- [<CommonParameters>]
+Get-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [[-Identity] <XdsIdentity>] [-LocalStore] [<CommonParameters>]
 ```
 
 ### Filter
 ```
-Get-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+Get-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+
+Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 returns information for all the online voice routing policies configured for use in the tenant.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy -Identity "RedmondOnlineVoiceRoutingPolicy"
+```
+
+In Example 2, information is returned for a single online voice routing policy: the policy with the Identity RedmondOnlineVoiceRoutingPolicy.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy -Filter "tag:*"
+```
+
+The command shown in Example 3 returns information about all the online voice routing policies configured at the per-user scope. To do this, the command uses the Filter parameter and the filter value "tag:\*"; that filter value limits the returned data to policies that have an Identity that begins with the string value "tag:".
+
+### -------------------------- Example 4 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy | Where-Object {$_.OnlinePstnUsages -contains "Long Distance"}
+```
+
+In Example 4, information is returned only for those online voice routing policies that include the PSTN usage "Long Distance". To carry out this task, the command first calls `Get-CsVoiceRoutingPolicy` without any parameters; that returns a collection of all the voice routing policies configured for use in the organization. This collection is then piped to the Where-Object cmdlet, which picks out only those policies where the OnlinePstnUsages property includes (-contains) the usage "Long Distance".
+
+### -------------------------- Example 5 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy | Where-Object {$_.OnlinePstnUsages -notcontains "Long Distance"}
+```
+
+Example 5 is a variation on the command shown in Example 4; in this case, however, information is returned only for those online voice routing policies that do not include the PSTN usage "Long Distance". In order to do that, the Where-Object cmdlet uses the -notcontains operator, which limits returned data to policies that do not include the usage "Long Distance".
 
 ## PARAMETERS
 
 ### -Filter
-{{Fill Filter Description}}
+Enables you to use wildcards when retrieving one or more online voice routing policies. For example, to return all the policies configured at the per-user scope, use this syntax:
+
+-Filter "tag:\*"
 
 ```yaml
 Type: String
@@ -52,7 +84,17 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+Unique identifier of the online voice routing policy to be retrieved. To return the global policy, use this syntax:
+
+-Identity global
+
+To return a policy configured at the per-user scope, use syntax like this:
+
+-Identity "RedmondOnlineVoiceRoutingPolicy"
+
+You cannot use wildcard characters when specifying the Identity.
+
+If neither the Identity nor the Filter parameters are specified, then `Get-CsOnlineVoiceRoutingPolicy` returns all the voice routing policies configured for use in the tenant.
 
 ```yaml
 Type: XdsIdentity
@@ -67,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -LocalStore
-{{Fill LocalStore Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: SwitchParameter
@@ -82,10 +124,18 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: System.Guid
+Type: Guid
 Parameter Sets: (All)
 Aliases:
 
@@ -112,3 +162,10 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[New-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Set-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Grant-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?view=skype-ps)

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoutingPolicy.md
@@ -23,7 +23,7 @@ Get-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-Filter <String>] [-LocalStore]
 ```
 
 ## DESCRIPTION
-Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+Online voice routing policies are used in Microsoft Phone System Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
 
 Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceRoutingPolicy.md
@@ -1,0 +1,114 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/d42b10a0-9199-41d9-b505-3eee144fdf88(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Get-CsOnlineVoiceRoutingPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [[-Identity] <XdsIdentity>] [-LocalStore]
+ [<CommonParameters>]
+```
+
+### Filter
+```
+Get-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Filter
+{{Fill Filter Description}}
+
+```yaml
+Type: String
+Parameter Sets: Filter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LocalStore
+{{Fill LocalStore Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Get-CsVoiceRoute.md
+++ b/skype/skype-ps/skype/Get-CsVoiceRoute.md
@@ -58,8 +58,8 @@ Get-CsVoiceRoute -Filter *test*
 ```
 
 This command displays voice route settings where the Identity contains the string "test" anywhere within the value.
-To find the string test only at the end of the Identity, use the value *test.
-Similarly, to find the string test only if it occurs at the beginning of the Identity, specify the value test*.
+To find the string test only at the end of the Identity, use the value \*test.
+Similarly, to find the string test only if it occurs at the beginning of the Identity, specify the value test\*.
 
 ### -------------------------- Example 4 --------------------------
 ```

--- a/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
@@ -1,39 +1,56 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/089fd324-a267-4e53-ad32-924875d15ef9(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Grant-CsOnlineVoiceRoutingPolicy
 
 ## SYNOPSIS
+Assigns a per-user online voice routing policy to one or more users. Online voice routing policies manage online PSTN usages for Phone System users.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Grant-CsOnlineVoiceRoutingPolicy [[-Identity] <UserIdParameter>] [-PolicyName] <String> [-Tenant <System.Guid>]
+Grant-CsOnlineVoiceRoutingPolicy [[-Identity] <UserIdParameter>] [-PolicyName] <String> [-Tenant <Guid>]
  [-DomainController <Fqdn>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### GrantToTenant
 ```
-Grant-CsOnlineVoiceRoutingPolicy [-PolicyName] <String> [-Tenant <System.Guid>] [-DomainController <Fqdn>]
+Grant-CsOnlineVoiceRoutingPolicy [-PolicyName] <String> [-Tenant <Guid>] [-DomainController <Fqdn>]
  [-PassThru] [-Global] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+
+Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Grant-CsOnlineVoiceRoutingPolicy -Identity "Ken Myer" -PolicyName "RedmondOnlineVoiceRoutingPolicy"
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 assigns the per-user online voice routing policy RedmondOnlineVoiceRoutingPolicy to the user with the display name "Ken Myer".
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Grant-CsOnlineVoiceRoutingPolicy -Identity "Ken Myer" -PolicyName $Null
+```
+
+In Example 2, any per-user online voice routing policy previously assigned to the user Ken Myer is unassigned from that user; as a result, Ken Myer will be managed by the global online voice routing policy. To unassign a per-user policy, set the PolicyName to a null value ($Null).
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> Get-CsOnlineUser | Grant-CsOnlineVoiceRoutingPolicy -PolicyName "RedmondOnlineVoiceRoutingPolicy"
+```
+
+Example 3 assigns the per-user online voice routing policy RedmondOnlineVoiceRoutingPolicy to all the users in the tenant. To do this, the command first calls the `Get-CsOnlineUser` cmdlet to get all users accounts enabled for Skype for Business Online. Those user accounts are then piped to the `Grant-CsOnlineVoiceRoutingPolicy` cmdlet, which assigns each user the online voice routing policy RedmondOnlineVoiceRoutingPolicy.
 
 ## PARAMETERS
 
@@ -53,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -DomainController
-{{Fill DomainController Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: Fqdn
@@ -83,7 +100,9 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+Indicates the Identity of the user account to be assigned the per-user online voice routing policy. User Identities can be specified using one of the following formats: 1) the user's SIP address; 2) the user's user principal name (UPN); or, 3) the user's Active Directory display name (for example, Ken Myer).
+
+You can use the asterisk (\*) wildcard character when using the Display Name as the user Identity. For example, the Identity "\*Smith" returns all the users who have a display name that ends with the string value "Smith".
 
 ```yaml
 Type: UserIdParameter
@@ -98,7 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-{{Fill PassThru Description}}
+Enables you to pass a user object through the pipeline that represents the user account being assigned the online voice routing policy. By default, the `Grant-CsOnlineVoiceRoutingPolicy` cmdlet does not pass objects through the pipeline.
 
 ```yaml
 Type: SwitchParameter
@@ -113,7 +132,9 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyName
-{{Fill PolicyName Description}}
+"Name" of the policy to be assigned. The PolicyName is simply the policy Identity minus the policy scope (the "tag:" prefix). For example, a policy with the Identity tag:Redmond has a PolicyName equal to Redmond; likewise, a policy with the Identity tag:RedmondOnlineVoiceRoutingPolicy has a PolicyName equal to RedmondOnlineVoiceRoutingPolicy.
+
+To unassign a per-user policy previously assigned to a user, set the PolicyName to a null value ($Null).
 
 ```yaml
 Type: String
@@ -128,7 +149,15 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
@@ -174,3 +203,10 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[New-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Get-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Set-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?view=skype-ps)

--- a/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
@@ -102,8 +102,6 @@ Accept wildcard characters: False
 ### -Identity
 Indicates the Identity of the user account to be assigned the per-user online voice routing policy. User Identities can be specified using one of the following formats: 1) the user's SIP address; 2) the user's user principal name (UPN); or, 3) the user's Active Directory display name (for example, Ken Myer).
 
-You can use the asterisk (\*) wildcard character when using the Display Name as the user Identity. For example, the Identity "\*Smith" returns all the users who have a display name that ends with the string value "Smith".
-
 ```yaml
 Type: UserIdParameter
 Parameter Sets: Identity

--- a/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -Global
-When you use this cmdlet without specifying an user identity, the policy applies to all users in your tenant. To skip a warning when you do this operation, specify "-Global".
+When you use this cmdlet without specifying a user identity, the policy applies to all users in your tenant. To skip a warning when you do this operation, specify "-Global".
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
@@ -1,0 +1,176 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/089fd324-a267-4e53-ad32-924875d15ef9(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Grant-CsOnlineVoiceRoutingPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Grant-CsOnlineVoiceRoutingPolicy [[-Identity] <UserIdParameter>] [-PolicyName] <String> [-Tenant <System.Guid>]
+ [-DomainController <Fqdn>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### GrantToTenant
+```
+Grant-CsOnlineVoiceRoutingPolicy [-PolicyName] <String> [-Tenant <System.Guid>] [-DomainController <Fqdn>]
+ [-PassThru] [-Global] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DomainController
+{{Fill DomainController Description}}
+
+```yaml
+Type: Fqdn
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Global
+{{Fill Global Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GrantToTenant
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: UserIdParameter
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -PassThru
+{{Fill PassThru Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyName
+{{Fill PolicyName Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Microsoft.Rtc.Management.AD.UserIdParameter
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
@@ -25,7 +25,7 @@ Grant-CsOnlineVoiceRoutingPolicy [-PolicyName] <String> [-Tenant <Guid>] [-Domai
 ```
 
 ## DESCRIPTION
-Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+Online voice routing policies are used in Microsoft Phone System Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
 
 Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 

--- a/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsOnlineVoiceRoutingPolicy.md
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -Global
-{{Fill Global Description}}
+When you use this cmdlet without specifying an user identity, the policy applies to all users in your tenant. To skip a warning when you do this operation, specify "-Global".
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # New-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Creates a new online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Creates a new online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Office 365 users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 
@@ -27,9 +27,11 @@ New-CsOnlineVoiceRoute [-Tenant <Guid>] -Name <String> [-Description <String>] [
 ```
 
 ## DESCRIPTION
-Use this cmdlet to create a new online voice route. All voice routes are created at the Global scope. However, multiple global voice routes can be defined. This is accomplished through the Identity parameter, which requires a unique route name.
+Use this cmdlet to create a new online voice route. All online voice routes are created at the Global scope. However, multiple global voice routes can be defined. This is accomplished through the Identity parameter, which requires a unique route name.
 
 Voice routes are associated with online voice policies through online PSTN usages. A voice route includes a regular expression that identifies which phone numbers will be routed through a given voice route: phone numbers matching the regular expression will be routed through this route.
+
+This cmdlet is used when configuring Microsoft Phone System Direct Routing.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -6,9 +6,9 @@ schema: 2.0.0
 ---
 
 # New-CsOnlineVoiceRoute
-Creates a new online voice route. Voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX). 
 
 ## SYNOPSIS
+Creates a new online voice route. Voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX). 
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -74,7 +74,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-{{Fill Description Description}}
+A description of what this online voice route is for.
 
 ```yaml
 Type: String
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{Fill Force Description}}
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
 ```yaml
 Type: SwitchParameter
@@ -104,7 +104,9 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+A name that uniquely identifies the online voice route. Voice routes can be defined only at the global scope, so the identity is simply the name you want to give the route. (You can have spaces in the route name, for instance Test Route, but you must enclose the full string in double quotes in the call to the New-CsOnlineVoiceRoute cmdlet.)
+
+If Identity is specified, the Name must be left blank. The value of the Identity will be assigned to the Name.
 
 ```yaml
 Type: XdsGlobalRelativeIdentity
@@ -119,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -InMemory
-{{Fill InMemory Description}}
+Creates an object reference without actually committing the object as a permanent change. If you assign the output of this cmdlet called with this parameter to a variable, you can make changes to the properties of the object reference and then commit those changes by calling this cmdlet's matching Set-<cmdlet>.
 
 ```yaml
 Type: SwitchParameter
@@ -134,7 +136,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-{{Fill Name Description}}
+The unique name of the voice route. If this parameter is set, the value will be automatically applied to the online voice route Identity. You cannot specify both an Identity and a Name.
 
 ```yaml
 Type: String
@@ -149,7 +151,9 @@ Accept wildcard characters: False
 ```
 
 ### -NumberPattern
-{{Fill NumberPattern Description}}
+A regular expression that specifies the phone numbers to which this route applies. Numbers matching this pattern will be routed according to the rest of the routing settings.
+
+Default: [0-9]{10}
 
 ```yaml
 Type: String
@@ -164,7 +168,9 @@ Accept wildcard characters: False
 ```
 
 ### -OnlinePstnGatewayList
-{{Fill OnlinePstnGatewayList Description}}
+This parameter contains a list of online gateways associated with this voice route. Each member of this list must be the service Identity of the online PSTN gateway. The service Identity is a string in the format OnlinePstnGateway:<FQDN>, where FQDN is the fully qualified domain name (FQDN) of the pool or the IP address of the server. For example, OnlinePstnGateway:redmondpool.litwareinc.com.
+
+By default this list is empty. However, if you leave this parameter blank when creating a new voice route, you'll receive a warning message.
 
 ```yaml
 Type: PSListModifier
@@ -179,7 +185,9 @@ Accept wildcard characters: False
 ```
 
 ### -OnlinePstnUsages
-{{Fill OnlinePstnUsages Description}}
+A list of online PSTN usages (such as Local, Long Distance, etc.) that can be applied to this online voice route. The PSTN usage must be an existing usage (PSTN usages can be retrieved by calling the Get-CsOnlinePstnUsage cmdlet).
+
+By default this list is empty. However, if you leave this parameter blank when creating a new online voice route, you'll receive a warning message.
 
 ```yaml
 Type: PSListModifier
@@ -194,7 +202,7 @@ Accept wildcard characters: False
 ```
 
 ### -Priority
-{{Fill Priority Description}}
+A number could resolve to multiple online voice routes. The priority determines the order in which the routes will be applied if more than one route is possible.
 
 ```yaml
 Type: Int32
@@ -209,7 +217,15 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
@@ -255,3 +271,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroute?view=skype-ps)
+
+[Set-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroute?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroute?view=skype-ps)

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -42,10 +42,10 @@ The command in this example creates a new online voice route with an Identity of
 
 ### -------------------------- Example 2 --------------------------
 ```
-PS C:\> New-CsOnlineVoiceRoute -Identity Route1 -OnlinePstnUsages @{add="Long Distance"} -OnlinePstnGatewayList @{add="OnlinePstnGateway:redmondpool.litwareinc.com"}
+PS C:\> New-CsOnlineVoiceRoute -Identity Route1 -OnlinePstnUsages @{add="Long Distance"} -OnlinePstnGatewayList @{add="OnlinePstnGateway:sbc1.litwareinc.com"}
 ```
 
-The command in this example creates a new online voice route with an Identity of Route1. It also adds the online PSTN usage Long Distance to the list of usages and the service ID PstnGateway:redmondpool.litwareinc.com to the list of online PSTN gateways.
+The command in this example creates a new online voice route with an Identity of Route1. It also adds the online PSTN usage Long Distance to the list of usages and the service ID PstnGateway:sbc1.litwareinc.com to the list of online PSTN gateways.
 
 ### -------------------------- Example 3 --------------------------
 ```
@@ -168,7 +168,7 @@ Accept wildcard characters: False
 ```
 
 ### -OnlinePstnGatewayList
-This parameter contains a list of online gateways associated with this voice route. Each member of this list must be the service Identity of the online PSTN gateway. The service Identity is a string in the format OnlinePstnGateway:<FQDN>, where FQDN is the fully qualified domain name (FQDN) of the pool or the IP address of the server. For example, OnlinePstnGateway:redmondpool.litwareinc.com.
+This parameter contains a list of online gateways associated with this online voice route. Each member of this list must be the service Identity of the online PSTN gateway. The service Identity is a string in the format OnlinePstnGateway:<FQDN>, where FQDN is the fully qualified domain name (FQDN) of the pool or the IP address of the server. For example, OnlinePstnGateway:redmondpool.litwareinc.com.
 
 By default this list is empty. However, if you leave this parameter blank when creating a new voice route, you'll receive a warning message.
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # New-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Creates a new online voice route. Voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX). 
+Creates a new online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -1,11 +1,12 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version:
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # New-CsOnlineVoiceRoute
+Creates a new online voice route. Voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX). 
 
 ## SYNOPSIS
 
@@ -13,29 +14,47 @@ schema: 2.0.0
 
 ### Identity (Default)
 ```
-New-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Description <String>] [-NumberPattern <String>]
+New-CsOnlineVoiceRoute [-Tenant <Guid>] [-Description <String>] [-NumberPattern <String>]
  [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>]
  [-Identity] <XdsGlobalRelativeIdentity> [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ParentAndRelativeKey
 ```
-New-CsOnlineVoiceRoute [-Tenant <System.Guid>] -Name <String> [-Description <String>] [-NumberPattern <String>]
+New-CsOnlineVoiceRoute [-Tenant <Guid>] -Name <String> [-Description <String>] [-NumberPattern <String>]
  [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>] [-InMemory]
  [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Use this cmdlet to create a new online voice route. All voice routes are created at the Global scope. However, multiple global voice routes can be defined. This is accomplished through the Identity parameter, which requires a unique route name.
+
+Voice routes are associated with online voice policies through online PSTN usages. A voice route includes a regular expression that identifies which phone numbers will be routed through a given voice route: phone numbers matching the regular expression will be routed through this route.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> New-CsOnlineVoiceRoute -Identity Route1
 ```
 
-{{ Add example description here }}
+The command in this example creates a new online voice route with an Identity of Route1. All other properties will be set to the default values.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> New-CsOnlineVoiceRoute -Identity Route1 -OnlinePstnUsages @{add="Long Distance"} -OnlinePstnGatewayList @{add="OnlinePstnGateway:redmondpool.litwareinc.com"}
+```
+
+The command in this example creates a new online voice route with an Identity of Route1. It also adds the online PSTN usage Long Distance to the list of usages and the service ID PstnGateway:redmondpool.litwareinc.com to the list of online PSTN gateways.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> $x = (Get-CsOnlinePstnUsage).Usage
+
+New-CsOnlineVoiceRoute -Identity Route1 -OnlinePstnUsages @{add=$x}
+```
+
+This example creates a new online voice route named Route1 and populates that route's list of PSTN usages with all the existing usages for the organization. The first command in this example retrieves the list of global online PSTN usages. Notice that the call to the `Get-CsOnlinePstnUsage` cmdlet is in parentheses; this means that we first retrieve an object containing PSTN usage information. (Because there is only one, global, online PSTN usage, only one object will be retrieved.) The command then retrieves the Usage property of this object. That property, which contains a list of usages, is assigned to the variable $x. In the second line of this example, the `New-CsOnlineVoiceRoute` cmdlet is called to create a new online voice route. This voice route will have an identity of Route1. Notice the value passed to the OnlinePstnUsages parameter: @{add=$x}. This value says to add the contents of $x, which contain the phone usages list retrieved in line 1, to the list of online PSTN usages for this route.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoute.md
@@ -1,0 +1,238 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version:
+schema: 2.0.0
+---
+
+# New-CsOnlineVoiceRoute
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+New-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Description <String>] [-NumberPattern <String>]
+ [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>]
+ [-Identity] <XdsGlobalRelativeIdentity> [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### ParentAndRelativeKey
+```
+New-CsOnlineVoiceRoute [-Tenant <System.Guid>] -Name <String> [-Description <String>] [-NumberPattern <String>]
+ [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>] [-InMemory]
+ [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+{{Fill Description Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{Fill Force Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsGlobalRelativeIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InMemory
+{{Fill InMemory Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+{{Fill Name Description}}
+
+```yaml
+Type: String
+Parameter Sets: ParentAndRelativeKey
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NumberPattern
+{{Fill NumberPattern Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OnlinePstnGatewayList
+{{Fill OnlinePstnGatewayList Description}}
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OnlinePstnUsages
+{{Fill OnlinePstnUsages Description}}
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Priority
+{{Fill Priority Description}}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
@@ -19,7 +19,7 @@ New-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-OnlinePstnUsages <PSListModifi
 ```
 
 ## DESCRIPTION
-Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+Online voice routing policies are used in Microsoft Phone System Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
 
 Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
@@ -193,4 +193,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 [Grant-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csonlinevoiceroutingpolicy?view=skype-ps)
 
-[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?
+[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?view=skype-ps)

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
@@ -1,0 +1,43 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version:
+schema: 2.0.0
+---
+
+# New-CsOnlineVoiceRoutingPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
@@ -1,27 +1,43 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version:
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # New-CsOnlineVoiceRoutingPolicy
 
 ## SYNOPSIS
+Creates a new online voice routing policy. Online voice routing policies manage online PSTN usages for users of Phone System.
 
 ## SYNTAX
+### Identity
+```
+New-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-OnlinePstnUsages <PSListModifier>]
+ [-Description <String>] [-RouteType <String>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+
+Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> New-CsOnlineVoiceRoutingPolicy -Identity "RedmondOnlineVoiceRoutingPolicy" -Name "RedmondOnlineVoiceRoutingPolicy" -OnlinePstnUsages "Long Distance"
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 creates a new online per-user voice routing policy with the Identity RedmondOnlineVoiceRoutingPolicy. This policy is assigned a single online PSTN usage: Long Distance.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> New-CsOnlineVoiceRoutingPolicy -Identity "RedmondOnlineVoiceRoutingPolicy" -Name "RedmondOnlineVoiceRoutingPolicy" -OnlinePstnUsages "Long Distance", "Local", "Internal"
+```
+
+Example 2 is a variation of the command shown in Example 1; in this case, however, the new policy is assigned three online PSTN usages: Long Distance; Local; Internal. Multiple usages can be assigned simply by separating each usage using a comma.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # New-CsOnlineVoiceRoutingPolicy
 
 ## SYNOPSIS
-Creates a new online voice routing policy. Online voice routing policies manage online PSTN usages for users of Phone System.
+Creates a new online voice routing policy. Online voice routing policies manage online PSTN usages for Phone System users.
 
 ## SYNTAX
 ### Identity
@@ -41,6 +41,136 @@ Example 2 is a variation of the command shown in Example 1; in this case, howeve
 
 ## PARAMETERS
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Enables administrators to provide explanatory text to accompany an online voice routing policy. For example, the Description might include information about the users the policy should be assigned to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier assigned to the policy when it was created.
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OnlinePstnUsages
+A list of online PSTN usages (such as Local or Long Distance) that can be applied to this online voice routing policy. The online PSTN usage must be an existing usage. (PSTN usages can be retrieved by calling the `Get-CsOnlinePstnUsage` cmdlet.)
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RouteType
+{{Fill RouteType Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
@@ -57,3 +187,10 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Set-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Grant-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?

--- a/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsOnlineVoiceRoutingPolicy.md
@@ -117,7 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -RouteType
-{{Fill RouteType Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
@@ -1,29 +1,130 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/fc442732-969a-43ea-a1a6-4b534faa1ece(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Remove-CsOnlineVoiceRoute
 
 ## SYNOPSIS
+Removes an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
+```
+Remove-CsOnlineVoiceRoute [-Tenant <Guid>] [[-Identity] <XdsGlobalRelativeIdentity>] [-Force] [-WhatIf] [-Confirm]
+```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Use this cmdlet to remove an existing online voice route. Online voice routes are associated with online voice policies through online PSTN usages, so removing a online voice route does not change any values relating to an online voice policy, it simply changes the routing for the numbers that had matched the pattern for the deleted online voice route.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Remove-CsOnlineVoiceRoute -Identity Route1
 ```
 
-{{ Add example description here }}
+Removes the settings for the online voice route with the identity Route1.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\ Get-CsOnlineVoiceRoute | Remove-CsOnlineVoiceRoute
+```
+
+This command removes all online voice routes from the organization. First all online voice routes are retrieved by the `Get-CsOnlineVoiceRoute` cmdlet. These online voice routes are then piped to the `Remove-CsOnlineVoiceRoute` cmdlet, which removes each one.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\ Get-CsOnlineVoiceRoute -Filter *Redmond* | Remove-CsOnlineVoiceRoute
+```
+
+This command removes all online voice routes with an identity that includes the string "Redmond". First the `Get-CsOnlineVoiceRoute` cmdlet is called with the Filter parameter. The value of the Filter parameter is the string Redmond surrounded by wildcard characters (\*), which specifies that the string can be anywhere within the Identity. After all of the online voice routes with identities that include the string Redmond are retrieved, these online voice routes are piped to the `Remove-CsOnlineVoiceRoute` cmdlet, which removes each one.
 
 ## PARAMETERS
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The unique identity of the online voice route. (If the route name contains a space, such as Test Route, you must enclose the full string in parentheses.)
+
+```yaml
+Type: XdsGlobalRelativeIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
@@ -41,3 +142,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroute?view=skype-ps)
+
+[New-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroute?view=skype-ps)
+
+[Set-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroute?view=skype-ps)

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
@@ -1,0 +1,43 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/fc442732-969a-43ea-a1a6-4b534faa1ece(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Remove-CsOnlineVoiceRoute
+
+## SYNOPSIS
+
+## SYNTAX
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Microsoft.Rtc.Management.Xds.XdsGlobalRelativeIdentity
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Remove-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Removes an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Removes an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Office 365 users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 ```
@@ -17,6 +17,8 @@ Remove-CsOnlineVoiceRoute [-Tenant <Guid>] [[-Identity] <XdsGlobalRelativeIdenti
 
 ## DESCRIPTION
 Use this cmdlet to remove an existing online voice route. Online voice routes are associated with online voice policies through online PSTN usages, so removing a online voice route does not change any values relating to an online voice policy, it simply changes the routing for the numbers that had matched the pattern for the deleted online voice route.
+
+This cmdlet is used when configuring Microsoft Phone System Direct Routing.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Remove-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Removes an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Removes an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 ```

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
@@ -1,29 +1,144 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/fc442732-969a-43ea-a1a6-4b534faa1ece(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Remove-CsOnlineVoiceRoutingPolicy
 
 ## SYNOPSIS
+Deletes an existing online voice routing policy. Online voice routing policies manage online PSTN usages for Phone System users.
 
 ## SYNTAX
 
+### Identity
+```
+Remove-CsOnlineVoiceRoutingPolicy [[-Identity] <XdsIdentity>] [-Tenant <Guid>] [-Force] [-WhatIf]
+[-Confirm] [<CommonParameters>]
+```
+
 ## DESCRIPTION
-{{Fill in the Description}}
+Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+
+Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Remove-CsOnlineVoiceRoutingPolicy -Identity "RedmondOnlineVoiceRoutingPolicy"
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 deletes the online voice routing policy RedmondOnlineVoiceRoutingPolicy.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy -Filter "tag:*" | Remove-CsOnlineVoiceRoutingPolicy
+```
+
+In Example 2, all the online voice routing policies configured at the per-user scope are removed. To do this, the command first calls the `Get-CsOnlineVoiceRoutingPolicy` cmdlet along with the Filter parameter; the filter value "tag:\*" limits the returned data to online voice routing policies configured at the per-user scope. Those per-user policies are then piped to and removed by, the `Remove-CsOnlineVoiceRoutingPolicy` cmdlet.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> Get-CsOnlineVoiceRoutingPolicy | Where-Object {$_.OnlinePstnUsages -contains "Long Distance"} | Remove-CsOnlineVoiceRoutingPolicy
+```
+
+In Example 3, all the online voice routing polices that include the online PSTN usage "Long Distance" are removed. To carry out this task, the `Get-CsOnlineVoiceRoutingPolicy` cmdlet is first called without any parameters in order to return a collection of all the available online voice routing policies. That collection is then piped to the Where-Object cmdlet, which picks out only those policies where the OnlinePstnUsages property includes (-contains) the usage "Long Distance". Policies that meet that criterion are then piped to the Remove-CsOnlineVoiceRoutingPolicy, which removes each online voice routing policy that includes the online PSTN usage "Long Distance".
 
 ## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier assigned to the policy when it was created. Online voice routing policies can be assigned at the global scope or the per-user scope. To refer to the global instance, use this syntax:
+
+-Identity global
+
+To refer to a per-user policy, use syntax similar to this:
+
+-Identity "RedmondOnlineVoiceRoutingPolicy"
+
+If you do not specify an Identity, then the `Set-CsOnlineVoiceRoutingPolicy` cmdlet will modify the global policy.
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
@@ -41,3 +156,10 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[New-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Get-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Set-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/set-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Grant-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csonlinevoiceroutingpolicy?view=skype-ps)

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
@@ -44,7 +44,7 @@ In Example 2, all the online voice routing policies configured at the per-user s
 PS C:\> Get-CsOnlineVoiceRoutingPolicy | Where-Object {$_.OnlinePstnUsages -contains "Long Distance"} | Remove-CsOnlineVoiceRoutingPolicy
 ```
 
-In Example 3, all the online voice routing polices that include the online PSTN usage "Long Distance" are removed. To carry out this task, the `Get-CsOnlineVoiceRoutingPolicy` cmdlet is first called without any parameters in order to return a collection of all the available online voice routing policies. That collection is then piped to the Where-Object cmdlet, which picks out only those policies where the OnlinePstnUsages property includes (-contains) the usage "Long Distance". Policies that meet that criterion are then piped to the Remove-CsOnlineVoiceRoutingPolicy, which removes each online voice routing policy that includes the online PSTN usage "Long Distance".
+In Example 3, all the online voice routing polices that include the online PSTN usage "Long Distance" are removed. To carry out this task, the `Get-CsOnlineVoiceRoutingPolicy` cmdlet is first called without any parameters in order to return a collection of all the available online voice routing policies. That collection is then piped to the Where-Object cmdlet, which picks out only those policies where the OnlinePstnUsages property includes (-contains) the usage "Long Distance". Policies that meet that criterion are then piped to the `Remove-CsOnlineVoiceRoutingPolicy`, which removes each online voice routing policy that includes the online PSTN usage "Long Distance".
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
@@ -79,15 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Unique identifier assigned to the policy when it was created. Online voice routing policies can be assigned at the global scope or the per-user scope. To refer to the global instance, use this syntax:
-
--Identity global
-
-To refer to a per-user policy, use syntax similar to this:
-
--Identity "RedmondOnlineVoiceRoutingPolicy"
-
-If you do not specify an Identity, then the `Set-CsOnlineVoiceRoutingPolicy` cmdlet will modify the global policy.
+Unique identifier assigned to the policy when it was created.
 
 ```yaml
 Type: XdsIdentity

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
@@ -1,0 +1,43 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/fc442732-969a-43ea-a1a6-4b534faa1ece(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Remove-CsOnlineVoiceRoutingPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Microsoft.Rtc.Management.Xds.XdsIdentity
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsOnlineVoiceRoutingPolicy.md
@@ -19,7 +19,7 @@ Remove-CsOnlineVoiceRoutingPolicy [[-Identity] <XdsIdentity>] [-Tenant <Guid>] [
 ```
 
 ## DESCRIPTION
-Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+Online voice routing policies are used in Microsoft Phone System Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
 
 Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -8,32 +8,35 @@ schema: 2.0.0
 # Set-CsOnlinePstnUsage
 
 ## SYNOPSIS
+Creates or modifies a PSTN Usage to use in your organization.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Set-CsOnlinePstnUsage [-Tenant <System.Guid>] [-Usage <PSListModifier>] [[-Identity] <XdsIdentity>] [-Force]
+Set-CsOnlinePstnUsage [-Tenant <Guid>] [-Usage <PSListModifier>] [[-Identity] <XdsIdentity>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Instance
 ```
-Set-CsOnlinePstnUsage [-Tenant <System.Guid>] [-Usage <PSListModifier>] [-Instance <PSObject>] [-Force]
+Set-CsOnlinePstnUsage [-Tenant <Guid>] [-Usage <PSListModifier>] [-Instance <PSObject>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+A PSTN Usage is a container for Voice Routes; can be shared in different Voice Routing Policies.
+
+The `Set-CsOnlinePstnUsage` creates or modifies a PSTN Usage to use in your organization.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Set-CsOnlinePstnUsage  -Identity Global -Usage @{Add="US and Canada"}
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 creates the PSTN Usage “US and Canada”.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -189,4 +189,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
-[Get-CsPstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/get-cspstnusage?view=skype-ps)
+[Get-CsOnlinePstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/get-csOnlinepstnusage?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Set-CsOnlinePstnUsage
 
 ## SYNOPSIS
-Modifies a set of strings that identify the allowed public switched telephone network (PSTN) usages. This cmdlet can be used to add usages to the list of PSTN usages or remove usages from the list.
+Modifies a set of strings that identify the allowed online public switched telephone network (PSTN) usages. This cmdlet can be used to add usages to the list of online PSTN usages or remove usages from the list.
 
 ## SYNTAX
 
@@ -25,7 +25,9 @@ Set-CsOnlinePstnUsage [-Tenant <Guid>] [-Usage <PSListModifier>] [-Instance <PSO
 ```
 
 ## DESCRIPTION
-PSTN usages are string values that are used for call authorization. A PSTN usage links a voice policy to a route. The `Set-CsOnlinePstnUsage` cmdlet is used to add or remove phone usages to or from the usage list. This list is global so it can be used by policies and routes throughout the tenant.
+Online PSTN usages are string values that are used for call authorization. An online PSTN usage links an online voice policy to a route. The `Set-CsOnlinePstnUsage` cmdlet is used to add or remove phone usages to or from the usage list. This list is global so it can be used by policies and routes throughout the tenant.
+
+This cmdlet is used when configuring Microsoft Phone System Direct Routing.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -1,0 +1,161 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/eecc8b8a-16c3-4334-91bf-3be5db4d14d5(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Set-CsOnlinePstnUsage
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Set-CsOnlinePstnUsage [-Tenant <System.Guid>] [-Usage <PSListModifier>] [[-Identity] <XdsIdentity>] [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Instance
+```
+Set-CsOnlinePstnUsage [-Tenant <System.Guid>] [-Usage <PSListModifier>] [-Instance <PSObject>] [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{Fill Force Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Instance
+{{Fill Instance Description}}
+
+```yaml
+Type: PSObject
+Parameter Sets: Instance
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Usage
+{{Fill Usage Description}}
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Management.Automation.PSObject
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -189,4 +189,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
-[Get-CsOnlinePstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/get-csOnlinepstnusage?view=skype-ps)
+[Get-CsOnlinePstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinepstnusage?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -1,14 +1,14 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/eecc8b8a-16c3-4334-91bf-3be5db4d14d5(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Set-CsOnlinePstnUsage
 
 ## SYNOPSIS
-Creates or modifies a PSTN Usage to use in your organization.
+Modifies a set of strings that identify the allowed public switched telephone network (PSTN) usages. This cmdlet can be used to add usages to the list of PSTN usages or remove usages from the list.
 
 ## SYNTAX
 
@@ -25,18 +25,37 @@ Set-CsOnlinePstnUsage [-Tenant <Guid>] [-Usage <PSListModifier>] [-Instance <PSO
 ```
 
 ## DESCRIPTION
-A PSTN Usage is a container for Voice Routes; can be shared in different Voice Routing Policies.
-
-The `Set-CsOnlinePstnUsage` creates or modifies a PSTN Usage to use in your organization.
+PSTN usages are string values that are used for call authorization. A PSTN usage links a voice policy to a route. The `Set-CsOnlinePstnUsage` cmdlet is used to add or remove phone usages to or from the usage list. This list is global so it can be used by policies and routes throughout the tenant.
 
 ## EXAMPLES
 
 ### -------------------------- Example 1 --------------------------
 ```
-PS C:\> Set-CsOnlinePstnUsage  -Identity Global -Usage @{Add="US and Canada"}
+PS C:\> Set-CsOnlinePstnUsage -Identity global -Usage @{add="International"}
 ```
 
-The command shown in Example 1 creates the PSTN Usage “US and Canada”.
+This command adds the string "International" to the current list of available PSTN usages.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Set-CsOnlinePstnUsage -Identity global -Usage @{remove="Local"}
+```
+
+This command removes the string "Local" from the list of available PSTN usages.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> Set-CsOnlinePstnUsage -Usage @{remove="Local"}
+```
+
+The command in this example performs the exact same action as the command in Example 2: it removes the "Local" PSTN usage. This example shows the command without the Identity parameter specified. The only Identity available to the Set-CsPstnUsage cmdlet is the Global identity; omitting the Identity parameter defaults to Global.
+
+### -------------------------- Example 4 --------------------------
+```
+PS C:\> Set-CsOnlinePstnUsage -Usage @{replace="International","Restricted"}
+```
+
+This command replaces everything in the usage list with the values International and Restricted. All previously existing usages are removed.
 
 ## PARAMETERS
 
@@ -56,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{Fill Force Description}}
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
 ```yaml
 Type: SwitchParameter
@@ -71,7 +90,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+The scope at which these settings are applied. The Identity for this cmdlet is always Global.
 
 ```yaml
 Type: XdsIdentity
@@ -86,7 +105,7 @@ Accept wildcard characters: False
 ```
 
 ### -Instance
-{{Fill Instance Description}}
+A reference to a PSTN usage object. This object must be of type PstnUsages and can be retrieved by calling the Get-CsOnlinePstnUsage cmdlet.
 
 ```yaml
 Type: PSObject
@@ -101,7 +120,15 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
@@ -116,7 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -Usage
-{{Fill Usage Description}}
+Contains a list of allowable usage strings. These entries can be any string value.
 
 ```yaml
 Type: PSListModifier
@@ -162,3 +189,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsPstnUsage](https://docs.microsoft.com/en-us/powershell/module/skype/get-cspstnusage?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -48,7 +48,7 @@ This command removes the string "Local" from the list of available PSTN usages.
 PS C:\> Set-CsOnlinePstnUsage -Usage @{remove="Local"}
 ```
 
-The command in this example performs the exact same action as the command in Example 2: it removes the "Local" PSTN usage. This example shows the command without the Identity parameter specified. The only Identity available to the Set-CsPstnUsage cmdlet is the Global identity; omitting the Identity parameter defaults to Global.
+The command in this example performs the exact same action as the command in Example 2: it removes the "Local" PSTN usage. This example shows the command without the Identity parameter specified. The only Identity available to the Set-CsOnlinePstnUsage cmdlet is the Global identity; omitting the Identity parameter defaults to Global.
 
 ### -------------------------- Example 4 --------------------------
 ```

--- a/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePstnUsage.md
@@ -131,7 +131,7 @@ Get-CsTenant | Select-Object DisplayName, TenantID
 If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: System.Guid
+Type: Guid
 Parameter Sets: (All)
 Aliases:
 

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Set-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Modifies an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Modifies an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Office 365 users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 
@@ -27,7 +27,9 @@ Set-CsOnlineVoiceRoute [-Tenant <Guid>] [-Description <String>] [-NumberPattern 
 ```
 
 ## DESCRIPTION
-Use this cmdlet to modify an existing online voice route. Voice routes are associated with online voice policies through online public switched telephone network (PSTN) usages. A voice route includes a regular expression that identifies which phone numbers will be routed through a given voice route: phone numbers matching the regular expression will be routed through this route.
+Use this cmdlet to modify an existing online voice route. Online voice routes are associated with online voice policies through online public switched telephone network (PSTN) usages. A online voice route includes a regular expression that identifies which phone numbers will be routed through a given voice route: phone numbers matching the regular expression will be routed through this route.
+
+This cmdlet is used when configuring Microsoft Phone System Direct Routing.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
@@ -1,41 +1,82 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/96a619a9-62fd-4d28-8ed0-968e2de35e1e(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
 # Set-CsOnlineVoiceRoute
 
 ## SYNOPSIS
+Modifies an online voice route. Voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Set-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Description <String>] [-NumberPattern <String>]
+Set-CsOnlineVoiceRoute [-Tenant <Guid>] [-Description <String>] [-NumberPattern <String>]
  [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>]
  [[-Identity] <XdsGlobalRelativeIdentity>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Instance
 ```
-Set-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Description <String>] [-NumberPattern <String>]
+Set-CsOnlineVoiceRoute [-Tenant <Guid>] [-Description <String>] [-NumberPattern <String>]
  [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>]
  [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Use this cmdlet to modify an existing online voice route. Voice routes are associated with online voice policies through online public switched telephone network (PSTN) usages. A voice route includes a regular expression that identifies which phone numbers will be routed through a given voice route: phone numbers matching the regular expression will be routed through this route.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Set-CsOnlineVoiceRoute -Identity Route1 -Description "Test Route"
 ```
 
-{{ Add example description here }}
+This command sets the Description of the Route1 online voice route to "Test Route."
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Set-CsOnlineVoiceRoute -Identity Route1 -PstnUsages @{add="Long Distance"}
+```
+
+The command in this example modifies the online voice route with the identity Route1 to add the online PSTN usage Long Distance to the list of usages for this voice route. Long Distance must be in the list of global online PSTN usages (which can be retrieved with a call to the `Get-CsOnlinePstnUsage` cmdlet).
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> $x = (Get-CsOnlinePstnUsage).Usage
+
+PS C:\> Set-CsOnlineVoiceRoute -Identity Route1 -OnlinePstnUsages @{replace=$x}
+```
+
+This example modifies the online voice route named Route1 to populate that route's list of online PSTN usages with all the existing usages for the organization. The first command in this example retrieves the list of global online PSTN usages. Notice that the call to the `Get-CsOnlinePstnUsage` cmdlet is in parentheses; this means that we first retrieve an object containing PSTN usage information. (Because there is only one--global--PSTN usage, only one object will be retrieved.) The command then retrieves the Usage property of this object. That property, which contains a list of online PSTN usages, is assigned to the variable $x. In the second line of this example, the Set-CsOnlineVoiceRoute cmdlet is called to modify the online voice route with the identity Route1. Notice the value passed to the OnlinePstnUsages parameter: @{replace=$x}. This value says to replace everything in the OnlinePstnUsages list for this route with the contents of $x, which contain the online PSTN usages list retrieved in line 1.
+
+### -------------------------- Example 4 --------------------------
+```
+PS C:\> $x = Get-CsOnlineVoiceRoute -Identity Route1
+
+PS C:\> $x.Name = "RouteA"
+
+PS C:\> Set-CsOnlineVoiceRoute -Instance $x
+```
+
+This set of commands changes the Name property of the online voice route with the identity Route1 to RouteA. Changing the Name property automatically changes the Identity property, in this case to RouteA.
+
+In the first line, the `Get-CsOnlineVoiceRoute` cmdlet is called to retrieve the online voice route with the identity Route1. The returned object is stored in the variable $x. Next, the Name property of that object is assigned the string value "RouteA". Finally, the object (contained in the variable $x) is passed to the Instance parameter of the `Set-CsOnlineVoiceRoute` cmdlet to make the change.
+
+### -------------------------- Example 5 --------------------------
+```
+PS C:\> $y = Get-CsOnlineVoiceRoute -Identity Route1
+
+PS C:\> $y.OnlinePstnGatewayList.Add("OnlinePstnGateway:192.168.0.100")
+
+PS C:\> Set-CsOnlineVoiceRoute -Instance $y
+```
+
+This example modifies the online voice route named Route1 and populates that route's list of online PSTN gateways (OnlinePstnGatewayList) with the server role of the gateway with the identity PstnGateway:192.168.0.100. In the first line of this example, the `Get-CsOnlineVoiceRoute` cmdlet is called to retrieve the online voice route we want to modify, in this case Route1. Next we call the Add method on the OnlinePstnGatewayList property of Route1. We pass the Add method the Identity of the service we want to add. Finally, we call the `Set-CsOnlineVoiceRoute` cmdlet, passing the Instance parameter the variable $y, which will update Route1 (stored in $y) with the newly-added online PSTN gateway.
 
 ## PARAMETERS
 
@@ -55,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-{{Fill Description Description}}
+A description of what this phone route is for.
 
 ```yaml
 Type: String
@@ -70,7 +111,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{Fill Force Description}}
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +126,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+The unique identity of the online voice route. (If the route name contains a space, such as Test Route, you must enclose the full string in parentheses.)
 
 ```yaml
 Type: XdsGlobalRelativeIdentity
@@ -100,7 +141,7 @@ Accept wildcard characters: False
 ```
 
 ### -Instance
-{{Fill Instance Description}}
+Allows you to pass a reference to an object to the cmdlet rather than set individual parameter values. This object can be retrieved by calling the `Get-CsOnlineVoiceRoute` cmdlet.
 
 ```yaml
 Type: PSObject
@@ -115,7 +156,7 @@ Accept wildcard characters: False
 ```
 
 ### -NumberPattern
-{{Fill NumberPattern Description}}
+A regular expression that specifies the phone numbers to which this route applies. Numbers matching this pattern will be routed according to the rest of the routing settings. For example, the default number pattern, [0-9]{10}, specifies a 10-digit number containing any digits 0 through 9.
 
 ```yaml
 Type: String
@@ -130,7 +171,9 @@ Accept wildcard characters: False
 ```
 
 ### -OnlinePstnGatewayList
-{{Fill OnlinePstnGatewayList Description}}
+This parameter contains a list of online gateways associated with this online voice route. Each member of this list must be the service Identity of the online PSTN gateway. The service Identity is a string in the format OnlinePstnGateway:<FQDN>, where FQDN is the fully qualified domain name (FQDN) of the pool or the IP address of the server. For example, OnlinePstnGateway:redmondpool.litwareinc.com.
+
+By default this list is empty. However, if you leave this parameter blank when creating a new voice route, you'll receive a warning message.
 
 ```yaml
 Type: PSListModifier
@@ -145,7 +188,9 @@ Accept wildcard characters: False
 ```
 
 ### -OnlinePstnUsages
-{{Fill OnlinePstnUsages Description}}
+A list of online PSTN usages (such as Local, Long Distance, etc.) that can be applied to this online voice route. The PSTN usage must be an existing usage (PSTN usages can be retrieved by calling the Get-CsOnlinePstnUsage cmdlet).
+
+By default this list is empty. However, if you leave this parameter blank when creating a new online voice route, you'll receive a warning message.
 
 ```yaml
 Type: PSListModifier
@@ -160,7 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -Priority
-{{Fill Priority Description}}
+A number could resolve to multiple online voice routes. The priority determines the order in which the routes will be applied if more than one route is possible.
 
 ```yaml
 Type: Int32
@@ -175,7 +220,15 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
@@ -221,3 +274,8 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroute?view=skype-ps)
+
+[New-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroute?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoute](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroute?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
@@ -1,0 +1,223 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/96a619a9-62fd-4d28-8ed0-968e2de35e1e(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Set-CsOnlineVoiceRoute
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Set-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Description <String>] [-NumberPattern <String>]
+ [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>]
+ [[-Identity] <XdsGlobalRelativeIdentity>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Instance
+```
+Set-CsOnlineVoiceRoute [-Tenant <System.Guid>] [-Description <String>] [-NumberPattern <String>]
+ [-OnlinePstnUsages <PSListModifier>] [-OnlinePstnGatewayList <PSListModifier>] [-Priority <Int32>]
+ [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+{{Fill Description Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{Fill Force Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsGlobalRelativeIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Instance
+{{Fill Instance Description}}
+
+```yaml
+Type: PSObject
+Parameter Sets: Instance
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -NumberPattern
+{{Fill NumberPattern Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OnlinePstnGatewayList
+{{Fill OnlinePstnGatewayList Description}}
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OnlinePstnUsages
+{{Fill OnlinePstnUsages Description}}
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Priority
+{{Fill Priority Description}}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Management.Automation.PSObject
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoute.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Set-CsOnlineVoiceRoute
 
 ## SYNOPSIS
-Modifies an online voice route. Voice routes contain instructions that tell Skype for Business Online how to route calls from Phone System users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
+Modifies an online voice route. Online voice routes contain instructions that tell Skype for Business Online how to route calls from Microsoft Phone System Direct Routing users to phone numbers on the public switched telephone network (PSTN) or a private branch exchange (PBX).
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
@@ -1,0 +1,193 @@
+---
+external help file: tmp_5cw4yxew.xls-help.xml
+Module Name: tmp_5cw4yxew.xls
+online version: http://technet.microsoft.com/EN-US/library/96a619a9-62fd-4d28-8ed0-968e2de35e1e(OCS.15).aspx
+schema: 2.0.0
+---
+
+# Set-CsOnlineVoiceRoutingPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+### Identity (Default)
+```
+Set-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-OnlinePstnUsages <PSListModifier>]
+ [-Description <String>] [-RouteType <String>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Instance
+```
+Set-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-OnlinePstnUsages <PSListModifier>]
+ [-Description <String>] [-RouteType <String>] [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{Fill in the Description}}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+{{Fill Description Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{Fill Force Description}}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Instance
+{{Fill Instance Description}}
+
+```yaml
+Type: PSObject
+Parameter Sets: Instance
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -OnlinePstnUsages
+{{Fill OnlinePstnUsages Description}}
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RouteType
+{{Fill RouteType Description}}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{Fill Tenant Description}}
+
+```yaml
+Type: System.Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Management.Automation.PSObject
+
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
@@ -230,4 +230,4 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 
 [Grant-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csonlinevoiceroutingpolicy?view=skype-ps)
 
-[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?
+[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
@@ -8,6 +8,7 @@ schema: 2.0.0
 # Set-CsOnlineVoiceRoutingPolicy
 
 ## SYNOPSIS
+Modifies an existing online voice routing policy. Online voice routing policies manage online PSTN usages for Phone System users.
 
 ## SYNTAX
 
@@ -26,16 +27,32 @@ Set-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-OnlinePstnUsages <PSLis
 ```
 
 ## DESCRIPTION
-{{Fill in the Description}}
+Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+
+Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### -------------------------- Example 1 --------------------------
+```
+PS C:\> Set-CsOnlineVoiceRoutingPolicy -Identity "RedmondOnlineVoiceRoutingPolicy" -OnlinePstnUsages @{Add="Long Distance"}
 ```
 
-{{ Add example description here }}
+The command shown in Example 1 adds the online PSTN usage "Long Distance" to the per-user online voice routing policy RedmondOnlineVoiceRoutingPolicy.
+
+### -------------------------- Example 2 --------------------------
+```
+PS C:\> Set-CsOnlineVoiceRoutingPolicy -Identity "RedmondOnlineVoiceRoutingPolicy" -OnlinePstnUsages @{Remove="Local"}
+```
+
+In Example 2, the online PSTN usage "Local" is removed from the per-user online voice routing policy RedmondOnlineVoiceRoutingPolicy.
+
+### -------------------------- Example 3 --------------------------
+```
+PS C:\> Set-CsOnlineVoiceRoutingPolicy | Where-Object {$_.OnlinePstnUsages -contains "Local"} | Set-CsOnlineVoiceRoutingPolicy -OnlinePstnUsages @{Remove="Local"}
+```
+
+Example 3 removes the online PSTN usage "Local" is removed from all the online voice routing policies that include that usage. In order to do this, the command first calls the `Get-CsOnlineVoiceRoutingPolicy` cmdlet without any parameters in order to return a collection of all the available online voice routing policies. That collection is then piped to the Where-Object cmdlet, which picks out only those policies where the OnlinePstnUsages property includes (-contains) the "Local" usage. Those policies are then piped to the `Set-CsOnlineVoiceRoutingPolicy` cmdlet, which deletes the Local usage from each policy.
 
 ## PARAMETERS
 
@@ -55,7 +72,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-{{Fill Description Description}}
+Enables administrators to provide explanatory text to accompany an online voice routing policy. For example, the Description might include information about the users the policy should be assigned to.
 
 ```yaml
 Type: String
@@ -70,7 +87,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{Fill Force Description}}
+Suppresses the display of any non-fatal error message that might arise when running the command.
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +102,15 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{Fill Identity Description}}
+Unique identifier assigned to the policy when it was created. Online voice routing policies can be assigned at the global scope or the per-user scope. To refer to the global instance, use this syntax:
+
+-Identity global
+
+To refer to a per-user policy, use syntax similar to this:
+
+-Identity "RedmondOnlineVoiceRoutingPolicy"
+
+If you do not specify an Identity, then the `Set-CsOnlineVoiceRoutingPolicy` cmdlet will modify the global policy.
 
 ```yaml
 Type: XdsIdentity
@@ -100,7 +125,7 @@ Accept wildcard characters: False
 ```
 
 ### -Instance
-{{Fill Instance Description}}
+Allows you to pass a reference to an object to the cmdlet rather than set individual parameter values.
 
 ```yaml
 Type: PSObject
@@ -115,7 +140,7 @@ Accept wildcard characters: False
 ```
 
 ### -OnlinePstnUsages
-{{Fill OnlinePstnUsages Description}}
+A list of online PSTN usages (such as Local or Long Distance) that can be applied to this online voice routing policy. The online PSTN usage must be an existing usage. (PSTN usages can be retrieved by calling the `Get-CsOnlinePstnUsage` cmdlet.)
 
 ```yaml
 Type: PSListModifier
@@ -145,10 +170,18 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{Fill Tenant Description}}
+Globally unique identifier (GUID) of the tenant account whose external user communication policy are being created. For example:
+
+-Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
+
+You can return your tenant ID by running this command:
+
+Get-CsTenant | Select-Object DisplayName, TenantID
+
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
-Type: System.Guid
+Type: Guid
 Parameter Sets: (All)
 Aliases:
 
@@ -191,3 +224,10 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## NOTES
 
 ## RELATED LINKS
+[New-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/new-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Get-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/get-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Grant-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/grant-csonlinevoiceroutingpolicy?view=skype-ps)
+
+[Remove-CsOnlineVoiceRoutingPolicy](https://docs.microsoft.com/en-us/powershell/module/skype/remove-csonlinevoiceroutingpolicy?

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
@@ -1,7 +1,7 @@
 ---
-external help file: tmp_5cw4yxew.xls-help.xml
-Module Name: tmp_5cw4yxew.xls
-online version: http://technet.microsoft.com/EN-US/library/96a619a9-62fd-4d28-8ed0-968e2de35e1e(OCS.15).aspx
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+applicable: Skype for Business Online
+title: Get-CsOnlineUser
 schema: 2.0.0
 ---
 
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ### Identity (Default)
 ```
-Set-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-OnlinePstnUsages <PSListModifier>]
+Set-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-OnlinePstnUsages <PSListModifier>]
  [-Description <String>] [-RouteType <String>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
@@ -21,13 +21,13 @@ Set-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-OnlinePstnUsages <PSListModifi
 
 ### Instance
 ```
-Set-CsOnlineVoiceRoutingPolicy [-Tenant <System.Guid>] [-OnlinePstnUsages <PSListModifier>]
+Set-CsOnlineVoiceRoutingPolicy [-Tenant <Guid>] [-OnlinePstnUsages <PSListModifier>]
  [-Description <String>] [-RouteType <String>] [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Online voice routing policies are used in Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
+Online voice routing policies are used in Microsoft Phone System Direct Routing scenarios. Assigning your Skype for Business Online users an online voice routing policy enables those users to receive and to place phones calls to the public switched telephone network by using your on-premises SIP trunks.
 
 Note that simply assigning a user an online voice routing policy will not enable them to make PSTN calls via Skype for Business Online or Teams. Among other things, you will also need to enable those users for Phone System and will need to assign them an appropriate online voice policy.
 

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceRoutingPolicy.md
@@ -155,7 +155,7 @@ Accept wildcard characters: False
 ```
 
 ### -RouteType
-{{Fill RouteType Description}}
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String


### PR DESCRIPTION
@kenwith @tomkau 

I don't know what "-RouteType" parameter do on New-CsOnlineVoiceRoutingPolicy and Set-CsOnlineVoiceRoutingPolicy.
Could you help me with this? Or should I use "This parameter is reserved for internal Microsoft use"?

Also, I am thinking that I should have write more information about that these cmdlets are related to Teams Direct Routing. What do you think?

Thanks!