### PR TITLE
URL in HTTPS

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
@@ -36,14 +36,14 @@ For permissions and the most current information about Windows PowerShell for Sh
 
 ### -----------------------EXAMPLE 1-----------------------------
 ```
-New-SPOSite -Url http://contoso.sharepoint.com/sites/mynewsite -Owner joe.healy@contoso.com -StorageQuota 1000 -Title "My new site collection"
+New-SPOSite -Url https://contoso.sharepoint.com/sites/mynewsite -Owner joe.healy@contoso.com -StorageQuota 1000 -Title "My new site collection"
 ```
 
 Example 1 creates a new site collection for the current company with specified site URL, title and owner. The storage quota is set to 1000 megabytes.
 
 ### -----------------------EXAMPLE 2-----------------------------
 ```
-New-SPOSite -Url http://contoso.sharepoint.com/sites/mynewsite -Owner joe.healy@contoso.com -StorageQuota 1000 -CompatibilityLevel 15 -LocaleID 1033 -ResourceQuota 300 -Template "STS#0" -TimeZoneId 13 -Title "My new site collection"
+New-SPOSite -Url https://contoso.sharepoint.com/sites/mynewsite -Owner joe.healy@contoso.com -StorageQuota 1000 -CompatibilityLevel 15 -LocaleID 1033 -ResourceQuota 300 -Template "STS#0" -TimeZoneId 13 -Title "My new site collection"
 ```
 
 Example 2 creates a new site collection for the current company with specified site URL, title, owner and template. The storage quota is set to 1000 megabytes and the resource quota is set to 300 megabytes. The template compatibility level is set to 15 which means that the site collection only supports the SharePoint 2013 template. The language is set to English - United States (LocaleID = 1033) and the time zone is set to (GMT-08:00) Pacific Time (US and Canada) (TimeZone = 13).


### PR DESCRIPTION
The 2 first URL in the example are in HTTP. When I try on a test tenant I had the following error:
New-SPOSite : The private site url http://contos.sharepoint.com/sites/newsite must use the https protocol.
and work with HTTPS.
It will be more logical to but the 3 examples in HTTPS. I didn't do something to force the HTTPS on my test tenant, so I suppose is the default option.