### PR TITLE
LinkType EventSubscribers has been deprecated in remove-UnifiedGroupLinks 

### DIFF
--- a/exchange/exchange-ps/exchange/users-and-groups/Remove-UnifiedGroupLinks.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/Remove-UnifiedGroupLinks.md
@@ -22,7 +22,7 @@ For information about the parameter sets in the Syntax section below, see Exchan
 
 ```
 Remove-UnifiedGroupLinks [-Identity] <UnifiedGroupIdParameter> -Links <RecipientIdParameter[]>
- -LinkType <Members | Owners | Subscribers | Aggregators | EventSubscribers> [-Confirm] [-WhatIf]
+ -LinkType <Members | Owners | Subscribers | Aggregators> [-Confirm] [-WhatIf]
  [<CommonParameters>]
 ```
 
@@ -117,10 +117,9 @@ The LinkType parameter specifies the Office 365 Group property that you want to 
 
 - Owners
 
-- Subscribers
 
 ```yaml
-Type: Members | Owners | Subscribers | Aggregators | EventSubscribers
+Type: Members | Owners | Subscribers | Aggregators
 Parameter Sets: (All)
 Aliases:
 Applicable: Exchange Online


### PR DESCRIPTION
-LinkType EventSubscribers has been deprecated or isn't available for customers to use. Please refer to VSTS:1047396 for more information or Skype IM me on Shivsi@microsoft.com