### PR TITLE
Remove "last accessed time" from Synopsis on Get-PublicFolderItemStatistics.md

### DIFF
--- a/exchange/exchange-ps/exchange/sharing-and-collaboration/Get-PublicFolderItemStatistics.md
+++ b/exchange/exchange-ps/exchange/sharing-and-collaboration/Get-PublicFolderItemStatistics.md
@@ -15,7 +15,7 @@ monikerRange: "exchserver-ps-2010 || exchserver-ps-2013 || exchserver-ps-2016 ||
 ## SYNOPSIS
 This cmdlet is available in on-premises Exchange and in the cloud-based service. Some parameters and settings may be exclusive to one environment or the other.
 
-Use the Get-PublicFolderItemStatistics cmdlet to view information about items within a specified public folder. Information returned includes subject, last modification time, last accessed time (on-premises Exchange only), creation time, attachments, message size, and the type of item. You can use this raw information to better understand the distribution of items and item characteristics across public folders.
+Use the Get-PublicFolderItemStatistics cmdlet to view information about items within a specified public folder. Information returned includes subject, last modification time, creation time, attachments, message size, and the type of item. You can use this raw information to better understand the distribution of items and item characteristics across public folders.
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-server/exchange-cmdlet-syntax).
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/office-docs-powershell/issues/5291