### PR TITLE
Update Example 2 to add .Identity to _$

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Get-TextMessagingAccount.md
+++ b/exchange/exchange-ps/exchange/client-access/Get-TextMessagingAccount.md
@@ -46,7 +46,7 @@ This example returns the text messaging settings for Tony's mailbox.
 ### -------------------------- Example 2 --------------------------
 ```
 $mbx = Get-Mailbox -RecipientTypeDetails UserMailbox -ResultSize Unlimited
-$mbx | foreach {Get-TextMessagingAccount -Identity $_ | where {($_.NotificationPhoneNumberVerified -eq $true)} | Format-Table Identity,NotificationPhoneNumber}
+$mbx | foreach {Get-TextMessagingAccount -Identity $_.Identity | where {($_.NotificationPhoneNumberVerified -eq $true)} | Format-Table Identity,NotificationPhoneNumber}
 ```
 
 This example finds all user mailboxes where text messaging notifications are enabled.


### PR DESCRIPTION
Whithout the .Idendity the powerwell fail with : 
Cannot process argument transformation on parameter 'Identity'. Cannot convert value "XXXXXX" to type
"Microsoft.Exchange.Configuration.Tasks.MailboxLocationIdParameter". Error: "Cannot convert hashtable to an object of
the following type: Microsoft.Exchange.Configuration.Tasks.MailboxLocationIdParameter. Hashtable-to-Object conversion
is not supported in restricted language mode or a Data section."
    + CategoryInfo          : InvalidData : (:) [Get-TextMessagingAccount], ParameterBindin...mationException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,Get-TextMessagingAccount
    + PSComputerName        : outlook.office365.com

Whit it it work ;-)

Good day