### PR TITLE
Changed sample script current shows error when running

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Initialize-PnPPowerShellAuthentication.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Initialize-PnPPowerShellAuthentication.md
@@ -43,7 +43,7 @@ Initialize-PnPPowerShellAuthentication -CertificatePath <String>
 
 ### ------------------EXAMPLE 1------------------
 ```powershell
-Initialize-PnPPowerShellAuthentication -ApplicationName TestApp -Tenant yourtenant.onmicrosoft.com -StoreLocation CurrentUser
+Initialize-PnPPowerShellAuthentication -ApplicationName TestApp -Tenant yourtenant.onmicrosoft.com -Store CurrentUser
 ```
 
 Creates a new Azure AD Application registration, creates a new self signed certificate, and adds it to the local certificate store. It will upload the certificate to the azure app registration and it will request the following permissions: Sites.FullControl.All, Group.ReadWrite.All, User.Read.All


### PR DESCRIPTION
When running the script of the sample an error appears saying the ´StoreLocation´ parameter could not be found.

´´´´ PowerShell
Initialize-PnPPowerShellAuthentication : A parameter cannot be found that matches parameter name 'StoreLocation'.
At line:1 char:127
+ ... ment -Tenant contentandcodedev.onmicrosoft.com -StoreLocation Current ...
+                                                    ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Initialize-PnPPowerShellAuthentication], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,SharePointPnP.PowerShell.Commands.Base.InitializePowerShellAuthen
   tication
´´´

Changing to ´Store´ did the trick.