### PR TITLE
Update Set-Mailbox Params exclude linked subtype

### DIFF
--- a/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/mailboxes/Set-Mailbox.md
@@ -3560,7 +3560,7 @@ Accept wildcard characters: False
 ```
 
 ### -MessageCopyForSendOnBehalfEnabled
-**Note**: Previously, this parameter was available only for shared mailboxes. In Exchange Online or Exchange 2016 CU6 or later, this parameter is also available for user mailboxes.
+**Note**: Previously, this parameter was available only for shared mailboxes. In Exchange Online or Exchange 2016 CU6 or later, this parameter is also available for user mailboxes. This parameter is not available for linked user mailboxes.
 
 The MessageCopyForSendOnBehalfEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send on behalf of" permission. Valid values are:
 
@@ -3583,7 +3583,7 @@ Accept wildcard characters: False
 ```
 
 ### -MessageCopyForSentAsEnabled
-**Note**: Previously, this parameter was available only for shared mailboxes. In Exchange Online or Exchange 2016 CU6 or later, this parameter is also available for user mailboxes.
+**Note**: Previously, this parameter was available only for shared mailboxes. In Exchange Online or Exchange 2016 CU6 or later, this parameter is also available for user mailboxes. This parameter is not available for linked user mailboxes.
 
 The MessageCopyForSentAsEnabled parameter specifies whether to copy the sender for messages that are sent from a mailbox by users that have the "send as" permission. Valid values are:
 


### PR DESCRIPTION
Update Parameter Description for Params:
- MessageCopyForSendAsEnabled
- MessageCopyForSendOnBehalfAsEnabled
to explicitly limit availability of parameter to user mailbox which are not linked.