### PR TITLE
Update Import-CsUserData.md

### DIFF
--- a/skype/skype-ps/skype/Import-CsUserData.md
+++ b/skype/skype-ps/skype/Import-CsUserData.md
@@ -39,6 +39,8 @@ Import-CsUserData -FileName <String> -PoolFqdn <Fqdn> [-ConfDirectoryFilter <Str
 The Import-CsUserData cmdlet is used to import previously-saved user data and/or conference directory data to Skype for Business Server.
 Note that this data must have been exported by using the Export-CsUserData cmdlet.
 
+To make sure changes happen after this cmdlet, FE services need to be stopped in all FE servers in the pool firstly then be restarted at the same time after executing Import-CsUserdata cmdlet. 
+
 Skype for Business Server Control Panel: The functions carried out by the Import-CsUserData cmdlet are not available in the Skype for Business Server Control Panel.
 
 


### PR DESCRIPTION
Based on tests and feedbacks shared by our customers, if we restart FE servers one by one after this Import-CsUserData cmdlet, the changes may not happen in the environment. It is because the active FE servers which haven't been restarted yet with legacy data may overwrite the new data we imported in backend SQL and other FE severs restarted already with the new data.

Customer would like to have official document regarding this procedure, currently there is no document from Microsoft explaining this yet. Update this cmdlet article with this information accordingly. 
