### PR TITLE
Max number of days for Get-MessageTrace

### DIFF
--- a/exchange/exchange-ps/exchange/mail-flow/Get-MessageTrace.md
+++ b/exchange/exchange-ps/exchange/mail-flow/Get-MessageTrace.md
@@ -28,9 +28,9 @@ Get-MessageTrace [-EndDate <DateTime>] [-Expression <Expression>] [-FromIP <Stri
 ```
 
 ## DESCRIPTION
-You can use this cmdlet to search message data for the last 30 days. If you run this cmdlet without any parameters, only data from the last 48 hours is returned.
+You can use this cmdlet to search message data for the last 10 days. If you run this cmdlet without any parameters, only data from the last 48 hours is returned.
 
-If you enter a time period that's older than 30 days, you won't receive an error, but the command will return no results. To search for message data that's between 30 and 90 days old, use the Start-HistoricalSearch and Get-HistoricalSearch cmdlets.
+If you enter a time period that's older than 10 days, you won't receive an error, but the command will return no results. To search for message data that's between 10 and 90 days old, use the Start-HistoricalSearch and Get-HistoricalSearch cmdlets.
 
 This cmdlet returns a maximum of 1000000 results, and will timeout on very large queries. If your query returns too many results, consider splitting it up using smaller StartDate and EndDate intervals.
 


### PR DESCRIPTION
Description under article states the Get-MessageTrace can search upto past 30 days results.
This is not true. Only past 10 days results can be fetched using this command line.