### PR TITLE
Update to the notes section

### DIFF
--- a/skype/skype-ps/skype/Grant-CsTeamsCallParkPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsCallParkPolicy.md
@@ -11,7 +11,7 @@ schema: 2.0.0
 
 The TeamsCallParkPolicy controls whether or not users are able to leverage the call park feature in Microsoft Teams.  Call park allows enterprise voice customers to place a call on hold and then perform a number of actions on that call: transfer to another department, retrieve via the same phone, or retrieve via a different Teams phone.  The Grant-CsTeamsCallParkPolicy cmdlet lets you assign a custom policy to a specific user.
 
-NOTE: the call park feature currently only available in desktop and web clients.  Call Park functionality is currently completely disabled in mobile clients.  Supported with TeamsOnly mode
+NOTE: the call park feature currently only available in desktop, web clients and mobile clients.  Call Park functionality is currently on the roadmap for Teams IP Phones.  Supported with TeamsOnly mode for users with the Phone Sytem license
 
 ## SYNTAX
 


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/microsoftteams/call-park-and-retrieve, the call park feature is available on mobile, and is on the roadmap for the teams IP phones. Updated notes to reflect this. Also added that you need to have phone system license