### PR TITLE
Update Set-OwaMailboxPolicy.md

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
@@ -1615,7 +1615,7 @@ Accept wildcard characters: False
 ```
 
 ### -SetPhotoURL
-The SetPhotoURL parameter specifies the location (URL) of user photos. The default value of this parameter is blank ($null).
+The SetPhotoURL parameter controls where users go to select their photo. Note that you can't specify a URL that contains one or more picture files, as there is no mechanism to copy a URL photo to the properties of the users' Exchange Online mailboxes.
 
 ```yaml
 Type: String


### PR DESCRIPTION
A change to clear up the actual purpose of the 'SetPhotoUrl' parameter.
It is based on older information posted here:
https://docs.microsoft.com/hu-hu/previous-versions/exchange-server/exchangeserver-149/hh674370(v=exchsrvcs.149)