### PR TITLE
Add note for recently moved mailboxes scenario.

### DIFF
--- a/exchange/exchange-ps/exchange/mailbox-databases-and-servers/Update-StoreMailboxState.md
+++ b/exchange/exchange-ps/exchange/mailbox-databases-and-servers/Update-StoreMailboxState.md
@@ -146,5 +146,8 @@ To see the input types that this cmdlet accepts, see [Cmdlet Input and Output Ty
 To see the return types, which are also known as output types, that this cmdlet accepts, see [Cmdlet Input and Output Types](https://go.microsoft.com/fwlink/p/?linkId=616387). If the Output Type field is blank, the cmdlet doesn't return data.
 
 ## NOTES
+In a scenario where a mailbox is moved to another database, then the mailbox is immediately disabled, there is a 24-hour delay to allow for replication. 
+
+In this scenario Update-StoreMailboxState may not immediately update DisconnectState and DisconnectReason when running Get-MailboxStatistics. The mailbox statistics will update approximately 24 hours after the move.
 
 ## RELATED LINKS


### PR DESCRIPTION
If a mailbox is moved, then disabled, the disconnection is delayed for 24 hours to allow for replication. Running Update-MailboxStoreState before the 24-hour timer has expired will have no effect on DisconnectState and DisconnectReason.