### PR TITLE
Update set-imapsettings

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-ImapSettings.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-ImapSettings.md
@@ -407,7 +407,7 @@ Accept wildcard characters: False
 ```
 
 ### -MaxCommandSize
-The MaxCommandSize parameter specifies the maximum size in bytes of a single IMAP4 command. Valid values are from 40 through 1024. The default value is 512.
+The MaxCommandSize parameter specifies the maximum size in bytes of a single IMAP4 command. Valid values are from 1024 through 16384. The default value is 10240.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
 max/min/default values based on https://docs.microsoft.com/en-us/exchange/set-connection-limits-for-imap4-exchange-2013-help#use-the-eac-to-set-imap4-connection-limits-for-a-server-an-ip-address-or-a-user