### PR TITLE
Added PreferredMeetingProviderForIslandsMode parameter

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -24,8 +24,8 @@ New-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
  [-AllowOutlookAddIn <Boolean>] [-AllowPowerPointSharing <Boolean>]
  [-AllowParticipantGiveRequestControl <Boolean>] [-AllowExternalParticipantGiveRequestControl <Boolean>]
  [-AllowSharedNotes <Boolean>] [-AllowWhiteboard <Boolean>] [-AllowTranscription <Boolean>]
- [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-Identity] <XdsIdentity> [-InMemory] [-Force]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-PreferredMeetingProviderForIslandsMode <string>]
+ [-Identity] <XdsIdentity> [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -414,6 +414,21 @@ Aliases: wi
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredMeetingProviderForIslandsMode
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: TeamsAndSfb
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -28,7 +28,7 @@ Set-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
  [-AllowParticipantGiveRequestControl <Boolean>] [-AllowExternalParticipantGiveRequestControl <Boolean>]
  [-AllowSharedNotes <Boolean>] [-AllowWhiteboard <Boolean>] [-AllowTranscription <Boolean>]
  [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-AllowPSTNUsersToBypassLobby <Boolean>]
- [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm]
+ [-PreferredMeetingProviderForIslandsMode <string>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -43,7 +43,7 @@ Set-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
  [-AllowParticipantGiveRequestControl <Boolean>] [-AllowExternalParticipantGiveRequestControl <Boolean>]
  [-AllowSharedNotes <Boolean>] [-AllowWhiteboard <Boolean>] [-AllowTranscription <Boolean>]
  [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-AllowPSTNUsersToBypassLobby <Boolean>]
- [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm]
+ [-PreferredMeetingProviderForIslandsMode <string>] [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -486,6 +486,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredMeetingProviderForIslandsMode
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: TeamsAndSfb
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Added PreferredMeetingProviderForIslandsMode parameter to Set-CsTeamsMeetingPolicy and New-CsTeamsMeetingPolicy as "This parameter is reserved for internal Microsoft use" because I get next message when I try to use it:
"You are not permitted to invoke Set-CsTeamsMeetingPolicy with the following parameters: PreferredMeetingProviderForIslandsMode"

Issue https://github.com/MicrosoftDocs/office-docs-powershell/issues/5044