### PR TITLE
Adding note, clarifying Voice Policy for online hosted accounts

### DIFF
--- a/skype/skype-ps/skype/Grant-CsVoicePolicy.md
+++ b/skype/skype-ps/skype/Grant-CsVoicePolicy.md
@@ -27,6 +27,8 @@ Grant-CsVoicePolicy [[-Identity] <UserIdParameter>] [-PolicyName] <String> [-Ten
 Grant-CsVoicePolicy [-PolicyName] <String> [-Tenant <Guid>] [-DomainController <Fqdn>] [-PassThru]
  [-Global] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
+    > [!NOTE]
+    > For accounts hosted in Skype for Business Online, it is not possible to grant a voice policy via PowerShell. In this scenario, the voice policy is automatically granted based on user licensing.
 
 ## DESCRIPTION
 

--- a/skype/skype-ps/skype/Grant-CsVoicePolicy.md
+++ b/skype/skype-ps/skype/Grant-CsVoicePolicy.md
@@ -27,8 +27,7 @@ Grant-CsVoicePolicy [[-Identity] <UserIdParameter>] [-PolicyName] <String> [-Ten
 Grant-CsVoicePolicy [-PolicyName] <String> [-Tenant <Guid>] [-DomainController <Fqdn>] [-PassThru]
  [-Global] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
-    > [!NOTE]
-    > For accounts hosted in Skype for Business Online, it is not possible to grant a voice policy via PowerShell. In this scenario, the voice policy is automatically granted based on user licensing.
+
 
 ## DESCRIPTION
 
@@ -41,7 +40,8 @@ For example:
 
 `Get-CsUser "Ken Myer" | Select-Object VoicePolicy`
 
-
+    > [!NOTE]
+    > For accounts hosted in Skype for Business Online, it is not possible to grant a voice policy via PowerShell. In this scenario, the voice policy is automatically granted based on user licensing.
 
 ## EXAMPLES
 


### PR DESCRIPTION
For accounts hosted in Skype for Business Online, the voice policy is automatically grated, based on user licenses. For example, granting Phone Sytem and Domestic/International Calling to a SfB/Teams account will automatically set the voice policy for this user to BusinessVoice.