### PR TITLE
AdditionalStorageProvidersAvailable in-by-default

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
@@ -226,7 +226,7 @@ Aliases:
 Applicable: Exchange Online
 Required: False
 Position: Named
-Default value: False
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
See roadmap Feature ID: 52597
We are adding more online storage providers to Outlook on the web and making it on by default. This update will bring two changes: 1. More providers, including personal OneDrive, Google Drive, and Facebook. 2. We are making this in-by-default
https://www.microsoft.com/en-gb/microsoft-365/roadmap?rtc=2&filters=&searchterms=52597