### PR TITLE
Clarification on needed role to run commandlet

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Apply-PnPTenantTemplate.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Apply-PnPTenantTemplate.md
@@ -9,7 +9,7 @@ title: Apply-PnPTenantTemplate
 # Apply-PnPTenantTemplate
 
 ## SYNOPSIS
-Applies a tenant template to the current tenant. You must be a SharePoint Online global administrator to run the cmdlet.
+Applies a tenant template to the current tenant. You must have the **Office 365 Global Admin** administrative role to run this cmdlet successfully.
 
 ## SYNTAX 
 


### PR DESCRIPTION
The named role is non-existent, and the SharePoint Administrator is not enough to run this successfully.