### PR TITLE
Improves LegacyAuthProtocolsEnabled documentation

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -737,18 +737,29 @@ Accept wildcard characters: False
 ```
 
 ### -LegacyAuthProtocolsEnabled
-By default this value is set to $True. 
+By default this value is set to $True, which means that authentication using legacy protocols is enabled.
 
-Setting this parameter prevents Office clients using non-modern authentication protocols from accessing SharePoint Online resources.
+Setting this parameter to $False prevents Office clients using non-modern authentication protocols from accessing SharePoint Online resources.
 
 A value of True- Enables Office clients using non-modern authentication protocols (such as, Forms-Based Authentication (FBA) or Identity Client Runtime Library (IDCRL)) to access SharePoint resources. 
 
-A value of False-Prevents Office clients using non-modern authentication protocols from accessing SharePoint Online resources.
+A value of False- Prevents Office clients using non-modern authentication protocols from accessing SharePoint Online resources.
 
 > [!NOTE] 
 > This may also prevent third-party apps from accessing SharePoint Online resources.
 Also, this will also block apps using the SharePointOnlineCredentials class to access SharePoint Online resources. For additional information about SharePointOnlineCredentials, see SharePointOnlineCredentials class.  
 
+> [!NOTE] 
+> The change is not instant. It might take up to 24 hours to be applied.
+
+#### EXAMPLES
+
+##### -----------------------EXAMPLE 1-----------------------------
+```
+Connect-SPOService
+Set-SPOTenant -LegacyAuthProtocolsEnabled $True
+```
+This example enables legacy authentication protocols on the tenant. This can help to enable login in situations where the admin users get an error like "Cannot contact web site 'https://contoso-admin.sharepoint.com/' or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'.", and the underlying error is "Access denied. Before opening files in this location, you must first browse to the web site and select the option to login automatically."
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -752,13 +752,12 @@ Also, this will also block apps using the SharePointOnlineCredentials class to a
 > [!NOTE] 
 > The change is not instant. It might take up to 24 hours to be applied.
 
-#### EXAMPLES
-
-##### -----------------------EXAMPLE 1-----------------------------
-```
+EXAMPLE
+`
 Connect-SPOService
 Set-SPOTenant -LegacyAuthProtocolsEnabled $True
-```
+`
+
 This example enables legacy authentication protocols on the tenant. This can help to enable login in situations where the admin users get an error like "Cannot contact web site 'https://contoso-admin.sharepoint.com/' or the web site does not support SharePoint Online credentials. The response status code is 'Unauthorized'.", and the underlying error is "Access denied. Before opening files in this location, you must first browse to the web site and select the option to login automatically."
 
 ```yaml


### PR DESCRIPTION
Fixes a misleading description in the documentation for -LegacyAuthProtocolsEnabled, adds an example and expands the documentation.

Fixes this issue:
#1994 