### PR TITLE
Cannot use displayname as identity

### DIFF
--- a/exchange/exchange-ps/exchange/email-addresses-and-address-books/Set-AddressList.md
+++ b/exchange/exchange-ps/exchange/email-addresses-and-address-books/Set-AddressList.md
@@ -74,8 +74,6 @@ The Identity parameter specifies the address list that you want to modify. You c
 
 - Name
 
-- Display name
-
 - Distinguished name (DN)
 
 - GUID


### PR DESCRIPTION
When I use display name value for identity parameter when I run set-addresslist in ExO, it fails with error. Error said "Object 'display name' not found in   'KAWPR01A001DC02.JPNPR01A001.PROD.OUTLOOK.COM'".