### PR TITLE
Corrected user requirement for Owner parameter

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
@@ -110,7 +110,7 @@ Accept wildcard characters: False
 ```
 
 ### -Owner
-Specifies the user name of the site collection’s primary owner. The owner must be a user instead of a security group or an email-enabled security group.
+Specifies the user name of the site collection’s primary owner. The owner must be a email-enabled user instead of a security group or an email-enabled security group.
 
 
 ```yaml


### PR DESCRIPTION
Corrected user requirement for Owner parameter, user must be email-enabled for the parameter to work. https://github.com/MicrosoftDocs/office-docs-powershell/issues/1300