### PR TITLE
Wrong cmdlet in notes for exchange 2013+

### DIFF
--- a/exchange/exchange-ps/exchange/devices/Set-ActiveSyncMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/devices/Set-ActiveSyncMailboxPolicy.md
@@ -16,7 +16,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Set-ActiveSyncMailboxPolicy cmdlet to apply a variety of Mobile Device mailbox policy settings to a server. You can set any of the parameters by using one command.
 
-Note: In Exchange 2013 or later, use the Set-MobileMailboxPolicy cmdlet instead. If you have scripts that use Set-ActiveSyncMailboxPolicy, update them to use Set-MobileMailboxPolicy.
+Note: In Exchange 2013 or later, use the Set-MobileDeviceMailboxPolicy cmdlet instead. If you have scripts that use Set-ActiveSyncMailboxPolicy, update them to use Set-MobileDeviceMailboxPolicy.
 
 For information about the parameter sets in the Syntax section below, see Exchange cmdlet syntax (https://technet.microsoft.com/library/bb123552.aspx).
 


### PR DESCRIPTION
Updated as @hegedusgyorgy mentioned in #3995 that the wrong cmdlet was being used.

Set-MobileDeviceMailboxPolicy is the proper cmdlet for ex2013, ex2016, ex2019 and exo.