### PR TITLE
Update Set-CASMailbox.md to include changes to PublicFolderClientAccess

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-CASMailbox.md
@@ -1121,8 +1121,6 @@ Accept wildcard characters: False
 ```
 
 ### -PublicFolderClientAccess
-This parameter is available only in the cloud-based service.
-
 The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook. Valid values are:
 
 - $true: The user can access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the value $true (the default value is $false).
@@ -1133,7 +1131,7 @@ The PublicFolderClientAccess parameter enables or disables access to public fold
 Type: $true | $false
 Parameter Sets: AdfsAuthenticationRawConfiguration, AdfsAuthenticationParameter
 Aliases:
-Applicable: Exchange Online
+Applicable: Exchange Server 2016, Exchange Server 2019, Exchange Online
 Required: False
 Position: Named
 Default value: $false


### PR DESCRIPTION
This is now supported in Exchange 2019 and 2016 as mentioned at https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Released-June-2019-Quarterly-Exchange-Updates/ba-p/698398 

"Controlled Connections to Public Folders in Outlook

As we announced towards the end of last year, we added support to Exchange Online to help admins have control over which users would see public folders in their Outlook clients.

We are including this functionality in Exchange Server 2019 Cumulative Update 2 and Exchange Server 2016 Cumulative Update 13, both released today."