### PR TITLE
Correction in the hyperlink to New-TeamsApp.md

### DIFF
--- a/teams/teams-ps/teams/teams.md
+++ b/teams/teams-ps/teams/teams.md
@@ -58,8 +58,8 @@ The following cmdlet references are for Microsoft Teams.
 ### [New-TeamChannel](New-TeamChannel.md)
 {{Manually Enter New-TeamChannel Description Here}}
 
-### [New-TeamsApp](New-TeamChannel.md)
-{{Manually Enter New-TeamChannel Description Here}}
+### [New-TeamsApp](New-TeamsApp.md)
+{{Manually Enter New-TeamsApp Description Here}}
 
 ### [Remove-Team](Remove-Team.md)
 {{Manually Enter Remove-Team Description Here}}


### PR DESCRIPTION
I made a fix for the hyperlink to New-TeamsApp.md, this one was pointing to New-TeamChannel.md