### PR TITLE
typo: behaviour -> behavior

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Add-PnPWorkflowDefinition.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Add-PnPWorkflowDefinition.md
@@ -41,7 +41,7 @@ Accept pipeline input: False
 ```
 
 ### -DoNotPublish
-Overrides the default behaviour, which is to publish workflow definitions.
+Overrides the default behavior, which is to publish workflow definitions.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION

Correct british spelling, but US spelling seems to be used elsewhere