### PR TITLE
URL Correction to EXO GCC High Endpoint

### DIFF
--- a/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/connect-to-exchange-online-powershell.md
@@ -78,7 +78,7 @@ Exchange Online PowerShell allows you to manage your Exchange Online settings fr
 
    - For Office 365 Germany, use the _ConnectionUri_ value: `https://outlook.office.de/powershell-liveid/`
     
-   - For Office 365 Government Community Cloud High (GCC High), use the _ConnectionUri_ value: `https://ps.compliance.protection.office365.us/powershell-liveid/`
+   - For Office 365 Government Community Cloud High (GCC High), use the _ConnectionUri_ value: `https://outlook.office365.us/powershell-liveid/`
 
    - If you're behind a proxy server, run this command first: `$ProxyOptions = New-PSSessionOption -ProxyAccessType <Value>`, where the _ProxyAccessType_ value is `IEConfig`, `WinHttpConfig`, or `AutoDetect`.
       


### PR DESCRIPTION
The endpoint listed currently is to connect to SCC/EOP in GCC High. The EXO PowerShell endpoint for GCC High should be https://outlook.office365.us/powershell-liveid/