### PR TITLE
Fix SipSignallingPort param name

### DIFF
--- a/skype/skype-ps/skype/New-CSOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/New-CSOnlinePSTNGateway.md
@@ -15,7 +15,7 @@ Creates a new Session Border Controller (SBC) Configuration that describes the s
 
 ### Identity (Default)
 ```
-New-CSOnlinePSTNGateway [-Tenant <System.Guid>] -SipSignallingPort <Int32> [-CodecPriority <String>]
+New-CSOnlinePSTNGateway [-Tenant <System.Guid>] -SipSignalingPort <Int32> [-CodecPriority <String>]
  [-ExcludedCodecs <String>] [-FailoverTimeSeconds <Int32>] [-ForwardCallHistory <Boolean>]
  [-ForwardPai <Boolean>] [-SendSipOptions <Boolean>] [-MaxConcurrentSessions <System.Int32>]
  [-Enabled <Boolean>] [-MediaBypass <Boolean>] [-GatewaySiteId <String>] [-Identity] <XdsGlobalRelativeIdentity> [-InMemory] [-Force]
@@ -24,7 +24,7 @@ New-CSOnlinePSTNGateway [-Tenant <System.Guid>] -SipSignallingPort <Int32> [-Cod
 
 ### ParentAndRelativeKey
 ```
-New-CSOnlinePSTNGateway [-Tenant <System.Guid>] -Fqdn <String> -SipSignallingPort <Int32>
+New-CSOnlinePSTNGateway [-Tenant <System.Guid>] -Fqdn <String> -SipSignalingPort <Int32>
  [-CodecPriority <String>] [-ExcludedCodecs <String>] [-FailoverTimeSeconds <Int32>]
  [-ForwardCallHistory <Boolean>] [-ForwardPai <Boolean>] [-SendSipOptions <Boolean>]
  [-MaxConcurrentSessions <System.Int32>] [-Enabled <Boolean>] [-MediaBypass <Boolean>] [-GatewaySiteId <String>] [-InMemory] [-Force]
@@ -38,14 +38,14 @@ Use this cmdlet to create a new Session Border Controller (SBC) configuration. E
 
 ### Example 1
 ```powershell
-PS C:\> New-CSOnlinePSTNGateway - FQDN sbc.contoso.com -SIPSignallingPort 5061
+PS C:\> New-CSOnlinePSTNGateway - FQDN sbc.contoso.com -SIPSignalingPort 5061
 ```
 
 This example creates an SBC with FQDN sbc.contoso.com and signaling port 5061. All others parameters will stay default. Note the SBC will be in the disabled state.
 
 ### Example 2
 ```powershell
-PS C:\> New-CSOnlinePSTNGateway - FQDN sbc.contoso.com -SIPSignallingPort 5061 -ForwardPAI $true -Enabled $true
+PS C:\> New-CSOnlinePSTNGateway - FQDN sbc.contoso.com -SIPSignalingPort 5061 -ForwardPAI $true -Enabled $true
 ```
 
 This example creates an SBC with FQDN sbc.contoso.com and signaling port 5061. For each outbound to SBC session, the Direct Routing interface will report in P-Asserted-Identity fields the TEL URI and SIP address of the user who made a call. This is useful when a tenant administrator set identity of the caller as "Anonymous" or a general number of the company, but for the billing purposes the real identity of the user should be reported.
@@ -275,7 +275,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SipSignallingPort
+### -SipSignalingPort
 Listening port used for communicating with Direct Routing services by using the Transport Layer Security (TLS) protocol. Must be value between 1 and 65535.
 
 ```yaml

--- a/skype/skype-ps/skype/Set-CSOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/Set-CSOnlinePSTNGateway.md
@@ -15,7 +15,7 @@ Modifies the previously defined Session Border Controller (SBC) Configuration th
 
 ### Identity (Default)
 ```
-Set-CSOnlinePSTNGateway [-Tenant <System.Guid>] [-SipSignallingPort <Int32>] [-CodecPriority <String>]
+Set-CSOnlinePSTNGateway [-Tenant <System.Guid>] [-SipSignalingPort <Int32>] [-CodecPriority <String>]
  [-ExcludedCodecs <String>] [-FailoverTimeSeconds <Int32>] [-ForwardCallHistory <Boolean>]
  [-ForwardPai <Boolean>] [-SendSipOptions <Boolean>] [-MaxConcurrentSessions <System.Int32>]
  [-Enabled <Boolean>] [-MediaBypass <Boolean>] [-GatewaySiteId <String>] [[-Identity] <XdsGlobalRelativeIdentity>] [-Force] [-WhatIf]
@@ -24,7 +24,7 @@ Set-CSOnlinePSTNGateway [-Tenant <System.Guid>] [-SipSignallingPort <Int32>] [-C
 
 ### Instance
 ```
-Set-CSOnlinePSTNGateway [-Tenant <System.Guid>] [-SipSignallingPort <Int32>] [-CodecPriority <String>]
+Set-CSOnlinePSTNGateway [-Tenant <System.Guid>] [-SipSignalingPort <Int32>] [-CodecPriority <String>]
  [-ExcludedCodecs <String>] [-FailoverTimeSeconds <Int32>] [-ForwardCallHistory <Boolean>]
  [-ForwardPai <Boolean>] [-SendSipOptions <Boolean>] [-MaxConcurrentSessions <System.Int32>]
  [-Enabled <Boolean>] [-MediaBypass <Boolean>] [-GatewaySiteId <String>] [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm]
@@ -45,10 +45,10 @@ This example enables previously created SBC with Identity (and FQDN) sbc.contoso
 
 ### Example 2
 ```powershell
-PS C:\> Set-CSOnlinePSTNGateway -Identity sbc.contoso.com -SIPSignallingPort 5064 -ForwardPAI $true -Enabled $true
+PS C:\> Set-CSOnlinePSTNGateway -Identity sbc.contoso.com -SIPSignalingPort 5064 -ForwardPAI $true -Enabled $true
 ```
 
-This example modifies the configuration of an SBC with identity (and FQDN)  sbc.contoso.com. It changes the SIPSignallingPort to 5064 and enabled P-Asserted-Identity field on outbound connections (outbound from Direct Routing to SBC). For each outbound to SBC session, the Direct Routing interface will report in P-Asserted-Identity fields the TEL URI and SIP address of the user who made a call. This is useful when a tenant administrator set identity of the caller as "Anonymous" or a general number of the company, but for the billing purposes the real identity of the user should be reported.
+This example modifies the configuration of an SBC with identity (and FQDN)  sbc.contoso.com. It changes the SIPSignalingPort to 5064 and enabled P-Asserted-Identity field on outbound connections (outbound from Direct Routing to SBC). For each outbound to SBC session, the Direct Routing interface will report in P-Asserted-Identity fields the TEL URI and SIP address of the user who made a call. This is useful when a tenant administrator set identity of the caller as "Anonymous" or a general number of the company, but for the billing purposes the real identity of the user should be reported.
 
 ## PARAMETERS
 
@@ -260,7 +260,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SipSignallingPort
+### -SipSignalingPort
 Listening port used for communicating with Direct Routing services by using the Transport Layer Security (TLS) protocol. The value must be between 1 and 65535.
 
 ```yaml


### PR DESCRIPTION
GB -> US English (removing one 'L' from the name)