### PR TITLE
Updating sample for Remove-SPOTenantCdnOrigin

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantCdnOrigin.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantCdnOrigin.md
@@ -26,7 +26,7 @@ Removes a new origin from the Public or Private content delivery network (CDN).
 
 ### -----------------------EXAMPLE 1-----------------------------
 ```
-Remove-SPOTenantCdnOrigin -CdnType Public -OriginScope Tenant -OriginUrl sites/pubsite/siteassets/subfolder
+Remove-SPOTenantCdnOrigin -CdnType Public -OriginUrl sites/pubsite/siteassets/subfolder
 ```
 
 The example removes a CDN from a tenant level.


### PR DESCRIPTION
the -OriginScope parameter is no longer accepted. It looks like it was removed from the documentation but not from the sample. Closes issue #2225 