### PR TITLE
Update Set-OwaMailboxPolicy

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-OwaMailboxPolicy.md
@@ -763,7 +763,7 @@ The ExplicitLogonEnabled parameter specifies whether to allow a user to open som
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019, Exchange Online
+Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
 
 Required: False
 Position: Named


### PR DESCRIPTION
Removing Exchange Online from ExplicitLogonEnabled since this is not supported.