### PR TITLE
Add SSO section for Issue #3206

### DIFF
--- a/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
@@ -133,6 +133,10 @@ If you want to use multi-factor authentication (MFA) to connect to Exchange Onli
 Get-PSSession | Remove-PSSession
 ```
 
+## Single Sign-On (SSO)
+If your organization has single sign-on enabled and you are logged into a computer as a user in that domain, then **Connect-EXPOPSSession** may fail with the error similar to "*New-ExoPSSession : User 'loggedonuser@contoso.com' returned by service does not match user
+'userprincipalname@contoso.com' in the request.*".  This occurs because single sign-on overrides the specified userprincipalname. As a work-around, log into another non-domain-joined computer or log in as a local user on the computer and try again.
+
 ## How do you know this worked?
 
 After Step 4, the Exchange Online cmdlets are imported into your Exchange Online Remote PowerShell Module session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online cmdlet, for example, **Get-Mailbox**, and see the results.

--- a/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
@@ -133,9 +133,13 @@ If you want to use multi-factor authentication (MFA) to connect to Exchange Onli
 Get-PSSession | Remove-PSSession
 ```
 
-## Single Sign-On (SSO)
-If your organization has single sign-on enabled and you are logged into a computer as a user in that domain, then **Connect-EXPOPSSession** may fail with the error similar to "*New-ExoPSSession : User 'loggedonuser@contoso.com' returned by service does not match user
-'userprincipalname@contoso.com' in the request.*".  This occurs because single sign-on overrides the specified userprincipalname. As a work-around, log into another non-domain-joined computer or log in as a local user on the computer and try again.
+## Single sign-on
+
+If your organization has single sign-on (SSO) enabled and you are logged on to a computer as a user in the SSO domain, then **Connect-EXPOPSSession** may fail with the following error:
+
+> New-ExoPSSession : User 'loggedonuser@contoso.com' returned by service does not match user 'userprincipalname@contoso.com' in the request.
+
+This error occurs because single sign-on overrides the specified user principal name (UPN). As a work-around, connect from a non-domain-joined computer or log on to the domain-joined computer using a local user account.
 
 ## How do you know this worked?
 


### PR DESCRIPTION
When a user is signed into a computer and domain with Single Sign-On (SSO) enabled, then the **Connect-EXPOPSSession** and **Connect-IPPSSession** cmdlets will fail when the user attempts to log in as another user within the same domain. This is a common problem (and point of frustration). The added text provides a work-around for the issue.