### PR TITLE
Underscore should not be escaped

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-MailboxRegionalConfiguration.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-MailboxRegionalConfiguration.md
@@ -234,7 +234,7 @@ The TimeZone parameter specifies the time zone for the mailbox.
 
 A valid value for this parameter is a supported time zone key name (for example, "Pacific Standard Time").
 
-To see the available values, run the following command: `$TimeZone = Get-ChildItem "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Time zones" | foreach {Get-ItemProperty $\_.PSPath}; $TimeZone | sort Display | Format-Table -Auto PSChildname,Display`.
+To see the available values, run the following command: `$TimeZone = Get-ChildItem "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Time zones" | foreach {Get-ItemProperty $_.PSPath}; $TimeZone | sort Display | Format-Table -Auto PSChildname,Display`.
 
 If the value contains spaces, enclose the value in quotation marks ("). The default value is the time zone setting of the Exchange server.
 


### PR DESCRIPTION
When trying to run the following with the underscore escaped in `{Get-ItemProperty $\_.PSPath}`:
```
$TimeZone = Get-ChildItem "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Time zones" | foreach {Get-ItemProperty $\_.PSPath}; $TimeZone | sort Display | Format-Table -Auto PSChildname,Display
```

A user gets the following error:
```
Get-ItemProperty : Cannot find path 'C:\Users\thomas.pike.admin\$\_.PSPath' because it does not exist.
At line:1 char:102
+ ... entVersion\Time zones" | foreach {Get-ItemProperty $\_.PSPath}; $Time ...
+                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\thomas.pike.admin\$\_.PSPath:String) [Get-ItemProperty], ItemN
   otFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetItemPropertyCommand
```

The correct code is (without the escaped underscore):
```
$TimeZone = Get-ChildItem "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Time zones" | foreach {Get-ItemProperty $_.PSPath}; $TimeZone | sort Display | Format-Table -Auto PSChildname,Display
```