### PR TITLE
https://github.com/MicrosoftDocs/office-docs-powershell/issues/3236

### DIFF
--- a/teams/teams-ps/teams/New-Team.md
+++ b/teams/teams-ps/teams/New-Team.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 ```
 
 ### -Classification
-Team classification using the strings set for your organization via AAD's Group Classifications.
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String
@@ -415,7 +415,7 @@ Accept wildcard characters: False
 ```
 
 ### -GroupId
-Specify a GroupId to convert to a Team.  If specified, you cannot provide the other values that are already specified by the existing group, namely: Classification, Visibility, Alias, Description, or DisplayName.
+Specify a GroupId to convert to a Team.  If specified, you cannot provide the other values that are already specified by the existing group, namely: Visibility, Alias, Description, or DisplayName.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-Team.md
+++ b/teams/teams-ps/teams/Set-Team.md
@@ -11,7 +11,7 @@ ms.reviewer:
 # Set-Team
 
 ## SYNOPSIS
-This cmdlet allows you to update properties of a team, including its displayname, classification, and team-specific settings.
+This cmdlet allows you to update properties of a team, including its displayname, description, and team-specific settings.
 
 ## SYNTAX
 
@@ -28,7 +28,7 @@ Set-Team -GroupId <String> [-DisplayName <String>] [-Description <String>] [-Mai
 
 ## DESCRIPTION
 
-This cmdlet allows you to update properties of a team, including its displayname, classification, and team-specific settings.  This cmdlet includes all settings that used to be set using the Set-TeamFunSettings, Set-TeamGuestSettings, etc. cmdlets
+This cmdlet allows you to update properties of a team, including its displayname, description, and team-specific settings.  This cmdlet includes all settings that used to be set using the Set-TeamFunSettings, Set-TeamGuestSettings, etc. cmdlets
 
 ## EXAMPLES
 
@@ -104,7 +104,7 @@ Accept wildcard characters: False
 ```
 
 ### -Classification
-Team classification as determined by the AAD group classification list.
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String


### PR DESCRIPTION
https://github.com/MicrosoftDocs/office-docs-powershell/issues/3236

I think AAD Group Classification is not ready yet to be used. Some information:

https://docs.microsoft.com/powershell/module/exchange/users-and-groups/new-unifiedgroup
https://techcommunity.microsoft.com/t5/Yammer/Group-Classifications/td-p/353235