### PR TITLE
CELA updates for CsTeamsComplianceRecording cmdlets

### DIFF
--- a/skype/skype-ps/skype/Get-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Get-CsTeamsComplianceRecordingApplication.md
@@ -32,15 +32,15 @@ Get-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Filter <Stri
 
 ## DESCRIPTION
 Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
-Note that if neither the Identity nor the Filter parameters are specified, then Get-CsTeamsComplianceRecordingApplication returns all application instances of policy-based recording applications that are associated with a Teams compliance recording policy.
+Note that if neither the Identity nor the Filter parameters are specified, then Get-CsTeamsComplianceRecordingApplication returns all application instances of policy-based recording applications that are associated with a Teams recording policy.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
@@ -53,7 +53,7 @@ Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdle
 PS C:\> Get-CsTeamsComplianceRecordingApplication
 ```
 
-The command shown in Example 1 returns information for all the application instances of policy-based recording applications associated with Teams compliance recording policies.
+The command shown in Example 1 returns information for all the application instances of policy-based recording applications associated with Teams recording policies.
 
 ### Example 2
 ```powershell
@@ -67,7 +67,7 @@ In Example 2, information is returned for a single application instance of a pol
 PS C:\> Get-CsTeamsComplianceRecordingApplication -Filter 'Tag:*'
 ```
 
-The command shown in Example 3 returns all the application instances associated with Teams compliance recording policies at the per-user scope.
+The command shown in Example 3 returns all the application instances associated with Teams recording policies at the per-user scope.
 To do this, the command uses the Filter parameter and the filter value "Tag:\*"; that filter value limits the returned data to policies that have an Identity that begins with the string value "Tag:".
 
 ### Example 4
@@ -75,14 +75,14 @@ To do this, the command uses the Filter parameter and the filter value "Tag:\*";
 PS C:\> Get-CsTeamsComplianceRecordingApplication -Filter 'Tag:ContosoPartnerComplianceRecordingPolicy*'
 ```
 
-The command shown in Example 4 returns all the application instances associated with Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 returns all the application instances associated with Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 To do this, the command uses the Filter parameter and the filter value "Tag:ContosoPartnerComplianceRecordingPolicy\*"; that filter value limits the returned data to policies that have an Identity that begins with the string value "Tag:ContosoPartnerComplianceRecordingPolicy".
 
 ## PARAMETERS
 
 ### -Filter
 Enables you to use wildcards when retrieving one or more application instances of policy-based recording applications.
-For example, to return all the application instances associated with Teams compliance recording policies at the per-user scope, use this syntax:
+For example, to return all the application instances associated with Teams recording policies at the per-user scope, use this syntax:
 
 -Filter "Tag:\*"
 
@@ -103,9 +103,9 @@ Unique identifier of the application instance of a policy-based recording applic
 
 You cannot use wildcard characters when specifying the Identity.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: XdsIdentity
@@ -135,7 +135,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/Get-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsComplianceRecordingPolicy.md
@@ -16,8 +16,6 @@ ms.reviewer:
 Returns information about the policies configured for governing automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
-**Note:** The system will load the bot and join it to appropriate calls and meetings in order for the bot to enforce compliance with the administrative set policy.
-
 ## SYNTAX
 
 ### Identity (Default)
@@ -33,18 +31,19 @@ Get-CsTeamsComplianceRecordingPolicy [-Tenant <System.Guid>] [-Filter <String>]
 ```
 
 ## DESCRIPTION
-Teams compliance recording policies are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Teams recording policies are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Note that if neither the Identity nor the Filter parameters are specified, then Get-CsTeamsComplianceRecordingPolicy returns all the Teams compliance recording policies configured for use in the tenant.
+Note that if neither the Identity nor the Filter parameters are specified, then Get-CsTeamsComplianceRecordingPolicy returns all the Teams recording policies configured for use in the tenant.
 
-Note that simply assigning a Teams compliance recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
+Note that simply assigning a Teams recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
 Among other things, you will need to create an application instance of a policy-based recording application i.e. a bot in your tenant and will then need to assign an appropriate policy to the user.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
 
-Assigning your Microsoft Teams users a Teams compliance recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+Assigning your Microsoft Teams users a Teams recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+The system will load the recording application and join it to appropriate calls and meetings in order for it to enforce compliance with the administrative set policy.
 Existing calls and meetings are unaffected.
 
 ## EXAMPLES
@@ -54,27 +53,27 @@ Existing calls and meetings are unaffected.
 PS C:\> Get-CsTeamsComplianceRecordingPolicy
 ```
 
