### PR TITLE
Update Set-IRMConfiguration.md

### DIFF
--- a/exchange/exchange-ps/exchange/encryption-and-certificates/Set-IRMConfiguration.md
+++ b/exchange/exchange-ps/exchange/encryption-and-certificates/Set-IRMConfiguration.md
@@ -119,7 +119,7 @@ The AzureRMSLicensingEnabled parameter specifies whether the Exchange Online org
 
 - $true: The Exchange Online organization can connect directly to Azure Rights Management. This enables Office 365 Message Encryption.
 
-- $false: The Exchange Online organization can't connect directly to Azure Rights Management. Do not configure this value unless you're directed to do so by Microsoft Customer Service and Support.
+- $false: The Exchange Online organization can't connect directly to Azure Rights Management.
 
 ```yaml
 Type: $true | $false


### PR DESCRIPTION
The line I removed is confusing to the customers, as another published document (https://docs.microsoft.com/en-us/office365/securitycompliance/manage-office-365-message-encryption#disable-the-new-capabilities-for-ome) explicitly tells them to do exactly this.