### PR TITLE
Missing parameter in Get-PnPHubSiteChild doc

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPHubSiteChild.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPHubSiteChild.md
@@ -13,7 +13,9 @@ Retrieves all sites linked to a specific hub site
 ## SYNTAX 
 
 ```powershell
-Get-PnPHubSiteChild [-Connection <SPOnlineConnection>]
+Get-PnPHubSiteChild
+    [-Connection <SPOnlineConnection>]
+    [-Identity SpoHubSitePipeBind>[<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
Missing `-Identity` parameter in Get-PnPHubSiteChild doc