### PR TITLE
Updating Add-TeamUser.md based on bug fix

### DIFF
--- a/teams/teams-ps/teams/Add-TeamUser.md
+++ b/teams/teams-ps/teams/Add-TeamUser.md
@@ -24,8 +24,6 @@ This cmdlet adds an owner or member to the team, and to the unified group which 
 > [!Note]
 > The command will return immediately, but the Teams application will not reflect the update immediately. The Teams application may need to be open for up to several hours before changes are reflected.
 
-It doesn't work in the same way that the Teams application. If you add an owner in the application the user is also added as member to the unified group. Using this cmdlet, it will add the user only as an owner to the unified group, not as a member. Then you can run the cmdlet again to add the user as member.
-
 ## EXAMPLES
 
 ### Example 1
@@ -68,7 +66,7 @@ Accept wildcard characters: False
 ```
 
 ### -Role
-Member or Owner.
+Member or Owner. If Owner is specified then the user is also added as a member to the Team backed by unified group. 
 
 ```yaml
 Type: String


### PR DESCRIPTION
Teams Engineering is fixing the bug where the cmdlet doesn't need to be run twice to add owner also as a member. Now when a user is added as an owner then they will also be added as a member in alignment with the functionality on Teams Client