### PR TITLE
-RemoveManagedFolderAndPolicy description

### DIFF
--- a/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
@@ -4120,7 +4120,7 @@ Accept wildcard characters: False
 ### -RemoveManagedFolderAndPolicy
 This parameter is available only in on-premises Exchange.
 
-The RemoveManagedFolderAndPolicyswitch specifies whether to remove all MRM 1.0 policies and attributes from a mailbox. If you use this switch, MRM 1.0 policies and MRM 1.0 properties from any managed folders that were created as part of any MRM 1.0 policies are removed. Managed folders that are empty are also removed from the mailbox, and managed folders that contain items are converted to standard folders.
+The RemoveManagedFolderAndPolicy switch specifies whether to remove all MRM policies and attributes from a mailbox. 
 
 You don't need to specify a value with this switch.
 


### PR DESCRIPTION
The old description makes someone think the switch is only valid for MRM 1.0, which was introduced in Exchange 2007 and can be used in Exchange 2010. 
Old description "The RemoveManagedFolderAndPolicyswitch specifies whether to remove all MRM 1.0 policies and attributes from a mailbox. If you use this switch, MRM 1.0 policies and MRM 1.0 properties from any managed folders that were created as part of any MRM 1.0 policies are removed. Managed folders that are empty are also removed from the mailbox, and managed folders that contain items are converted to standard folders."
 However, that is incorrect. The switch also removes MRM 2.0 policies. I have tested this in an Exchange 2013 CU20 lab.
Instead we should say " The RemoveManagedFolderAndPolicy switch specifies whether to remove all MRM policies and attributes from a mailbox."

