### PR TITLE
Update Get-PublicFolderStatistics.md

### DIFF
--- a/exchange/exchange-ps/exchange/sharing-and-collaboration/Get-PublicFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/sharing-and-collaboration/Get-PublicFolderStatistics.md
@@ -113,6 +113,8 @@ Accept wildcard characters: False
 ```
 
 ### -ResultSize
+This parameter is available only in on-premises Exchange.
+
 The ResultSize parameter specifies the maximum number of results to return. If you want to return all requests that match the query, use unlimited for the value of this parameter. The default value is 1000.
 
 ```yaml


### PR DESCRIPTION
-ResultSize parameter is available only in on-premises Exchange.