### PR TITLE
Replace all instances of > with Set-Content

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Test-CalendarConnectivity.md
+++ b/exchange/exchange-ps/exchange/client-access/Test-CalendarConnectivity.md
@@ -54,7 +54,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-CalendarConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\Calendar Test.html"
+Test-CalendarConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\Calendar Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/client-access/Test-EcpConnectivity.md
+++ b/exchange/exchange-ps/exchange/client-access/Test-EcpConnectivity.md
@@ -52,7 +52,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-EcpConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\EAC Test.html"
+Test-EcpConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\EAC Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/client-access/Test-ImapConnectivity.md
+++ b/exchange/exchange-ps/exchange/client-access/Test-ImapConnectivity.md
@@ -53,7 +53,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-IMAPConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\IMAP Test.html"
+Test-IMAPConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\IMAP Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/client-access/Test-PopConnectivity.md
+++ b/exchange/exchange-ps/exchange/client-access/Test-PopConnectivity.md
@@ -53,7 +53,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-PopConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\POP Test.html"
+Test-PopConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\POP Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/client-access/Test-PowerShellConnectivity.md
+++ b/exchange/exchange-ps/exchange/client-access/Test-PowerShellConnectivity.md
@@ -71,7 +71,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-PowerShellConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\PowerShell Test.html"
+Test-PowerShellConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\PowerShell Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/client-access/Test-WebServicesConnectivity.md
+++ b/exchange/exchange-ps/exchange/client-access/Test-WebServicesConnectivity.md
@@ -89,7 +89,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-WebServicesConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\EWS Test.html"
+Test-WebServicesConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\EWS Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/devices/Test-ActiveSyncConnectivity.md
+++ b/exchange/exchange-ps/exchange/devices/Test-ActiveSyncConnectivity.md
@@ -53,7 +53,7 @@ The test results are displayed on-screen. The cmdlet returns the following infor
 
 You can write the results to a file by piping the output to ConvertTo-Html or ConvertTo-Csv and adding \> \<filename\> to the command. For example:
 
