### PR TITLE
Remove some arguments from CSMeetingConfiguration

### DIFF
--- a/skype/skype-ps/skype/Set-CsMeetingConfiguration.md
+++ b/skype/skype-ps/skype/Set-CsMeetingConfiguration.md
@@ -167,7 +167,7 @@ The default value is True.
 Type: Boolean
 Parameter Sets: (All)
 Aliases: 
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -205,7 +205,7 @@ The default value is True.
 Type: Boolean
 Parameter Sets: (All)
 Aliases: 
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named


### PR DESCRIPTION
From bellow bug, EnableAssignedConferenceType and AssignedConferenceTypeByDefault are not supported by MeetingConfiguration. So please remove SPO from these argument to prevent confusion of admins.
https://skype.visualstudio.com/SBS/_workitems/edit/1468690