### PR TITLE
Remove WhatIf parameter from Set-CASMailboxPlan

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/set-CASMailboxPlan.md
+++ b/exchange/exchange-ps/exchange/client-access/set-CASMailboxPlan.md
@@ -35,7 +35,7 @@ Set-CASMailboxPlan [-Identity] <MailboxPlanIdParameter> [-ActiveSyncDebugLogging
  [-PopEnableExactRFC822Size <$true | $false>] [-PopForceICalForCalendarRetrievalOption <$true | $false>]
  [-PopMessagesRetrievalMimeFormat <TextOnly | HtmlOnly | HtmlAndTextAlternative | TextEnrichedOnly | TextEnrichedAndTextAlternative | BestBodyFormat | Tnef>]
  [-PopProtocolLoggingEnabled <$true | $false>] [-PopSuppressReadReceipt <$true | $false>]
- [-PopUseProtocolDefaults <$true | $false>] [-RemotePowerShellEnabled <$true | $false>] [-WhatIf]
+ [-PopUseProtocolDefaults <$true | $false>] [-RemotePowerShellEnabled <$true | $false>]
  [<CommonParameters>]
 ```
 
@@ -651,21 +651,6 @@ This parameter is reserved for internal Microsoft use.
 Type: $true | $false
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WhatIf
-The WhatIf switch simulates the actions of the command. You can use this switch to view the changes that would occur without actually applying those changes. You don't need to specify a value with this switch.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
 Applicable: Exchange Online
 Required: False
 Position: Named


### PR DESCRIPTION
When admins use WhatIf parameter with Set-CASMailboxPlan, the admin will see the error that admin can't use WhatIf option with Set-CASMailboxPlan command.
And from the spec that attached to the Task (https://o365exchange.visualstudio.com/DefaultCollection/Enterprise%20Cloud/_workitems/edit/54730), there is no WhatIf option.

With these, WhatIf option seems not supported with the command, how about remove the option from public document to prevent admin confusion.