### PR TITLE
Fixed code block fencing on winrm commands

### DIFF
--- a/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
@@ -56,15 +56,15 @@ If you want to use multi-factor authentication (MFA) to connect to Exchange Onli
 
      ![Click Install in the Exchange Online PowerShell Module window](../../media/0fd389a1-a32d-4e2f-bf5f-78e9b6407d4c.png)
 
-- Windows Remote Management (WinRM) on your computer needs to allow basic authentication (it's enabled by default). To verify that basic authentication is enabled, run this command in a Command Prompt:
+- Windows Remote Management (WinRM) on your computer needs to allow basic authentication (it's enabled by default). To verify that basic authentication is enabled, run this command **in a Command Prompt**:
 
-  ```PowerShell
+  ```
   winrm get winrm/config/client/auth
   ```
 
   If you don't see the value `Basic = true`, you need to run this command to enable basic authentication for WinRM:
 
-  ```PowerShell
+  ```
   winrm set winrm/config/client/auth @{Basic="true"}
   ```
 

--- a/exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/mfa-connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/mfa-connect-to-scc-powershell.md
@@ -56,15 +56,15 @@ If your account uses multi-factor authentication (MFA) or federated authenticati
 
      ![Click Install in the Exchange Online PowerShell Module window](../../media/0fd389a1-a32d-4e2f-bf5f-78e9b6407d4c.png)
 
-- Windows Remote Management (WinRM) on your computer needs to allow basic authentication (it's enabled by default). To verify that basic authentication is enabled, run this command in a Command Prompt:
+- Windows Remote Management (WinRM) on your computer needs to allow basic authentication (it's enabled by default). To verify that basic authentication is enabled, run this command **in a Command Prompt**:
 
-  ```text
+  ```
   winrm get winrm/config/client/auth
   ```
 
   If you don't see the value `Basic = true`, you need to run this command from an elevated Command Prompt (a Command Prompt window you open by selecting **Run as administrator**) to enable basic authentication for WinRM:
 
-  ```text
+  ```
   winrm set winrm/config/client/auth @{Basic="true"}
   ```
 


### PR DESCRIPTION
Commands don't work as described in PowerShell (they work fine from a Command Prompt, but there's no code block fence for Command Prompt).