-The command shown in Example 1 returns information for all the Teams compliance recording policies configured for use in the tenant.
+The command shown in Example 1 returns information for all the Teams recording policies configured for use in the tenant.
 
 ### Example 2
 ```powershell
 PS C:\> Get-CsTeamsComplianceRecordingPolicy -Identity 'ContosoPartnerComplianceRecordingPolicy'
 ```
 
-In Example 2, information is returned for a single Teams compliance recording policy: the policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+In Example 2, information is returned for a single Teams recording policy: the policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 ### Example 3
 ```powershell
 PS C:\> Get-CsTeamsComplianceRecordingPolicy -Filter 'Tag:*'
 ```
 
-The command shown in Example 3 returns information about all the Teams compliance recording policies configured at the per-user scope.
+The command shown in Example 3 returns information about all the Teams recording policies configured at the per-user scope.
 To do this, the command uses the Filter parameter and the filter value "Tag:\*"; that filter value limits the returned data to policies that have an Identity that begins with the string value "Tag:".
 
 ## PARAMETERS
 
 ### -Filter
-Enables you to use wildcards when retrieving one or more Teams compliance recording policies.
+Enables you to use wildcards when retrieving one or more Teams recording policies.
 For example, to return all the policies configured at the per-user scope, use this syntax:
 
 -Filter "Tag:\*"
@@ -92,7 +91,7 @@ Accept wildcard characters: True
 ```
 
 ### -Identity
-Unique identifier of the Teams compliance recording policy to be retrieved.
+Unique identifier of the Teams recording policy to be retrieved.
 To return the global policy, use this syntax:
 
 -Identity "Global"
@@ -131,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/Get-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsComplianceRecordingPolicy.md
@@ -16,6 +16,8 @@ ms.reviewer:
 Returns information about the policies configured for governing automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
+**Note:** The system will load the bot and join it to appropriate calls and meetings in order for the bot to enforce compliance with the administrative set policy.
+
 ## SYNTAX
 
 ### Identity (Default)

--- a/skype/skype-ps/skype/Grant-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsComplianceRecordingPolicy.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # Grant-CsTeamsComplianceRecordingPolicy
 
 ## SYNOPSIS
-Assigns a per-user Teams compliance recording policy to one or more users.
+Assigns a per-user Teams recording policy to one or more users.
 This policy is used to govern automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
@@ -34,16 +34,17 @@ Grant-CsTeamsComplianceRecordingPolicy [-Global] [-PolicyName <String>]
 ```
 
 ## DESCRIPTION
-Teams compliance recording policies are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Teams recording policies are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Note that simply assigning a Teams compliance recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
+Note that simply assigning a Teams recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
 Among other things, you will need to create an application instance of a policy-based recording application i.e. a bot in your tenant and will then need to assign an appropriate policy to the user.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
 
-Assigning your Microsoft Teams users a Teams compliance recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+Assigning your Microsoft Teams users a Teams recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+The system will load the recording application and join it to appropriate calls and meetings in order for it to enforce compliance with the administrative set policy.
 Existing calls and meetings are unaffected.
 
 ## EXAMPLES
@@ -53,20 +54,20 @@ Existing calls and meetings are unaffected.
 PS C:\> Grant-CsTeamsComplianceRecordingPolicy -Identity 'Ken Myer' -PolicyName 'ContosoPartnerComplianceRecordingPolicy'
 ```
 
-The command shown in Example 1 assigns the per-user Teams compliance recording policy ContosoPartnerComplianceRecordingPolicy to the user with the display name "Ken Myer".
+The command shown in Example 1 assigns the per-user Teams recording policy ContosoPartnerComplianceRecordingPolicy to the user with the display name "Ken Myer".
 
 ### Example 2
 ```powershell
 PS C:\> Grant-CsTeamsComplianceRecordingPolicy -Identity 'Ken Myer' -PolicyName $null
 ```
 
-In Example 2, any per-user Teams compliance recording policy previously assigned to the user "Ken Myer" is revoked.
-As a result, the user will be managed by the global Teams compliance recording policy.
+In Example 2, any per-user Teams recording policy previously assigned to the user "Ken Myer" is revoked.
+As a result, the user will be managed by the global Teams recording policy.
 
 ## PARAMETERS
 
 ### -Identity
-Indicates the Identity of the user account to be assigned the per-user Teams compliance recording policy.
+Indicates the Identity of the user account to be assigned the per-user Teams recording policy.
 User Identities can be specified using one of the following formats:
 1) the user's SIP address;
 2) the user's user principal name (UPN);
@@ -120,7 +121,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
@@ -161,7 +162,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
-Enables you to pass a user object through the pipeline that represents the user account being assigned the Teams compliance recording policy.
+Enables you to pass a user object through the pipeline that represents the user account being assigned the Teams recording policy.
 By default, the Grant-CsTeamsComplianceRecordingPolicy cmdlet does not pass objects through the pipeline.
 
 ```yaml

