### PR TITLE
Update Set-CsMeetingConfiguration.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsMeetingConfiguration.md
+++ b/skype/skype-ps/skype/Set-CsMeetingConfiguration.md
@@ -143,6 +143,7 @@ Accept wildcard characters: False
 Determines whether meetings will, by default, allow attendance by anonymous users (that is, by unauthenticated users) or by federated users (authenticated users from other tenants).
 Set this value to True if you would like new meetings to allow for attendance by anonymous users or federated users by default.
 Set this value to False if you would prefer that, by default, new meetings do not allow for attendance by anonymous users or federated users. When set to False, anonymous and federated users will be placed in the lobby of a meeting when trying to join it. After being placed in the lobby, they can be admitted by any presenter in the meeting.
+When this value is changed, the change will only apply to new meetings and it will not applied to meetings already scheduled.
 The default value is True.
 
 ```yaml

--- a/skype/skype-ps/skype/Set-CsMeetingConfiguration.md
+++ b/skype/skype-ps/skype/Set-CsMeetingConfiguration.md
@@ -140,9 +140,9 @@ Accept wildcard characters: False
 ```
 
 ### -AdmitAnonymousUsersByDefault
-Determines whether meetings will, by default, allow attendance by anonymous users (that is, by unauthenticated users).
-Set this value to True if you would like new meetings to allow for attendance by anonymous users by default.
-Set this value to False if you would prefer that, by default, new meetings do not allow for attendance by anonymous users.
+Determines whether meetings will, by default, allow attendance by anonymous users (that is, by unauthenticated users) or by federated users (authenticated users from other tenants).
+Set this value to True if you would like new meetings to allow for attendance by anonymous users or federated users by default.
+Set this value to False if you would prefer that, by default, new meetings do not allow for attendance by anonymous users or federated users. When set to False, anonymous and federated users will be placed in the lobby of a meeting when trying to join it. After being placed in the lobby, they can be admitted by any presenter in the meeting.
 The default value is True.
 
 ```yaml


### PR DESCRIPTION
Expanded the description of the AdmitAnonymousUsersByDefault attribute to indicate that in addition to anonymous users, the behavior controlled by the attribute also applies to federated users.