### PR TITLE
Removing support for IsOptimizedforAccessibility

### DIFF
--- a/exchange/exchange-ps/exchange/client-access/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-CASMailbox.md
@@ -748,7 +748,7 @@ The IsOptimizedForAccessibility parameter specifies whether the mailbox is confi
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2016, Exchange Server 2019, Exchange Online
+Applicable: Exchange Server 2016, Exchange Server 2019
 
 Required: False
 Position: Named

--- a/exchange/exchange-ps/exchange/client-access/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/client-access/Set-CASMailbox.md
@@ -738,6 +738,8 @@ Accept wildcard characters: False
 ```
 
 ### -IsOptimizedForAccessibility
+This parameter is available only in on-premises Exchange.
+
 The IsOptimizedForAccessibility parameter specifies whether the mailbox is configured to use the light version of Outlook on the web. Valid values are:
 
 - $true: The mailbox is configured to use the light version of Outlook on the web.


### PR DESCRIPTION
This is no longer needed or supported in Exchange Online.  The main experience is fully accessible supported.