### PR TITLE
Removing reference to missing parameters

### DIFF
--- a/exchange/exchange-ps/exchange/users-and-groups/Set-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/users-and-groups/Set-UnifiedGroup.md
@@ -155,10 +155,6 @@ To specify senders for this parameter, you can use any value that uniquely ident
 
 You can enter multiple senders separated by commas. To overwrite any existing entries, use the following syntax: \<sender1\>,\<sender2\>,...\<senderN\>. If the values contain spaces or otherwise require quotation marks, use the following syntax: "\<sender1\>","\<sender2\>",..."\<senderN\>".
 
-To add or remove individual senders or groups without affecting other existing entries, use the AcceptMessagesOnlyFrom and AcceptMessageOnlyFromDLMembers parameters.
-
-The individual senders and groups you specify for this parameter are automatically copied to the AcceptMessagesOnlyFrom and AcceptMessagesOnlyFromDLMembers properties, respectively. Therefore, you can't use the AcceptMessagesOnlyFromSendersOrMembers parameter and the AcceptMessagesOnlyFrom or AcceptMessagesOnlyFromDLMembers parameters in the same command.
-
 By default, this parameter is blank ($null), which allows this recipient to accept messages from all senders.
 
 ```yaml


### PR DESCRIPTION
The help for the AcceptMessagesOnlyFromSendersOrMembers parameter refers to the AcceptMessagesOnlyFrom and AcceptMessageOnlyFromDLMembers parameters.  But this cmdlet doesn't have those parameters.