### PR TITLE
Update New-OrganizationRelationship

### DIFF
--- a/exchange/exchange-ps/exchange/sharing-and-collaboration/New-OrganizationRelationship.md
+++ b/exchange/exchange-ps/exchange/sharing-and-collaboration/New-OrganizationRelationship.md
@@ -98,9 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -DomainNames
-This parameter is available only in on-premises Exchange.
-
-The DomainNames parameter specifies the SMTP domains of the external organization. You can specify multiple domains separated by commas (for example, "contoso.com","northamerica.contoso.com").
+The DomainNames parameter specifies the SMTP domains of the external organization. You can specify multiple domains separated by commas (for example, "contoso.com","northamerica.contoso.com"), limited to 238 domains in one request.
 
 ```yaml
 Type: MultiValuedProperty

--- a/exchange/exchange-ps/exchange/sharing-and-collaboration/New-OrganizationRelationship.md
+++ b/exchange/exchange-ps/exchange/sharing-and-collaboration/New-OrganizationRelationship.md
@@ -104,7 +104,7 @@ The DomainNames parameter specifies the SMTP domains of the external organizatio
 Type: MultiValuedProperty
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
+Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019, Exchange Online
 Required: True
 Position: Named
 Default value: None


### PR DESCRIPTION
Updated -DomainNames parameter:
- It is available in Exchange Online
- It is limited to 240 domains in PowerShell and 238 in the UI, so I put a mention in. Error response in PowerShell and UI say limit is 250, which seems incorrect.

Please see my blogpost on this: https://blog.yannickreekmans.be/the-curious-case-of-get-federationinformation-and-new-organizationrelationship/