### PR TITLE
Suggested Updates to New-PnPTenantSite.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/New-PnPTenantSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/New-PnPTenantSite.md
@@ -75,7 +75,7 @@ Accept pipeline input: False
 ```
 
 ### -Lcid
-Specifies the language of this site collection. For more information, see Locale IDs Assigned by Microsoft: https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.splanguage.lcid.aspx
+Specifies the language of this site collection. For more information, see Locale IDs Assigned by Microsoft: https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.splanguage.lcid.aspx. To get the list of supported languages use: (Get-PnPWeb -Includes RegionalSettings.InstalledLanguages).RegionalSettings.InstalledLanguages
 
 ```yaml
 Type: UInt32
@@ -161,7 +161,7 @@ Accept pipeline input: False
 ```
 
 ### -Template
-Specifies the site collection template type. Use the Get-PnPWebTemplate cmdlet to get the list of valid templates. If no template is specified, one can be added later. The Template and LocaleId parameters must be a valid combination as returned from the Get-PnPWebTemplates cmdlet.
+Specifies the site collection template type. Use the Get-PnPWebTemplates cmdlet to get the list of valid templates. If no template is specified, one can be added later. The Template and LocaleId parameters must be a valid combination as returned from the Get-PnPWebTemplates cmdlet.
 
 ```yaml
 Type: String
@@ -234,4 +234,7 @@ Accept pipeline input: False
 
 ## RELATED LINKS
 
-[SharePoint Developer Patterns and Practices](http://aka.ms/sppnp)[Locale IDs](http://go.microsoft.com/fwlink/p/?LinkId=242911Id=242911)[Resource Usage Limits on Sandboxed Solutions in SharePoint 2010](http://msdn.microsoft.com/en-us/library/gg615462.aspx.)[Creating on-premises site collections using CSOM](http://blogs.msdn.com/b/vesku/archive/2014/06/09/provisioning-site-collections-using-sp-app-model-in-on-premises-with-just-csom.aspx)
+* [SharePoint Developer Patterns and Practices](http://aka.ms/sppnp)
+* [Locale IDs](http://go.microsoft.com/fwlink/p/?LinkId=242911)
+* [Resource Usage Limits on Sandboxed Solutions in SharePoint 2010](http://msdn.microsoft.com/en-us/library/gg615462.aspx.)
+* [Creating on-premises site collections using CSOM](http://blogs.msdn.com/b/vesku/archive/2014/06/09/provisioning-site-collections-using-sp-app-model-in-on-premises-with-just-csom.aspx)


### PR DESCRIPTION
The LCID references do not list the ID codes for creating a site with a specific LocaleID with a type of UINT32 so have added a command to get that from SharePoint online. Minor corrections to the other commands and seemingly corrected a bad URL at the bottom of the article.