-Test-ActiveSyncConnectivity -ClientAccessServer MBX01 | ConvertTo-Html \> "C:\\My Documents\\EAS Test.html"
+Test-ActiveSyncConnectivity -ClientAccessServer MBX01 | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\EAS Test.html"
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see Find the permissions required to run any Exchange cmdlet (https://technet.microsoft.com/library/mt432940.aspx).
 

--- a/exchange/exchange-ps/exchange/mail-flow/Get-SystemMessage.md
+++ b/exchange/exchange-ps/exchange/mail-flow/Get-SystemMessage.md
@@ -60,7 +60,7 @@ This example displays detailed information for the specified custom quota messag
 
 ### -------------------------- Example 4 --------------------------
 ```
-Get-SystemMessage -Original | Select-Object -Property Identity,DsnCode,Language,Text | ConvertTo-Html > "C:\My Documents\Default System Messages.html"
+Get-SystemMessage -Original | Select-Object -Property Identity,DsnCode,Language,Text | ConvertTo-Html | Set-Content -Path "C:\My Documents\Default System Messages.html"
 ```
 
 This example outputs the list of all default system messages in all languages to an HTML file named C:\\My Documents\\Default System Messages.html.

--- a/exchange/exchange-ps/exchange/mail-flow/New-SystemMessage.md
+++ b/exchange/exchange-ps/exchange/mail-flow/New-SystemMessage.md
@@ -64,7 +64,7 @@ The DsnCode parameter specifies the enhanced status code for the custom system m
 
 Valid values are 4.x.y or 5.x.y where x and y are one to three digit numbers. You can specify a default code that's included with Exchange, or you can specify a custom code.
 
-To generate a list of default enhanced status codes that are used by Exchange, run this command: Get-SystemMessage -Original | Select-Object -Property Identity,DsnCode,Language,Text | ConvertTo-Html \> "C:\\My Documents\\Default DSNs.html".
+To generate a list of default enhanced status codes that are used by Exchange, run this command: Get-SystemMessage -Original | Select-Object -Property Identity,DsnCode,Language,Text | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\Default DSNs.html".
 
 You need to use this parameter with the Language and Internal parameters.
 

--- a/exchange/exchange-ps/exchange/mail-flow/Set-SystemMessage.md
+++ b/exchange/exchange-ps/exchange/mail-flow/Set-SystemMessage.md
@@ -63,7 +63,7 @@ The identity value of a system message uses one of these formats:
 
 \<Language\>: For the list of supported language codes, see Supported languages for NDRs (https://technet.microsoft.com/library/aa996803.aspx#NDRLanguages).
 
-\<DSNcode\>: Valid values are 4.x.y or 5.x.y where x and y are one to three digit numbers. To see the enhanced system codes that are currently used by custom system messages, run the command Get-SystemMessage. To generate a list of default enhanced status codes that are used by Exchange, run this command: Get-SystemMessage -Original | Select-Object -Property Identity,DsnCode,Language,Text | ConvertTo-Html \> "C:\\My Documents\\Default DSNs.html".
+\<DSNcode\>: Valid values are 4.x.y or 5.x.y where x and y are one to three digit numbers. To see the enhanced system codes that are currently used by custom system messages, run the command Get-SystemMessage. To generate a list of default enhanced status codes that are used by Exchange, run this command: Get-SystemMessage -Original | Select-Object -Property Identity,DsnCode,Language,Text | ConvertTo-Html | Set-Content -Path "C:\\My Documents\\Default DSNs.html".
 
 \<QuotaMessageType\>: Valid value are:
 

--- a/exchange/exchange-ps/exchange/mailboxes/Get-CalendarDiagnosticAnalysis.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Get-CalendarDiagnosticAnalysis.md
@@ -81,7 +81,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### -------------------------- Example 1 --------------------------
 ```
-$logs = Get-CalendarDiagnosticLog -Identity oevans -MeetingID 040000008200E00074C5B7101A82E008000000009421DCCD5046CD0100000000000000001000000010B0349F6B17454685E17D9F9512E71F; Get-CalendarDiagnosticAnalysis -CalendarLogs $logs -DetailLevel Advanced> "C:\My Documents\Oscar Evans Analysis.csv"
+$logs = Get-CalendarDiagnosticLog -Identity oevans -MeetingID 040000008200E00074C5B7101A82E008000000009421DCCD5046CD0100000000000000001000000010B0349F6B17454685E17D9F9512E71F; Get-CalendarDiagnosticAnalysis -CalendarLogs $logs -DetailLevel Advanced | Set-Content -Path "C:\My Documents\Oscar Evans Analysis.csv"
 ```
 
 This example gets the specified calendar item from Oscar Evans' mailbox, stores the item as a variable and writes the advanced analysis of the item to a CSV file.
@@ -90,7 +90,7 @@ For basic analysis of the item, don't include the DetailLevel parameter, or use 
 
 ### -------------------------- Example 2 --------------------------
 ```
-Get-CalendarDiagnosticAnalysis -LogLocation "C:\My Documents\Exported Calendar Logs\jkozma@contoso.com" -DetailLevel Advanced -OutputAs HTML > "C:\My Documents\Jasen Kozma Analysis.html"
+Get-CalendarDiagnosticAnalysis -LogLocation "C:\My Documents\Exported Calendar Logs\jkozma@contoso.com" -DetailLevel Advanced -OutputAs HTML | Set-Content -Path "C:\My Documents\Jasen Kozma Analysis.html"
 ```
 
 This example analyzes the calendar items that were exported from Jasen Kozma's mailbox by using the Get-CalendarDiagnosticLog cmdlet with the LogLocation parameter and writes the advanced analysis of the items to an HTML file.

--- a/exchange/exchange-ps/exchange/mailboxes/Get-CalendarDiagnosticLog.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Get-CalendarDiagnosticLog.md
@@ -327,7 +327,7 @@ In the location you specify, a subfolder is automatically created for the specif
 
 In on-premises Exchange organizations, you can use the Get-CalendarDiagnosticAnalysis cmdlet with the LogLocation parameter to analyze the exported .msg files.
 
-Note: Commands that use this parameter might fail if the calendar item doesn't have a title. If you receive errors when you use this parameter, run the command again and replace this parameter with redirection to a file (\> "C:\\My Documents\\Calendar Export") or substitute the output to a PowerShell variable.
+Note: Commands that use this parameter might fail if the calendar item doesn't have a title. If you receive errors when you use this parameter, run the command again and replace this parameter with redirection to a file (| Set-Content -Path "C:\\My Documents\\Calendar Export") or substitute the output to a PowerShell variable.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Generally we should be making use of Set-Content (or Add-Content) to output data to files. Redirection operators are supported but are more a feature of the console than PowerShell itself, the examples and documentation should be recommending the PowerShell approach over any other method.