### PR TITLE
Update Invoke-SPOSiteSwap.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Invoke-SPOSiteSwap.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Invoke-SPOSiteSwap.md
@@ -24,6 +24,7 @@ Invoke-SPOSiteSwap
     -TargetUrl <string>
     -ArchiveUrl <string>
     [-DisableRedirection]
+    [-Force]
     [<CommonParameters>]
 ```
 
@@ -33,14 +34,11 @@ Swaps the location of a source site with a target site while archiving the origi
 
 When the swap is initiated, the target site is moved to the archive location and the source site is moved to the target location. By default, a site redirect is created at the source location that will redirect traffic to the target location.
 
-You must use the SharePoint Admin PowerShell version 16.0.19418.0 or later.
-
-Use of this cmdlet is subject to the rollout of this capability.
-
 If the target is the root site at <https://tenant-name.sharepoint.com,> then the following preparation activities should be performed prior to performing the swap:
 
 1. Any Featured links defined in SharePoint Start Page at <https://tenant-name.sharepoint.com/_layouts/15/sharepoint.aspx> will not be displayed after performing the swap. If required, the Featured links should be documented so they can be manually recreated after the swap.
 2. Functionality such as external sharing and application interfaces are dependent on the policies and permissions defined at the root site. Review the source site to ensure that it has the required policies and permissions as per the existing root site. This includes external sharing settings as well as site permissions.
+3. Larger tenants that have more than ~10,000 licenses may also need to run the [Page Diagnostic Tool](https://docs.microsoft.com/en-us/office365/enterprise/page-diagnostics-for-spo) against the source site. Any analysis results that have the category Attention required (Red) or Improvement opprtunities (Orange) will need to be remediated before performing the swap.
 
 The source and target sites can't be connected to an Office 365 group. They also can't be hub sites or associated with a hub.
 If a site is a hub site, unregister it as a hub site, swap the root site, and then register the site as a hub site. If a site is associated with a hub, disassociate the site, swap the root site, and then reassociate the site.
@@ -70,6 +68,14 @@ Invoke-SPOSiteSwap -SourceUrl https://contoso.sharepoint.com/sites/Communication
 ```
 
 Archives the existing site at <https://contoso.sharepoint.com> to <https://contoso.sharepoint.com/sites/Archive> and moves <https://contoso.sharepoint.com/sites/CommunicationSite> to <https://contoso.sharepoint.com.> A site redirect will not be created at <https://contoso.sharepoint.com/sites/CommunicationSite.>
+
+### EXAMPLE 4
+
+```powershell
+Invoke-SPOSiteSwap -SourceUrl https://contoso.sharepoint.com/sites/SearchSite -TargetUrl https://contoso.sharepoint.com/search -ArchiveUrl https://contoso.sharepoint.com/sites/Archive -Force
+```
+
+Archives the existing Search Center site at <https://contoso.sharepoint.com/search> to <https://contoso.sharepoint.com/sites/Archive> and moves the <https://contoso.sharepoint.com/sites/SearchSite> to <https://contoso.sharepoint.com/search.> A site redirect be created at <https://contoso.sharepoint.com/sites/SearchSite> that will redirect any requests to <https://contoso.sharepoint.com/search.> Any warnings identified by the Page Diagnostic Tool will be ignored and the swap will be initiated. However, any errors identified by the Page Diagnostic Tool will still prevent the swap from being initiated.
 
 ## PARAMETERS
 
@@ -150,6 +156,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Force
+
+Overrides and ignores any warnings that have been identified by the Page Diagnostic Tool that are preventing a swap from being initiated.
+Any errors identified by the Page Diagnostic Tool will still always prevent a swap from being initiated regardless of this parameter.
+
+```yaml
+Type: Switch Parameter
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
@@ -159,3 +183,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Getting started with SharePoint Online Management Shell](https://docs.microsoft.com/powershell/sharepoint/sharepoint-online/connect-sharepoint-online?view=sharepoint-ps)
 [Modernize your root site](https://docs.microsoft.com/en-us/sharepoint/modern-root-site)
 [Manage site redirects](https://docs.microsoft.com/en-us/sharepoint/manage-site-redirects)
+[Page Diagnostic Tool](https://docs.microsoft.com/en-us/office365/enterprise/page-diagnostics-for-spo)


### PR DESCRIPTION
Enabling Site Swap for Tenants > 10k licenses. In particular:

1. Added that the Page Diagnostic Tool may need to be executed against the Source site
2. New -Force parameter that can ignore Warnings identified by the Page Diagnostic Tool