### PR TITLE
Example 7: wrong parameter, should be Path instead of filename

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Add-PnPFile.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Add-PnPFile.md
@@ -92,7 +92,7 @@ This will add a file sample.docx to the Documents folder and will set the Modifi
 
 ### ------------------EXAMPLE 7------------------
 ```powershell
-Add-PnPFile -FileName sample.docx -Folder "Documents" -NewFileName "differentname.docx"
+Add-PnPFile -Path sample.docx -Folder "Documents" -NewFileName "differentname.docx"
 ```
 
 This will upload a local file sample.docx to the Documents folder giving it the filename differentname.docx on SharePoint


### PR DESCRIPTION
Got an InvalidArgument : (:) [Add-PnPFile], ParameterBindingException with Filename.