### PR TITLE
[Set-Mailbox] adding ability to remove delay hold applied with groupmailbox 

### DIFF
--- a/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
@@ -101,6 +101,7 @@ Set-Mailbox [-Identity] <MailboxIdParameter>
  [-ForwardingSmtpAddress <ProxyAddress>]
  [-GMGen <$true | $false>]
  [-GrantSendOnBehalfTo <MultiValuedProperty>]
+ [-GroupMailbox <MailboxIdParameter>]
  [-HiddenFromAddressListsEnabled <$true | $false>]
  [-IgnoreDefaultScope]
  [-ImListMigrationCompleted <$true | $false>]
@@ -381,6 +382,7 @@ Set-Mailbox [-Identity] <MailboxIdParameter> [-RemoveDelayHoldApplied]
  [-ForwardingAddress <RecipientIdParameter>]
  [-ForwardingSmtpAddress <ProxyAddress>]
  [-GrantSendOnBehalfTo <MultiValuedProperty>]
+ [-GroupMailbox <MailboxIdParameter>]
  [-HiddenFromAddressListsEnabled <$true | $false>]
  [-ImListMigrationCompleted <$true | $false>]
  [-ImmutableId <String>]
@@ -2884,7 +2886,10 @@ Accept wildcard characters: False
 
 ### -GroupMailbox
 This parameter is available only in the cloud-based service.
-The GroupMailbox switch is required to modify Group Mailboxes in Exchange Online.  You can use any value that uniquely identifies the group mailbox. For example:
+
+The GroupMailbox switch is required to modify Group Mailboxes in Exchange Online. You don't need to specify a value with this switch.
+
+You can use any value that uniquely identifies the Group Mailbox. For example:
 
 - Name
 
@@ -2906,9 +2911,9 @@ The GroupMailbox switch is required to modify Group Mailboxes in Exchange Online
 
 - User ID or user principal name (UPN)
 
-```Telaws
+```yaml
 Type: MailboxIdParameter
-Parameter Sets: Identity
+Parameter Sets: Identity, RemoveDelayHoldApplied
 Aliases:
 Applicable: Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
 Required: False
@@ -4303,7 +4308,7 @@ The RemoveDelayHoldApplied switch specifies whether to remove delay holds from t
 
 The removal of a hold from a mailbox is temporarily delayed to prevent the accidental purge of content that's no longer affected by the hold. This temporary delay in the removal of the hold is known as a delay hold. To see the hold history on a mailbox, replace \<MailboxIdentity\> with the name, email address, or alias of the mailbox, and run this command: Export-MailboxDiagnosticLogs -Identity \<MailboxIdentity\> -ComponentName HoldTracking.
 
-The RemoveDelayHoldApplied switch can also be used with the GroupMailbox switch in order to remove delay holds from group mailboxes.
+You can use this switch with the GroupMailbox switch to remove delay holds from group mailboxes.
 
 ```yaml
 Type: SwitchParameter

--- a/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
@@ -2882,6 +2882,42 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -GroupMailbox
+This parameter is available only in the cloud-based service.
+The GroupMailbox switch is required to modify Group Mailboxes in Exchange Online.  You can use any value that uniquely identifies the group mailbox. For example:
+
+- Name
+
+- Alias
+
+- Distinguished name (DN)
+
+- Canonical DN
+
+- \<domain name\>\\\<account name\>
+
+- Email address
+
+- GUID
+
+- LegacyExchangeDN
+
+- SamAccountName
+
+- User ID or user principal name (UPN)
+
+```Telaws
+Type: MailboxIdParameter
+Parameter Sets: Identity
+Aliases:
+Applicable: Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -HiddenFromAddressListsEnabled
 The HiddenFromAddressListsEnabled parameter specifies whether this recipient is visible in address lists. Valid values are:
 
@@ -4266,6 +4302,8 @@ This parameter is available only in the cloud-based service.
 The RemoveDelayHoldApplied switch specifies whether to remove delay holds from the mailbox. You don't need to specify a value with this switch.
 
 The removal of a hold from a mailbox is temporarily delayed to prevent the accidental purge of content that's no longer affected by the hold. This temporary delay in the removal of the hold is known as a delay hold. To see the hold history on a mailbox, replace \<MailboxIdentity\> with the name, email address, or alias of the mailbox, and run this command: Export-MailboxDiagnosticLogs -Identity \<MailboxIdentity\> -ComponentName HoldTracking.
+
+The RemoveDelayHoldApplied switch can also be used with the GroupMailbox switch in order to remove delay holds from group mailboxes.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
I recently checked in code that allows the ability to remove a delay hold applied from a group mailbox using parameters -GroupMailbox and -RemoveDelayHoldApplied:

set-mailbox testgroupmailbox -GroupMailbox -RemoveDelayHoldApplied

Prior to my change this was not possible for a Group Mailbox.  Additionally, I don't see the documentation listing parameter -GroupMailbox. 

Please update the documentation to cover above scenario and parameters.