### PR TITLE
Update Set-DistributionGroup.md

### DIFF
--- a/exchange/exchange-ps/exchange/users-and-groups/Set-DistributionGroup.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/Set-DistributionGroup.md
@@ -733,13 +733,11 @@ Accept wildcard characters: False
 ### -ExpansionServer
 This parameter is available only in on-premises Exchange.
 
-The ExpansionServer parameter specifies the Exchange server that's used to expand the distribution group. The default value is blank ($null), which means expansion happens on the closest available Exchange 2016 Mailbox server. If you specify an expansion server, and that server is unavailable, any messages that are sent to the distribution group can't be delivered.
+The ExpansionServer parameter specifies the Exchange server that's used to expand the distribution group. The default value is blank ($null), which means expansion happens on the closest available Exchange server. If you specify an expansion server, and that server is unavailable, any messages that are sent to the distribution group can't be delivered.
 
 You can specify the following types of servers as expansion servers:
 
-- An Exchange 2016 Mailbox server.
-
-- An Exchange 2013 Mailbox server.
+- An Exchange 2013 or later Mailbox server.
 
 - An Exchange 2010 Hub Transport server.
 

--- a/exchange/exchange-ps/exchange/users-and-groups/Set-DistributionGroup.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/Set-DistributionGroup.md
@@ -733,7 +733,7 @@ Accept wildcard characters: False
 ### -ExpansionServer
 This parameter is available only in on-premises Exchange.
 
-The ExpansionServer parameter specifies the Exchange server that's used to expand the distribution group. The default value is blank ($null), which means expansion happens on the closest available Exchange 2016 Mailbox server. If you specify an expansion server, and that server is unavailable, any messages that are sent to the distribution group can't be delivered. Therefore, you should consider implementing a high availability solution for an expansion server.
+The ExpansionServer parameter specifies the Exchange server that's used to expand the distribution group. The default value is blank ($null), which means expansion happens on the closest available Exchange 2016 Mailbox server. If you specify an expansion server, and that server is unavailable, any messages that are sent to the distribution group can't be delivered.
 
 You can specify the following types of servers as expansion servers:
 


### PR DESCRIPTION
When validating the value passed to the 'ExpansionServer' attribute, the ValidateExpansionServer method is evaluated.
This method takes a single Exchange server only (not an array), so how can a high availability solution be deployed here?
Is this part of older documentation that got carried over? From 2013 onward, our recommendation is to allow any Mailbox server to expand.