### PR TITLE
Fixes incorrect formatting for ConditionalAccessPolicy

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -32,7 +32,7 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [
  [-SharingBlockedDomainList <String>] [-SharingDomainRestrictionMode <SharingDomainRestrictionModes>]
  [-ShowPeoplePickerSuggestionsForGuestUsers <Boolean>] [-StorageQuotaReset] 
  [-DefaultSharingLinkType] [-DefaultLinkPermission] [<CommonParameters>]
- [-ConditionalAccessPolicy <SPOConditionalAccessPolicyType>]
+ [-ConditionalAccessPolicy <SPOConditionalAccessPolicyType>] [-LimitedAccessFileType <SPOLimitedAccessFileType>] [-AllowEditing <Boolean>]
 ```
 ### ParamSet2
 ```powershell
@@ -750,28 +750,64 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ConditionalAccessPolicy  
+### -ConditionalAccessPolicy
+
+Please read [Control access from unmanaged devices](https://docs.microsoft.com/sharepoint/control-access-from-unmanaged-devices ) documentation here to understand Conditional Access Policy usage in SharePoint Online.
+
 PARAMVALUE: AllowFullAccess | LimitedAccess | BlockAccess
-Please read documentation here to understand Conditional Access Policy usage in SharePoint Online "https://docs.microsoft.com/en-us/sharepoint/control-access-from-unmanaged-devices"
-```powershell
-Set-SPOSite -identity <url> -ConditionalAccessPolicy AllowLimitedAccess 
+
+```yaml
+Type: SPOConditionalAccessPolicyType
+Parameter Sets: ParamSet1
+Aliases: 
+Applicable: SharePoint Online
+
+Required: False
+Position: Named
+Default value: AllowFullAccess
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -AllowEditing  
-PARAMVALUE: $true | $false 
+
 Prevents users from editing Office files in the browser and copying and pasting Office file contents out of the browser window.
-```powershell
-Set-SPOSite -identity <url> -ConditionalAccessPolicy AllowLimitedAccess -AllowEditing $false
+
+PARAMVALUE: $true | $false 
+
+```yaml
+Type: Boolean
+Parameter Sets: ParamSet1
+Aliases: 
+Applicable: SharePoint Online
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -LimitedAccessFileType 
-PARAMVALUE: OfficeOnlineFilesOnly | WebPreviewableFiles | OtherFiles
+
 The following parameters can be used with -ConditionalAccessPolicy AllowLimitedAccess for both the organization-wide setting and the site-level setting. 
--OfficeOnlineFilesOnly Allows users to preview only Office files in the browser. This option increases security but may be a barrier to user productivity.
--LimitedAccessFileType WebPreviewableFiles (default) Allows users to preview Office files and other file types (such as PDF files and images) in the browser. Note that the contents of file types other than Office files are handled in the browser. This option optimizes for user productivity but offers less security for files that aren't Office files.
--LimitedAccessFileType OtherFiles Allows users to download files that can't be previewed, such as .zip and .exe. This option offers less security.
-```powershell
-Set-SPOSite -identity <url> -ConditionalAccessPolicy AllowLimitedAccess -LimitedAccessFileType <OfficeOnlineFilesOnly | WebPreviewableFiles | OtherFiles>
+-OfficeOnlineFilesOnly: Allows users to preview only Office files in the browser. This option increases security but may be a barrier to user productivity.
+-LimitedAccessFileType WebPreviewableFiles (default): Allows users to preview Office files and other file types (such as PDF files and images) in the browser. Note that the contents of file types other than Office files are handled in the browser. This option optimizes for user productivity but offers less security for files that aren't Office files.
+-LimitedAccessFileType OtherFiles: Allows users to download files that can't be previewed, such as .zip and .exe. This option offers less security.
+
+PARAMVALUE: OfficeOnlineFilesOnly | WebPreviewableFiles | OtherFiles
+
+```yaml
+Type: SPOLimitedAccessFileType
+Parameter Sets: ParamSet1
+Aliases: 
+Applicable: SharePoint Online
+
+Required: False
+Position: Named
+Default value: WebPreviewableFiles
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### CommonParameters


### PR DESCRIPTION
Fixes incorrect formatting for ConditionalAccessPolicy parameters that was accidentally merged and prevented to be rendered in the Live version of the article.
Issues related: https://github.com/MicrosoftDocs/office-docs-powershell/issues/3217

cc @kenwith 