### PR TITLE
Update New-SPEnterpriseSearchMetadataCrawledProperty.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-server/New-SPEnterpriseSearchMetadataCrawledProperty.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/New-SPEnterpriseSearchMetadataCrawledProperty.md
@@ -244,7 +244,8 @@ For more information about valid values for this property, see VARIANT Type Cons
 
 The type must be an integer that specifies the variant data type of the property set.
 
-> [!NOTE] This parameter is required although the value is not used in SharePoint Server 2013 through SharePoint Server 2019. You will see an Obsolete warning when running the cmdlet. You may ignore this message.
+> [!NOTE] 
+> This parameter is required although the value is not used in SharePoint Server 2013 through SharePoint Server 2019. You will see an Obsolete warning when running the cmdlet. You may ignore this message.
 
 ```yaml
 Type: Int32

--- a/sharepoint/sharepoint-ps/sharepoint-server/New-SPEnterpriseSearchMetadataCrawledProperty.md
+++ b/sharepoint/sharepoint-ps/sharepoint-server/New-SPEnterpriseSearchMetadataCrawledProperty.md
@@ -244,6 +244,7 @@ For more information about valid values for this property, see VARIANT Type Cons
 
 The type must be an integer that specifies the variant data type of the property set.
 
+> [!NOTE] This parameter is required although the value is not used in SharePoint Server 2013 through SharePoint Server 2019. You will see an Obsolete warning when running the cmdlet. You may ignore this message.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
Fix for #4211. The parameter is required although marked as obsolete and the value supplied is not used for 2013-2019.