### PR TITLE
Changed Example 2

### DIFF
--- a/exchange/exchange-ps/exchange/federation-and-hybrid/Enable-RemoteMailbox.md
+++ b/exchange/exchange-ps/exchange/federation-and-hybrid/Enable-RemoteMailbox.md
@@ -80,7 +80,8 @@ After the user is mail-enabled, directory synchronization synchronizes the mail-
 
 ### -------------------------- Example 2 --------------------------
 ```
-Enable-RemoteMailbox "Kim Akers" -RemoteRoutingAddress "kima@contoso.mail.onmicrosoft.com" -Archive
+Enable-RemoteMailbox "Kim Akers" -RemoteRoutingAddress "kima@contoso.mail.onmicrosoft.com"
+Enable-RemoteMailbox "Kim Akers" -Archive
 ```
 
 This example does the following:


### PR DESCRIPTION
RemoteRoutingAddress and Archive parameters can not be used in the same sentence. https://github.com/MicrosoftDocs/office-docs-powershell/issues/3792

@chrisda please review