### PR TITLE
Update Set-TransportRule.md

### DIFF
--- a/exchange/exchange-ps/exchange/policy-and-compliance/Set-TransportRule.md
+++ b/exchange/exchange-ps/exchange/policy-and-compliance/Set-TransportRule.md
@@ -4479,7 +4479,7 @@ In on-premises Exchange, this action is only available on Mailbox servers.
 
 The RejectMessageEnhancedStatusCode parameter specifies the enhanced status code that's used when the rule rejects messages. Valid values are 5.7.1 or between 5.7.900 and 5.7.999.
 
-You can use this parameter with the NotifySender and RejectMessageReasonText parameters to specify the custom enhanced status code that's used. If you don't use this parameter, the default value 5.7.1 is used.
+You can use this parameter with the NotifySender and RejectMessageReasonText parameters to specify the custom enhanced status code that's used. If -RejectMessageReasonText specified, status code is defaulted to "5.7.1"
 
 To further customize the NDR (for example, multiple languages), you need to create a custom message by using the New-SystemMessage cmdlet.
 
@@ -4502,7 +4502,7 @@ In on-premises Exchange, this action is only available on Mailbox servers.
 
 The RejectMessageReasonText parameter specifies the explanation text that's used when the rule rejects messages. If the value contains spaces, enclose the value in quotation marks (").
 
-You can use this parameter with the NotifySender and RejectMessageEnhancedStatusCode parameters to specify the custom explanation text that's used. If you don't use this parameter, the default value Delivery not authorized, message refused is used.
+You can use this parameter with the NotifySender and RejectMessageEnhancedStatusCode parameters to specify the custom explanation text that's used. If -RejectMessageEnhancedStatusCode specified, RejectMessageReasonText is set to "Delivery not authorized, message refused"
 
 To further customize the NDR (for example, multiple languages), you need to create a custom message by using the New-SystemMessage cmdlet.
 


### PR DESCRIPTION
Correction made on 4482 and 4505

If -RejectMessageReasonText specified, status code is defaulted to "5.7.1"
If -RejectMessageEnhancedStatusCode specified, RejectMessageReasonText is set to "Delivery not authorized, message refused"