--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # New-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Creates a new association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant.
+Creates a new association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
@@ -38,13 +38,13 @@ New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] -Parent <Strin
 
 ## DESCRIPTION
 Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
@@ -57,7 +57,7 @@ Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdle
 PS C:\> New-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899'
 ```
 
-The command shown in Example 1 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 ### Example 2
 ```powershell
@@ -65,14 +65,14 @@ PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerCom
 ```
 
 The command shown in Example 2 is a variation of Example 1.
-It also creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy, but it does this by using the Parent and Id parameters instead of the Identity parameter.
+It also creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy, but it does this by using the Parent and Id parameters instead of the Identity parameter.
 
 ### Example 3
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 3 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 3 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is deemed optional for meetings but mandatory for calls.
 Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
@@ -82,7 +82,7 @@ Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredD
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeCallEstablishment $false -RequiredDuringCall $false
 ```
 
-The command shown in Example 4 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is deemed optional for calls but mandatory for meetings.
 Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
@@ -92,7 +92,7 @@ Please refer to the documentation of the RequiredBeforeCallEstablishment and Req
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -ConcurrentInvitationCount 2
 ```
 
-The command shown in Example 5 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 5 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting.
 Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
@@ -102,7 +102,7 @@ Please refer to the documentation of the ConcurrentInvitationCount parameter for
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications @(New-CsTeamsComplianceRecordingPairedApplication -Id '39dc3ede-c80e-4f19-9153-417a65a1f144')
 ```
 
-The command shown in Example 6 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 6 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
 Separate invites are sent to the paired applications for the same call or meeting.
@@ -116,9 +116,9 @@ Please refer to the documentation of the ComplianceRecordingPairedApplications p
 ### -Identity
 A name that uniquely identifies the application instance of the policy-based recording application.
 
-Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: XdsIdentity
@@ -133,8 +133,8 @@ Accept wildcard characters: False
 ```
 
 ### -Parent
-The Identity of the Teams compliance recording policy that this application instance of a policy-based recording application is associated with.
-For example, the Parent of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy\", which indicates that the application instance is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+The Identity of the Teams recording policy that this application instance of a policy-based recording application is associated with.
+For example, the Parent of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy\", which indicates that the application instance is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: String
@@ -328,7 +328,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPairedApplication.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPairedApplication.md
@@ -25,9 +25,9 @@ New-CsTeamsComplianceRecordingPairedApplication -Id <String>
 
 ## DESCRIPTION
 Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
 In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
 If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.

--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPolicy.md
@@ -13,8 +13,10 @@ ms.reviewer:
 # New-CsTeamsComplianceRecordingPolicy
 
 ## SYNOPSIS
-Creates a new Teams compliance recording policy for governing automatic policy-based recording in your tenant.
+Creates a new Teams recording policy for governing automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
+
+**Note:** The system will load the bot and join it to appropriate calls and meetings in order for the bot to enforce compliance with the administrative set policy.
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPolicy.md
@@ -16,8 +16,6 @@ ms.reviewer:
 Creates a new Teams recording policy for governing automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
-**Note:** The system will load the bot and join it to appropriate calls and meetings in order for the bot to enforce compliance with the administrative set policy.
-
 ## SYNTAX
 
 ```
