### PR TITLE
Update Set-SPOSite.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -755,7 +755,7 @@ Accept wildcard characters: False
 
 Please read [Control access from unmanaged devices](https://docs.microsoft.com/sharepoint/control-access-from-unmanaged-devices ) documentation here to understand Conditional Access Policy usage in SharePoint Online.
 
-PARAMVALUE: AllowFullAccess | LimitedAccess | BlockAccess
+PARAMVALUE: AllowFullAccess | AllowLimitedAccess | BlockAccess
 
 ```yaml
 Type: SPOConditionalAccessPolicyType


### PR DESCRIPTION
Updated conditional params. My module (16.0.9021.1201) was throwing an error 

et-SPOSite : Cannot bind parameter 'ConditionalAccessPolicy'. Cannot convert value "LimitedAccess" to type "Microsoft.Online.SharePoint.TenantManagement.SPOConditionalAccessPolicyType".       
Error: "**Unable to match the identifier name LimitedAccess to a valid enumerator name. Specify one of the following enumerator names and try again:
AllowFullAccess, AllowLimitedAccess, BlockAccess"**
At line:1 char:57
+ Set-SPOSite -Identity $siteUrl -ConditionalAccessPolicy LimitedAccess
+                                                         ~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-SPOSite], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgumentNoMessage,Microsoft.Online.SharePoint.PowerShell.SetSite