### PR TITLE
Added OfficeTemplateLibrary value to OrgAssetType parameter

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOOrgAssetsLibrary.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOOrgAssetsLibrary.md
@@ -77,14 +77,14 @@ Accept wildcard characters: False
 
 ### -OrgAssetType
 
-Indicates the type of content in this library. Currently supported value is ImageDocumentLibrary, which is set by default.
+Indicates the type of content in this library. Currently supported values are ImageDocumentLibrary, which is set by default, and OfficeTemplateLibrary.
 
 ```yaml
 Type: OrgAssetType
 Parameter Sets: (All)
 Aliases:
 Applicable: SharePoint Online
-Accepted values: ImageDocumentLibrary
+Accepted values: ImageDocumentLibrary, OfficeTemplateLibrary
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/Set-CsOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePSTNGateway.md
@@ -275,7 +275,7 @@ Accept wildcard characters: False
 ```
 
 ### -SipSignalingPort
-Listening port used for communicating with Direct Routing services by using the Transport Layer Security (TLS) protocol. The value must be between 1 and 65535. Please note: Spelling of this parameter changed recently from SipSignallingPort to SipSignalingPort.
+Listening port used for communicating with Direct Routing services by using the Transport Layer Security (TLS) protocol. The value must be between 1 and 65535.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
Added "OfficeTemplateLibrary" as accepted value to "OrgAssetType" parameter
Reference:
verified Ian Moran's blog post on "How to create an Organisation Assets library in SharePoint Online to store Office Templates":
https://regarding365.com/how-to-create-an-organisation-assets-library-in-sharepoint-online-to-store-office-templates-b19e1a435191