### PR TITLE
adds note for beta on channel operations affected

### DIFF
--- a/teams/teams-ps/teams/Add-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Add-TeamChannelUser.md
@@ -7,6 +7,10 @@ schema: 2.0.0
 
 # Add-TeamChannelUser
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 Adds an owner or member to the private channel.
 

--- a/teams/teams-ps/teams/Add-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Add-TeamChannelUser.md
@@ -8,8 +8,7 @@ schema: 2.0.0
 # Add-TeamChannelUser
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 Adds an owner or member to the private channel.

--- a/teams/teams-ps/teams/Add-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Add-TeamChannelUser.md
@@ -7,9 +7,6 @@ schema: 2.0.0
 
 # Add-TeamChannelUser
 
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
-
 ## SYNOPSIS
 Adds an owner or member to the private channel.
 
@@ -25,6 +22,9 @@ Add-TeamChannelUser -GroupId <String> -DisplayName <String> -User <String> [-Rol
 ```
 
 ## DESCRIPTION
+
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-TeamChannel.md
+++ b/teams/teams-ps/teams/Get-TeamChannel.md
@@ -5,12 +5,10 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-TeamChannel
-
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+# Get-TeamChannel  
 
 ## SYNOPSIS
+
 Get all the channels for a team.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-TeamChannel.md
+++ b/teams/teams-ps/teams/Get-TeamChannel.md
@@ -7,6 +7,10 @@ schema: 2.0.0
 
 # Get-TeamChannel
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 Get all the channels for a team.
 

--- a/teams/teams-ps/teams/Get-TeamChannel.md
+++ b/teams/teams-ps/teams/Get-TeamChannel.md
@@ -8,8 +8,7 @@ schema: 2.0.0
 # Get-TeamChannel
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 Get all the channels for a team.

--- a/teams/teams-ps/teams/Get-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Get-TeamChannelUser.md
@@ -7,6 +7,10 @@ schema: 2.0.0
 
 # Get-TeamChannelUser
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 Returns users of a channel.
 

--- a/teams/teams-ps/teams/Get-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Get-TeamChannelUser.md
@@ -8,8 +8,7 @@ schema: 2.0.0
 # Get-TeamChannelUser
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 Returns users of a channel.

--- a/teams/teams-ps/teams/Get-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Get-TeamChannelUser.md
@@ -5,10 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-TeamChannelUser
-
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+# Get-TeamChannelUser 
 
 ## SYNOPSIS
 Returns users of a channel.
@@ -20,6 +17,9 @@ Get-TeamChannelUser -GroupId <String> -DisplayName <String> [-Role <String>] [<C
 ```
 
 ## DESCRIPTION
+
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/New-TeamChannel.md
+++ b/teams/teams-ps/teams/New-TeamChannel.md
@@ -10,9 +10,6 @@ ms.reviewer:
 
 # New-TeamChannel
 
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
-
 ## SYNOPSIS
 
 Add a new channel to a team.
@@ -24,6 +21,9 @@ New-TeamChannel -GroupId <String> -DisplayName <String> [-Description <String>] 
 ```
 
 ## DESCRIPTION
+
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/New-TeamChannel.md
+++ b/teams/teams-ps/teams/New-TeamChannel.md
@@ -10,6 +10,10 @@ ms.reviewer:
 
 # New-TeamChannel
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 
 Add a new channel to a team.

--- a/teams/teams-ps/teams/New-TeamChannel.md
+++ b/teams/teams-ps/teams/New-TeamChannel.md
@@ -11,8 +11,7 @@ ms.reviewer:
 # New-TeamChannel
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 

--- a/teams/teams-ps/teams/Remove-TeamChannel.md
+++ b/teams/teams-ps/teams/Remove-TeamChannel.md
@@ -10,9 +10,6 @@ ms.reviewer:
 
 # Remove-TeamChannel
 
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
-
 ## SYNOPSIS
 
 Delete a channel.
@@ -28,6 +25,9 @@ Remove-TeamChannel -GroupId <String> -DisplayName <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Remove-TeamChannel.md
+++ b/teams/teams-ps/teams/Remove-TeamChannel.md
@@ -10,6 +10,10 @@ ms.reviewer:
 
 # Remove-TeamChannel
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 
 Delete a channel.

--- a/teams/teams-ps/teams/Remove-TeamChannel.md
+++ b/teams/teams-ps/teams/Remove-TeamChannel.md
@@ -11,8 +11,7 @@ ms.reviewer:
 # Remove-TeamChannel
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -7,6 +7,10 @@ schema: 2.0.0
 
 # Remove-TeamChannelUser
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 Note: the command will return immediately, but the Teams application will not reflect the update immediately, please refresh the members page to see the update.
 

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -7,9 +7,6 @@ schema: 2.0.0
 
 # Remove-TeamChannelUser
 
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
-
 ## SYNOPSIS
 Note: the command will return immediately, but the Teams application will not reflect the update immediately, please refresh the members page to see the update.
 
@@ -25,6 +22,9 @@ Remove-TeamChannelUser -GroupId <String> -DisplayName <String> -User <String> [-
 ```
 
 ## DESCRIPTION
+
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -8,8 +8,7 @@ schema: 2.0.0
 # Remove-TeamChannelUser
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 Note: the command will return immediately, but the Teams application will not reflect the update immediately, please refresh the members page to see the update.

--- a/teams/teams-ps/teams/Set-TeamChannel.md
+++ b/teams/teams-ps/teams/Set-TeamChannel.md
@@ -10,6 +10,10 @@ ms.reviewer:
 
 # Set-TeamChannel
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
+Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+
 ## SYNOPSIS
 
 Update Team channels settings.

--- a/teams/teams-ps/teams/Set-TeamChannel.md
+++ b/teams/teams-ps/teams/Set-TeamChannel.md
@@ -10,9 +10,6 @@ ms.reviewer:
 
 # Set-TeamChannel
 
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
-
 ## SYNOPSIS
 
 Update Team channels settings.
@@ -25,6 +22,9 @@ Set-TeamChannel -GroupId <String> -CurrentDisplayName <String> [-NewDisplayName 
 ```
 
 ## DESCRIPTION
+
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Set-TeamChannel.md
+++ b/teams/teams-ps/teams/Set-TeamChannel.md
@@ -11,8 +11,7 @@ ms.reviewer:
 # Set-TeamChannel
 
 > [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. 
-Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.  
 
 ## SYNOPSIS
 


### PR DESCRIPTION
New functionality was added to support private channels, this is currently on /beta graph endpoint only.
We are adding a note for this if user is running the version on PS INT 