### PR TITLE
Update Set-CsConferencingPolicy.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsConferencingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsConferencingPolicy.md
@@ -966,7 +966,7 @@ Determines the protocol used for screen sharing - VbSS vs RDP.  This parameter i
 Type: String
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named


### PR DESCRIPTION
It's clearly outlined in the description:
"This parameter is used only in SfB Server"

But the "Applicable" field, shows SfB Online as well as SfB Server... which is incorrect and goes against the description. 

(Also confirmed that this is not available, on the SfB Online module)