### PR TITLE
Added example to create default labels for new term

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/New-PnPTerm.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/New-PnPTerm.md
@@ -34,6 +34,17 @@ New-PnPTerm -TermSet "Departments" -TermGroup "Corporate" -Name "Finance"
 
 Creates a new taxonomy term named "Finance" in the termset Departments which is located in the "Corporate" termgroup
 
+### ------------------EXAMPLE 2------------------
+```powershell
+$context = Get-PnPContext
+$term = New-PnPTerm -Name "Finance" -TermSet "Departments" -TermGroup "Corporate" -LCID 1033
+$createLabel = $term.CreateLabel("Finanzwesen", 1031, $true)
+$context.Load($term)
+Invoke-PnPQuery
+```
+
+This example creates a new English taxonomy term named "Finance" in the termset "Departments" which is located in the "Corporate" termgroup and adds a German default label for the newly created English term by means of the **[CreateLabel](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sharepoint.taxonomy.term.createlabel)** method.
+
 ## PARAMETERS
 
 ### -CustomProperties


### PR DESCRIPTION
This is an example on how to create multilingual default term labels for a different LCID whilst creating a new taxonomy terms.

Resources:
[answer on sharepoint.stackexchange](https://sharepoint.stackexchange.com/questions/268529/how-to-set-other-label-value-of-a-term-set/268550#268550) by [Gautam Sheth](https://sharepoint.stackexchange.com/users/8068/gautam-sheth)
[O365 - Create Labels on Managed Metadata Terms using CSOM in PowerShell from a CSV file](https://docs.microsoft.com/en-us/archive/blogs/fromthefield/o365-create-labels-on-managed-metadata-terms-using-csom-in-powershell-from-a-csv-file)
[CreateLabel](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sharepoint.taxonomy.term.createlabel) method of the Term class

