### PR TITLE
Update Disable-RemoteMailbox.md

### DIFF
--- a/exchange/exchange-ps/exchange/federation-and-hybrid/Disable-RemoteMailbox.md
+++ b/exchange/exchange-ps/exchange/federation-and-hybrid/Disable-RemoteMailbox.md
@@ -34,7 +34,7 @@ If you want to remove both the cloud-based mailbox and the associated on-premise
 Directory synchronization must be configured correctly for a mailbox to be removed from the cloud. Removal of the cloud-based mailbox isn't immediate and depends on the directory synchronization schedule.
 
 > [!NOTE]
-> If you are deprovisioning a cloud mailbox and its associated online archive, you must disable the online archive with ```Disable-RemoteMailbox <user> -Archive``` and then perform a directory synchronization prior to disabling the remote mailbox. Attempting to disable both the online archive and cloud mailbox without a sync between them may result in an ArchiveGuid mismatch and validation error. 
+> If you are deprovisioning a cloud mailbox and its associated online archive, you must disable the online archive with Disable-RemoteMailbox \<user\> -Archive and then perform a directory synchronization prior to disabling the remote mailbox. Attempting to disable both the online archive and cloud mailbox without a sync between them may result in an ArchiveGuid mismatch and validation error. 
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/federation-and-hybrid/Disable-RemoteMailbox.md
+++ b/exchange/exchange-ps/exchange/federation-and-hybrid/Disable-RemoteMailbox.md
@@ -33,8 +33,7 @@ If you want to remove both the cloud-based mailbox and the associated on-premise
 
 Directory synchronization must be configured correctly for a mailbox to be removed from the cloud. Removal of the cloud-based mailbox isn't immediate and depends on the directory synchronization schedule.
 
-> [!NOTE]
-> If you are deprovisioning a cloud mailbox and its associated online archive, you must disable the online archive with Disable-RemoteMailbox \<user\> -Archive and then perform a directory synchronization prior to disabling the remote mailbox. Attempting to disable both the online archive and cloud mailbox without a sync between them may result in an ArchiveGuid mismatch and validation error. 
+Note: If you are deprovisioning a cloud mailbox and its associated online archive, you must first disable the online archive with Disable-RemoteMailbox \<user\> -Archive and then perform a directory synchronization prior to disabling the remote mailbox. Attempting to disable both the online archive and cloud mailbox without a sync between them may result in an ArchiveGuid mismatch and validation error. 
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/federation-and-hybrid/Disable-RemoteMailbox.md
+++ b/exchange/exchange-ps/exchange/federation-and-hybrid/Disable-RemoteMailbox.md
@@ -33,6 +33,9 @@ If you want to remove both the cloud-based mailbox and the associated on-premise
 
 Directory synchronization must be configured correctly for a mailbox to be removed from the cloud. Removal of the cloud-based mailbox isn't immediate and depends on the directory synchronization schedule.
 
+> [!NOTE]
+> If you are deprovisioning a cloud mailbox and its associated online archive, you must disable the online archive with ```Disable-RemoteMailbox <user> -Archive``` and then perform a directory synchronization prior to disabling the remote mailbox. Attempting to disable both the online archive and cloud mailbox without a sync between them may result in an ArchiveGuid mismatch and validation error.
+
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 
 ## EXAMPLES


### PR DESCRIPTION
Updating to include a warning note about disabling the online archive and remote mailbox in the same dirsync cycle.

> [!NOTE]
> If you are deprovisioning a cloud mailbox and its associated online archive, you must disable the online archive with ```Disable-RemoteMailbox <user> -Archive``` and then perform a directory synchronization prior to disabling the remote mailbox. Attempting to disable both the online archive and cloud mailbox without a sync between them may result in an ArchiveGuid mismatch and validation error.