### PR TITLE
[Investigating] Update New-MailboxRepairRequest.md

### DIFF
--- a/exchange/exchange-ps/exchange/mailbox-databases-and-servers/New-MailboxRepairRequest.md
+++ b/exchange/exchange-ps/exchange/mailbox-databases-and-servers/New-MailboxRepairRequest.md
@@ -108,6 +108,32 @@ The CorruptionType parameter specifies the type of corruption that you want to d
 
 - FolderView
 
+- ReplState
+
+- MessagePtagCn
+
+- MessageId
+
+Starting with Exchange Server 2013 these values can also be used:
+
+- RuleMessageClass 
+
+- RestrictionFolder 
+
+- FolderACL 
+
+- UniqueMidIndex 
+
+- CorruptJunkRule 
+
+- MissingSpecialFolders 
+
+- DropAllLazyIndexes 
+
+- ImapId 
+
+- CleanupOrphanedIndexes 
+
 You can search for multiple corruption types at a time. Separate multiple types with a comma, for example, SearchFolder,AggregateCounts.
 
 ```yaml


### PR DESCRIPTION
Updating parameter -CorruptionType to include missing Exchange 2010 values.
- ReplState
- MessagePtagCn
- MessageId
As well as those added with Exchange 2013.
- RuleMessageClass 
- RestrictionFolder 
- FolderACL 
- UniqueMidIndex 
- CorruptJunkRule 
- MissingSpecialFolders 
- DropAllLazyIndexes 
- ImapId 
- CleanupOrphanedIndexes 