### PR TITLE
Update Set-CsTenantNetworkSite.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsTenantNetworkSite.md
+++ b/skype/skype-ps/skype/Set-CsTenantNetworkSite.md
@@ -49,10 +49,10 @@ The network region 'RegionRedmond' is created beforehand and 'MicrosoftSite1' wi
 
 ###-------------------------- Example 2 --------------------------
 ```powershell
-PS C:\> Set-CsTenantNetworkSite -Identity "site2" -Description "site 2" -NetworkRegionID "RedmondRegion" -LocationPolicy "TestLocationPolicy" -EnableLocationBasedRouting $true -SiteAddress "One Microsoft way" -OnlineVoiceRoutingPolicy "OVRP1"
+PS C:\> Set-CsTenantNetworkSite -Identity "site2" -Description "site 2" -NetworkRegionID "RedmondRegion" -LocationPolicy "TestLocationPolicy" -EnableLocationBasedRouting $true -SiteAddress "One Microsoft way" 
 ```
 
-The command shown in Example 2 set the network site 'site2' with description 'site 2'. This site is enabled for LBR, and associates with network region 'RedmondRegion', with location policy 'TestLocationPolicy', and with OnlineVoiceRoutingPolicy "OVRP1"
+The command shown in Example 2 set the network site 'site2' with description 'site 2'. This site is enabled for LBR, and associates with network region 'RedmondRegion', and with location policy 'TestLocationPolicy'
 
 ## PARAMETERS
 
@@ -164,23 +164,6 @@ Accept wildcard characters: False
 
 ### -NetworkRegionID
 NetworkRegionID is the identifier for the network region which the current network site is associating to.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -OnlineVoiceRoutingPolicy
-This parameter determines the unique name of existing OnlineVoiceRoutingPolicy that the current network site associates to.
-
-OnlineVoiceRoutingPolicy is used to associate a user with the appropriate PSTN usages.
 
 ```yaml
 Type: String


### PR DESCRIPTION
@tomkau @chrisda @roykuntz 

Removing OVRP from Set-CsTenantSite as this is being hidden from PowerShell as it's not currently in use. 
LCSMain Change: 1970462