### PR TITLE
Add missing note to get-teamChannel

### DIFF
--- a/teams/teams-ps/teams/Get-TeamChannel.md
+++ b/teams/teams-ps/teams/Get-TeamChannel.md
@@ -19,6 +19,9 @@ Get-TeamChannel -GroupId <String> [-MembershipType <String>] [<CommonParameters>
 
 ## DESCRIPTION
 
+> [!IMPORTANT]
+> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
+
 ## EXAMPLES
 
 ### Example 1


### PR DESCRIPTION
Get-TeamChannel was missing the note for PS INT gallery, I'm adding it to the docs as there is extra functionality for the Graph /beta endpoint in get-teamChannel