@@ -28,16 +26,17 @@ New-CsTeamsComplianceRecordingPolicy [-Tenant <System.Guid>] [-Identity <XdsIden
 ```
 
 ## DESCRIPTION
-Teams compliance recording policies are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Teams recording policies are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Note that simply assigning a Teams compliance recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
+Note that simply assigning a Teams recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
 Among other things, you will need to create an application instance of a policy-based recording application i.e. a bot in your tenant and will then need to assign an appropriate policy to the user.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
 
-Assigning your Microsoft Teams users a Teams compliance recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+Assigning your Microsoft Teams users a Teams recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+The system will load the recording application and join it to appropriate calls and meetings in order for it to enforce compliance with the administrative set policy.
 Existing calls and meetings are unaffected.
 
 ## EXAMPLES
@@ -47,7 +46,7 @@ Existing calls and meetings are unaffected.
 PS C:\> New-CsTeamsComplianceRecordingPolicy -Identity 'ContosoPartnerComplianceRecordingPolicy' -Enabled $true -ComplianceRecordingApplications @(New-CsTeamsComplianceRecordingApplication -Parent 'ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899')
 ```
 
-The command shown in Example 1 creates a new per-user Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 creates a new per-user Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 This policy is assigned a single application instance of a policy-based recording application: d93fefc7-93cc-4d44-9a5d-344b0fff2899, which is the ObjectId of the application instance as obtained from the Get-CsOnlineApplicationInstance cmdlet.
 
 Any Microsoft Teams users who are assigned this policy will have their calls and meetings recorded by that application instance. Existing calls and meetings are unaffected.
@@ -58,14 +57,14 @@ PS C:\> New-CsTeamsComplianceRecordingPolicy -Identity 'ContosoPartnerCompliance
 ```
 
 Example 2 is a variation of Example 1.
-In this case, the Teams compliance recording policy is assigned two application instances of policy-based recording applications.
+In this case, the Teams recording policy is assigned two application instances of policy-based recording applications.
 
 Any Microsoft Teams users who are assigned this policy will have their calls and meetings recorded by both those application instances. Existing calls and meetings are unaffected.
 
 ## PARAMETERS
 
 ### -Identity
-Unique identifier to be assigned to the new Teams compliance recording policy.
+Unique identifier to be assigned to the new Teams recording policy.
 
 Use the "Global" Identity if you wish to assign this policy to the entire tenant.
 
@@ -82,7 +81,7 @@ Accept wildcard characters: False
 ```
 
 ### -Enabled
-Controls whether this Teams compliance recording policy is active or not.
+Controls whether this Teams recording policy is active or not.
 
 Setting this to True and having the right set of ComplianceRecordingApplications will initiate automatic policy-based recording for all new calls and meetings of all Microsoft Teams users who are assigned this policy. Existing calls and meetings are unaffected.
 
@@ -116,7 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-Enables administrators to provide explanatory text to accompany a Teams compliance recording policy. For example, the Description might include information about the users the policy should be assigned to.
+Enables administrators to provide explanatory text to accompany a Teams recording policy. For example, the Description might include information about the users the policy should be assigned to.
 
 ```yaml
 Type: String
@@ -150,7 +149,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/Remove-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsComplianceRecordingApplication.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # Remove-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Deletes an existing association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant.
+Deletes an existing association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
@@ -25,13 +25,13 @@ Remove-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Identity 
 
 ## DESCRIPTION
 Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
@@ -44,7 +44,7 @@ Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdle
 PS C:\> Remove-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899'
 ```
 
-The command shown in Example 1 deletes an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 deletes an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 ### Example 2
 ```powershell
@@ -58,8 +58,8 @@ The command shown in Example 2 deletes all existing associations between applica
 ### -Identity
 A name that uniquely identifies the application instance of the policy-based recording application.
 
-Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
+Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
 For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/Remove-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsComplianceRecordingPolicy.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # Remove-CsTeamsComplianceRecordingPolicy
 
 ## SYNOPSIS
-Deletes an existing Teams compliance recording policy that is used to govern automatic policy-based recording in your tenant.
+Deletes an existing Teams recording policy that is used to govern automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
@@ -24,16 +24,17 @@ Remove-CsTeamsComplianceRecordingPolicy [-Tenant <System.Guid>] [-Identity <XdsI
 ```
 
 ## DESCRIPTION
-Teams compliance recording policies are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Teams recording policies are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Note that simply assigning a Teams compliance recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
+Note that simply assigning a Teams recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
 Among other things, you will need to create an application instance of a policy-based recording application i.e. a bot in your tenant and will then need to assign an appropriate policy to the user.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
 
-Assigning your Microsoft Teams users a Teams compliance recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+Assigning your Microsoft Teams users a Teams recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+The system will load the recording application and join it to appropriate calls and meetings in order for it to enforce compliance with the administrative set policy.
 Existing calls and meetings are unaffected.
 
 ## EXAMPLES
@@ -43,20 +44,20 @@ Existing calls and meetings are unaffected.
 PS C:\> Remove-CsTeamsComplianceRecordingPolicy -Identity 'ContosoPartnerComplianceRecordingPolicy'
 ```
 
-The command shown in Example 1 deletes the Teams compliance recording policy ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 deletes the Teams recording policy ContosoPartnerComplianceRecordingPolicy.
 
 ### Example 2
 ```powershell
 PS C:\> Get-CsTeamsComplianceRecordingPolicy -Filter 'Tag:*' | Remove-CsTeamsComplianceRecordingPolicy
 ```
 
-In Example 2, all the Teams compliance recording policies configured at the per-user scope are removed.
-The Filter value "Tag:*" limits the returned data to Teams compliance recording policies configured at the per-user scope. Those per-user policies are then removed.
+In Example 2, all the Teams recording policies configured at the per-user scope are removed.
+The Filter value "Tag:*" limits the returned data to Teams recording policies configured at the per-user scope. Those per-user policies are then removed.
 
 ## PARAMETERS
 
 ### -Identity
-Unique identifier to be assigned to the new Teams compliance recording policy.
+Unique identifier to be assigned to the new Teams recording policy.
 
 Use the "Global" Identity if you wish to assign this policy to the entire tenant.
 
@@ -73,7 +74,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # Set-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Modifies an existing association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant.
+Modifies an existing association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
@@ -38,13 +38,13 @@ Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Instance <PS
 
 ## DESCRIPTION
 Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
@@ -57,7 +57,7 @@ Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdle
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 1 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is made optional for meetings.
 Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
@@ -67,7 +67,7 @@ Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredD
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeCallEstablishment $false -RequiredDuringCall $false
 ```
 
-The command shown in Example 2 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 2 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is made optional for calls.
 Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
@@ -77,7 +77,7 @@ Please refer to the documentation of the RequiredBeforeCallEstablishment and Req
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ConcurrentInvitationCount 2
 ```
 
-The command shown in Example 3 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 3 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting.
 Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
@@ -87,7 +87,7 @@ Please refer to the documentation of the ConcurrentInvitationCount parameter for
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications @(New-CsTeamsComplianceRecordingPairedApplication -Id '39dc3ede-c80e-4f19-9153-417a65a1f144')
 ```
 
-The command shown in Example 4 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
 Separate invites are sent to the paired applications for the same call or meeting.
@@ -101,7 +101,7 @@ Please refer to the documentation of the ComplianceRecordingPairedApplications p
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications $null
 ```
 
-The command shown in Example 5 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 5 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 In this example, the application's resiliency is removed by removing the pairing it had with the application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
 Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
@@ -114,7 +114,7 @@ Please refer to the documentation of the ComplianceRecordingPairedApplications p
 PS C:\> Get-CsTeamsComplianceRecordingApplication | Set-CsTeamsComplianceRecordingApplication -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 6 modifies all existing associations between application instances of policy-based recording applications and their corresponding Teams compliance recording policy.
+The command shown in Example 6 modifies all existing associations between application instances of policy-based recording applications and their corresponding Teams recording policy.
 
 In this example, all applications are made optional for meetings.
 Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
@@ -124,9 +124,9 @@ Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredD
 ### -Identity
 A name that uniquely identifies the application instance of the policy-based recording application.
 
-Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams compliance recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: XdsIdentity
@@ -319,7 +319,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingPolicy.md
@@ -13,8 +13,10 @@ ms.reviewer:
 # Set-CsTeamsComplianceRecordingPolicy
 
 ## SYNOPSIS
-Modifies an existing Teams compliance recording policy for governing automatic policy-based recording in your tenant.
+Modifies an existing Teams recording policy for governing automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
+
+**Note:** The system will load the bot and join it to appropriate calls and meetings in order for the bot to enforce compliance with the administrative set policy.
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingPolicy.md
@@ -16,8 +16,6 @@ ms.reviewer:
 Modifies an existing Teams recording policy for governing automatic policy-based recording in your tenant.
 Automatic policy-based recording is only applicable to Microsoft Teams users.
 
-**Note:** The system will load the bot and join it to appropriate calls and meetings in order for the bot to enforce compliance with the administrative set policy.
-
 ## SYNTAX
 
 ### Identity (Default)
@@ -37,16 +35,17 @@ Set-CsTeamsComplianceRecordingPolicy [-Tenant <System.Guid>] [-Instance <PSObjec
 ```
 
 ## DESCRIPTION
-Teams compliance recording policies are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Teams recording policies are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Note that simply assigning a Teams compliance recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
+Note that simply assigning a Teams recording policy to a Microsoft Teams user will not activate automatic policy-based recording for all Microsoft Teams calls and meetings that the user participates in.
 Among other things, you will need to create an application instance of a policy-based recording application i.e. a bot in your tenant and will then need to assign an appropriate policy to the user.
 
 Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
 Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
 
-Assigning your Microsoft Teams users a Teams compliance recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+Assigning your Microsoft Teams users a Teams recording policy activates automatic policy-based recording for all new Microsoft Teams calls and meetings that the users participate in.
+The system will load the recording application and join it to appropriate calls and meetings in order for it to enforce compliance with the administrative set policy.
 Existing calls and meetings are unaffected.
 
 ## EXAMPLES
@@ -56,7 +55,7 @@ Existing calls and meetings are unaffected.
 PS C:\> Set-CsTeamsComplianceRecordingPolicy -Identity 'ContosoPartnerComplianceRecordingPolicy' -ComplianceRecordingApplications @(New-CsTeamsComplianceRecordingApplication -Parent 'ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899')
 ```
 
-The command shown in Example 1 modifies an existing per-user Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 modifies an existing per-user Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 This policy is re-assigned a single application instance of a policy-based recording application: d93fefc7-93cc-4d44-9a5d-344b0fff2899, which is the ObjectId of the application instance as obtained from the Get-CsOnlineApplicationInstance cmdlet.
 
 Any Microsoft Teams users who are assigned this policy will have their calls and meetings recorded by that application instance. Existing calls and meetings are unaffected.
@@ -67,7 +66,7 @@ PS C:\> Set-CsTeamsComplianceRecordingPolicy -Identity 'ContosoPartnerCompliance
 ```
 
 Example 2 is a variation of Example 1.
-In this case, the Teams compliance recording policy is re-assigned two application instances of policy-based recording applications.
+In this case, the Teams recording policy is re-assigned two application instances of policy-based recording applications.
 
 Any Microsoft Teams users who are assigned this policy will have their calls and meetings recorded by both those application instances. Existing calls and meetings are unaffected.
 
@@ -90,13 +89,13 @@ The command shown in Example 4 causes automatic policy-based recording to occur 
 PS C:\> Get-CsTeamsComplianceRecordingPolicy | Set-CsTeamsComplianceRecordingPolicy -Enabled $false
 ```
 
-The command shown in Example 5 stops automatic policy-based recording for all Teams compliance recording policies.
-This effectively stops automatic policy-based recording for all new calls and meetings of all Microsoft Teams users who are assigned any Teams compliance recording policy. Existing calls and meetings are unaffected.
+The command shown in Example 5 stops automatic policy-based recording for all Teams recording policies.
+This effectively stops automatic policy-based recording for all new calls and meetings of all Microsoft Teams users who are assigned any Teams recording policy. Existing calls and meetings are unaffected.
 
 ## PARAMETERS
 
 ### -Identity
-Unique identifier to be assigned to the new Teams compliance recording policy.
+Unique identifier to be assigned to the new Teams recording policy.
 
 Use the "Global" Identity if you wish to assign this policy to the entire tenant.
 
@@ -128,7 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -Enabled
-Controls whether this Teams compliance recording policy is active or not.
+Controls whether this Teams recording policy is active or not.
 
 Setting this to True and having the right set of ComplianceRecordingApplications will initiate automatic policy-based recording for all new calls and meetings of all Microsoft Teams users who are assigned this policy. Existing calls and meetings are unaffected.
 
@@ -162,7 +161,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-Enables administrators to provide explanatory text to accompany a Teams compliance recording policy. For example, the Description might include information about the users the policy should be assigned to.
+Enables administrators to provide explanatory text to accompany a Teams recording policy. For example, the Description might include information about the users the policy should be assigned to.
 
 ```yaml
 Type: String
@@ -196,7 +195,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried.
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
 For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"


### PR DESCRIPTION
Add a note from CELA that bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.

Remove the word "compliance" from any descriptions.