### PR TITLE
Update Set-DatabaseAvailabilityGroup.md

### DIFF
--- a/exchange/exchange-ps/exchange/database-availability-groups/Set-DatabaseAvailabilityGroup.md
+++ b/exchange/exchange-ps/exchange/database-availability-groups/Set-DatabaseAvailabilityGroup.md
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 ```
 
 ### -AutoDagBitlockerEnabled
-This parameter is reserved for internal Microsoft use.
+The AutoDagBitlockerEnabled is used to ensure that Disk Reclaimer handles spare disks correctly and encrypts them with BitLocker. If Bitlocker is used to encrypt database disks, set this to $true on all mailbox servers in the DAG (once all mailbox servers in the DAG have been upgraded to either Exchange 2013 CU13 (or later) or Exchange 2016 CU2 (or later))
 
 ```yaml
 Type: $true | $false

--- a/exchange/exchange-ps/exchange/database-availability-groups/Set-DatabaseAvailabilityGroup.md
+++ b/exchange/exchange-ps/exchange/database-availability-groups/Set-DatabaseAvailabilityGroup.md
@@ -256,7 +256,7 @@ Accept wildcard characters: False
 ```
 
 ### -AutoDagBitlockerEnabled
-The AutoDagBitlockerEnabled is used to ensure that Disk Reclaimer handles spare disks correctly and encrypts them with BitLocker. If Bitlocker is used to encrypt database disks, set this to $true on all mailbox servers in the DAG (once all mailbox servers in the DAG have been upgraded to either Exchange 2013 CU13 (or later) or Exchange 2016 CU2 (or later))
+The AutoDagBitlockerEnabled parameter ensures that Disk Reclaimer handles spare disks correctly and encrypts them with BitLocker. If Bitlocker is used to encrypt database disks, set the value of this parameter to $true on all Mailbox servers in the DAG after they are all running Exchange 2013 CU13 or later, or Exchange 2016 CU2 or later.
 
 ```yaml
 Type: $true | $false


### PR DESCRIPTION
In this Exchange Team Blog post the parameter AutoDagBitlockerEnabled is mentioned https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Enabling-BitLocker-on-Exchange-Servers/ba-p/603965 as recommended/required to ensure that spare disks will encrypted. So I think "is reserved for internal Microsoft use" is not correct anymore. Please check.