### PR TITLE
Error when using display name as identity in ExO

### DIFF
--- a/exchange/exchange-ps/exchange/email-addresses-and-address-books/Remove-AddressList.md
+++ b/exchange/exchange-ps/exchange/email-addresses-and-address-books/Remove-AddressList.md
@@ -49,8 +49,6 @@ The Identity parameter specifies the address list that you want to remove. You c
 
 - Name
 
-- Display name
-
 - Distinguished name (DN)
 
 - GUID


### PR DESCRIPTION
When I use Display Name value with identity parameter in ExO, it fails with error. Error is something like "Object 'DisplayName' not found in  'KAWPR01A001DC02.JPNPR01A001.PROD.OUTLOOK.COM'".
Not sure if it works on Onpremise Exchange server.