### PR TITLE
Cannot use DisplayName as identity in ExO

### DIFF
--- a/exchange/exchange-ps/exchange/email-addresses-and-address-books/Get-AddressList.md
+++ b/exchange/exchange-ps/exchange/email-addresses-and-address-books/Get-AddressList.md
@@ -109,7 +109,6 @@ The Identity parameter specifies the address list that you want to view. You can
 
 - Name
 
-- Display name
 
 - Distinguished name (DN)
 


### PR DESCRIPTION
In ExO the command fails when I use Display Name with identity parameter. Error is something like Object 'Display Name' not found in 'KAWPR01A001DC02.JPNPR01A001.PROD.OUTLOOK.COM'.
I am not sure if it works in Onpremise Exchange Server.