### PR TITLE
Update the New/Set-CsTeamsComplianceRecordingApplication documentation - remove warnings

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
@@ -1,54 +1,48 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
-online version: https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingapplication
+Module Name: Microsoft.Rtc.Management.Hosted
+online version:
 applicable: Skype for Business Online
-title: New-CsTeamsComplianceRecordingApplication
+title : New-CsTeamsComplianceRecordingApplication
 schema: 2.0.0
 manager: nakumar
-author: aditdalvi
-ms.author: aditd
+author: ansrin
+ms.author: ansrin
 ms.reviewer:
 ---
 
 # New-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Creates a new association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
-Automatic policy-based recording is only applicable to Microsoft Teams users.
+Creates a new association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant. Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Identity <XdsIdentity>]
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
- [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
- [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
- [-Priority <Int32>] [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-ComplianceRecordingPairedApplications <>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredBeforeCallEstablishment <Boolean>]
+ [-RequiredDuringMeeting <Boolean>] [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>]
+ [-Priority <Int32>] [-Identity] <XdsIdentity> [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ParentAndRelativeKey
 ```
 New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] -Parent <String> -Id <String>
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
- [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
- [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
- [-Priority <Int32>] [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ComplianceRecordingPairedApplications <>] [-RequiredBeforeMeetingJoin <Boolean>]
+ [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringMeeting <Boolean>]
+ [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>] [-Priority <Int32>] [-InMemory] [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
+Policy-based recording applications are used in automatic policy-based recording scenarios. When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. Once the association is done, the Identity of these application instances becomes <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
-Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
-Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
-Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
+Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application. Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application. Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
 
 ## EXAMPLES
 
@@ -57,91 +51,131 @@ Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdle
 PS C:\> New-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899'
 ```
 
-The command shown in Example 1 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 ### Example 2
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899'
 ```
 
-The command shown in Example 2 is a variation of Example 1.
-It also creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy, but it does this by using the Parent and Id parameters instead of the Identity parameter.
+The command shown in Example 2 is a variation of Example 1. It also creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy, but it does this by using the Parent and Id parameters instead of the Identity parameter.
 
 ### Example 3
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 3 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 3 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is deemed optional for meetings but mandatory for calls.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
+In this example, the application is deemed optional for meetings but mandatory for calls. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
 
 ### Example 4
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeCallEstablishment $false -RequiredDuringCall $false
 ```
 
-The command shown in Example 4 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is deemed optional for calls but mandatory for meetings.
-Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
+In this example, the application is deemed optional for calls but mandatory for meetings. Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
 
 ### Example 5
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -ConcurrentInvitationCount 2
 ```
 
-The command shown in Example 5 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 5 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting.
-Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
+In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting. Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
 
 ### Example 6
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications @(New-CsTeamsComplianceRecordingPairedApplication -Id '39dc3ede-c80e-4f19-9153-417a65a1f144')
 ```
 
-The command shown in Example 6 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 6 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
-Separate invites are sent to the paired applications for the same call or meeting.
-Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
-
-**Integration of this example into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
+In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144. Separate invites are sent to the paired applications for the same call or meeting. Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
 
 ## PARAMETERS
 
-### -Identity
-A name that uniquely identifies the application instance of the policy-based recording application.
+### -ComplianceRecordingPairedApplications
+Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
 
-Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
 
 ```yaml
-Type: XdsIdentity
-Parameter Sets: Identity
+Type: ComplianceRecordingPairedApplication[]
+Parameter Sets: (All)
 Aliases:
-
-Required: True
-Position: 1
+Applicable: Skype for Business Online
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Parent
-The Identity of the Teams recording policy that this application instance of a policy-based recording application is associated with.
-For example, the Parent of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy\", which indicates that the application instance is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+### -ConcurrentInvitationCount
+Determines the number of invites to send out to the application instance of the policy-based recording application.
+
+In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
 
 ```yaml
-Type: String
-Parameter Sets: ParentAndRelativeKey
+Type: UInt32
+Parameter Sets: (All)
 Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
-Required: True
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -149,14 +183,13 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-The ObjectId of the application instance of a policy-based recording application as exposed by the Get-CsOnlineApplicationInstance cmdlet.
-For example, the Id of an application instance can be \"39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance has ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
+The ObjectId of the application instance of a policy-based recording application as exposed by the Get-CsOnlineApplicationInstance cmdlet. For example, the Id of an application instance can be "39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance has ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f14
 
 ```yaml
 Type: String
 Parameter Sets: ParentAndRelativeKey
 Aliases:
-
+Applicable: Skype for Business Online
 Required: True
 Position: Named
 Default value: None
@@ -164,42 +197,66 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RequiredBeforeMeetingJoin
-Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
+### -Identity
+A name that uniquely identifies the application instance of the policy-based recording application.
 
-If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting.
-The meeting will still continue for users who are in the meeting.
-
-If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
+Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. To do this association correctly, the Identity of these application instances must be <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
-Type: Boolean
-Parameter Sets: (All)
+Type: XdsIdentity
+Parameter Sets: Identity
 Aliases:
-
-Required: False
-Position: Named
-Default value: True
+Applicable: Skype for Business Online
+Required: True
+Position: 1
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RequiredDuringMeeting
-Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
-
-If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
-The meeting will still continue for users who are in the meeting.
-
-If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+### -InMemory
+Creates an object reference without actually committing the object as a permanent change. If you assign the output of this cmdlet called with this parameter to a variable, you can make changes to the properties of the object reference and then commit those changes by calling this cmdlet's matching Set- cmdlet.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
-Default value: True
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parent
+The Identity of the Teams compliance recording policy that this application instance of a policy-based recording application is associated with. For example, the Parent of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy", which indicates that the application instance is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+
+```yaml
+Type: String
+Parameter Sets: ParentAndRelativeKey
+Aliases:
+Applicable: Skype for Business Online
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Priority
+This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
+
+All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies. So this parameter does not affect the order of invitations to the applications, or any other routing.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -215,7 +272,26 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
+### -RequiredBeforeMeetingJoin
+Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
+
+If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting. The meeting will still continue for users who are in the meeting.
+
+If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: True
@@ -234,7 +310,7 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: True
@@ -242,94 +318,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ConcurrentInvitationCount
-Determines the number of invites to send out to the application instance of the policy-based recording application.
+### -RequiredDuringMeeting
+Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
 
-In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting.
-If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting. The meeting will still continue for users who are in the meeting.
 
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
-However, you cannot do both.
-Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
+If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
 
 ```yaml
-Type: UInt32
+Type: Boolean
 Parameter Sets: (All)
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
-Default value: 1
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ComplianceRecordingPairedApplications
-Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
-
-In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
-If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
-
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
-However, you cannot do both.
-Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-**Integration of this parameter into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
-
-```yaml
-Type: ComplianceRecordingPairedApplication[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Priority
-This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
-
-All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies.
-So this parameter does not affect the order of invitations to the applications, or any other routing.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
-For example:
+Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried. For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
 
@@ -337,61 +346,13 @@ You can return your tenant ID by running this command:
 
 Get-CsTenant | Select-Object DisplayName, TenantID
 
-If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter.
-Instead, the tenant ID will automatically be filled in for you based on your connection information.
-The Tenant parameter is primarily for use in a hybrid deployment.
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
 Parameter Sets: (All)
 Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses the display of any non-fatal error message that might arise when running the command.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InMemory
-Creates an object reference without actually committing the object as a permanent change.
-If you assign the output of this cmdlet called with this parameter to a variable, you can make changes to the properties of the object reference and then commit those changes by calling this cmdlet's matching Set- cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: None
@@ -407,7 +368,7 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: None
@@ -425,23 +386,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
+## NOTES
 
 ## RELATED LINKS
-
-[Get-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[New-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Set-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Grant-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/grant-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Remove-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Get-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingapplication?view=skype-ps)
-
-[Set-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingapplication?view=skype-ps)
-
-[Remove-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingapplication?view=skype-ps)
-
-[New-CsTeamsComplianceRecordingPairedApplication](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpairedapplication?view=skype-ps)

--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
@@ -1,48 +1,54 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
-Module Name: Microsoft.Rtc.Management.Hosted
-online version:
+online version: https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingapplication
 applicable: Skype for Business Online
-title : New-CsTeamsComplianceRecordingApplication
+title: New-CsTeamsComplianceRecordingApplication
 schema: 2.0.0
 manager: nakumar
-author: ansrin
-ms.author: ansrin
+author: aditdalvi
+ms.author: aditd
 ms.reviewer:
 ---
 
 # New-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Creates a new association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant. Automatic policy-based recording is only applicable to Microsoft Teams users.
+Creates a new association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
+Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-ComplianceRecordingPairedApplications <>]
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredBeforeCallEstablishment <Boolean>]
- [-RequiredDuringMeeting <Boolean>] [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>]
- [-Priority <Int32>] [-Identity] <XdsIdentity> [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Identity <XdsIdentity>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
+ [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
+ [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
+ [-Priority <Int32>] [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ParentAndRelativeKey
 ```
 New-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] -Parent <String> -Id <String>
- [-ComplianceRecordingPairedApplications <>] [-RequiredBeforeMeetingJoin <Boolean>]
- [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringMeeting <Boolean>]
- [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>] [-Priority <Int32>] [-InMemory] [-Force]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
+ [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
+ [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
+ [-Priority <Int32>] [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Policy-based recording applications are used in automatic policy-based recording scenarios. When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Policy-based recording applications are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. Once the association is done, the Identity of these application instances becomes <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
-Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application. Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application. Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
+Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
+Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
+Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
 
 ## EXAMPLES
 
@@ -51,162 +57,74 @@ Please work with your Microsoft certified policy-based recording application pro
 PS C:\> New-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899'
 ```
 
-The command shown in Example 1 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
 ### Example 2
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899'
 ```
 
-The command shown in Example 2 is a variation of Example 1. It also creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy, but it does this by using the Parent and Id parameters instead of the Identity parameter.
+The command shown in Example 2 is a variation of Example 1.
+It also creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy, but it does this by using the Parent and Id parameters instead of the Identity parameter.
 
 ### Example 3
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 3 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 3 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is deemed optional for meetings but mandatory for calls. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
+In this example, the application is deemed optional for meetings but mandatory for calls.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
 
 ### Example 4
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeCallEstablishment $false -RequiredDuringCall $false
 ```
 
-The command shown in Example 4 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is deemed optional for calls but mandatory for meetings. Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
+In this example, the application is deemed optional for calls but mandatory for meetings.
+Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
 
 ### Example 5
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -ConcurrentInvitationCount 2
 ```
 
-The command shown in Example 5 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 5 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting. Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
+In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting.
+Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
 
 ### Example 6
 ```powershell
 PS C:\> New-CsTeamsComplianceRecordingApplication -Parent 'Tag:ContosoPartnerComplianceRecordingPolicy' -Id 'd93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications @(New-CsTeamsComplianceRecordingPairedApplication -Id '39dc3ede-c80e-4f19-9153-417a65a1f144')
 ```
 
-The command shown in Example 6 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 6 creates a new association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144. Separate invites are sent to the paired applications for the same call or meeting. Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
+In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
+Separate invites are sent to the paired applications for the same call or meeting.
+Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
+
+**Integration of this example into the policy-based recording workflows is still a work in progress.**
+**This warning will be removed once the integration is complete.**
 
 ## PARAMETERS
-
-### -ComplianceRecordingPairedApplications
-Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
-
-In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
-
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-```yaml
-Type: ComplianceRecordingPairedApplication[]
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ConcurrentInvitationCount
-Determines the number of invites to send out to the application instance of the policy-based recording application.
-
-In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
-
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-```yaml
-Type: UInt32
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: 1
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses the display of any non-fatal error message that might arise when running the command.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-The ObjectId of the application instance of a policy-based recording application as exposed by the Get-CsOnlineApplicationInstance cmdlet. For example, the Id of an application instance can be "39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance has ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f14
-
-```yaml
-Type: String
-Parameter Sets: ParentAndRelativeKey
-Aliases:
-Applicable: Skype for Business Online
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Identity
 A name that uniquely identifies the application instance of the policy-based recording application.
 
-Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. To do this association correctly, the Identity of these application instances must be <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: XdsIdentity
 Parameter Sets: Identity
 Aliases:
-Applicable: Skype for Business Online
+
 Required: True
 Position: 1
 Default value: None
@@ -214,29 +132,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InMemory
-Creates an object reference without actually committing the object as a permanent change. If you assign the output of this cmdlet called with this parameter to a variable, you can make changes to the properties of the object reference and then commit those changes by calling this cmdlet's matching Set- cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Parent
-The Identity of the Teams compliance recording policy that this application instance of a policy-based recording application is associated with. For example, the Parent of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy", which indicates that the application instance is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+The Identity of the Teams recording policy that this application instance of a policy-based recording application is associated with.
+For example, the Parent of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy\", which indicates that the application instance is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: String
 Parameter Sets: ParentAndRelativeKey
 Aliases:
-Applicable: Skype for Business Online
+
 Required: True
 Position: Named
 Default value: None
@@ -244,19 +148,58 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Priority
-This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
-
-All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies. So this parameter does not affect the order of invitations to the applications, or any other routing.
+### -Id
+The ObjectId of the application instance of a policy-based recording application as exposed by the Get-CsOnlineApplicationInstance cmdlet.
+For example, the Id of an application instance can be \"39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance has ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
 
 ```yaml
-Type: Int32
-Parameter Sets: (All)
+Type: String
+Parameter Sets: ParentAndRelativeKey
 Aliases:
-Applicable: Skype for Business Online
-Required: False
+
+Required: True
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequiredBeforeMeetingJoin
+Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
+
+If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting.
+The meeting will still continue for users who are in the meeting.
+
+If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequiredDuringMeeting
+Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
+
+If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+The meeting will still continue for users who are in the meeting.
+
+If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -272,26 +215,7 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: True
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
-### -RequiredBeforeMeetingJoin
-Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
-
-If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting. The meeting will still continue for users who are in the meeting.
-
-If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: True
@@ -310,7 +234,7 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
 Default value: True
@@ -318,27 +242,94 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RequiredDuringMeeting
-Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
+### -ConcurrentInvitationCount
+Determines the number of invites to send out to the application instance of the policy-based recording application.
 
-If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting. The meeting will still continue for users who are in the meeting.
+In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting.
+If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
 
-If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
+However, you cannot do both.
+Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
 
 ```yaml
-Type: Boolean
+Type: UInt32
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
-Default value: True
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComplianceRecordingPairedApplications
+Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
+
+In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
+If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
+However, you cannot do both.
+Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
+
+**Integration of this parameter into the policy-based recording workflows is still a work in progress.**
+**This warning will be removed once the integration is complete.**
+
+```yaml
+Type: ComplianceRecordingPairedApplication[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Priority
+This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
+
+All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies.
+So this parameter does not affect the order of invitations to the applications, or any other routing.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried. For example:
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
+For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
 
@@ -346,13 +337,61 @@ You can return your tenant ID by running this command:
 
 Get-CsTenant | Select-Object DisplayName, TenantID
 
-If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter.
+Instead, the tenant ID will automatically be filled in for you based on your connection information.
+The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InMemory
+Creates an object reference without actually committing the object as a permanent change.
+If you assign the output of this cmdlet called with this parameter to a variable, you can make changes to the properties of the object reference and then commit those changes by calling this cmdlet's matching Set- cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
 Required: False
 Position: Named
 Default value: None
@@ -368,7 +407,7 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
 Default value: None
@@ -386,6 +425,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
 ## RELATED LINKS
+
+[Get-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[New-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Set-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Grant-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/grant-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Remove-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Get-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingapplication?view=skype-ps)
+
+[Set-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingapplication?view=skype-ps)
+
+[Remove-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingapplication?view=skype-ps)
+
+[New-CsTeamsComplianceRecordingPairedApplication](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpairedapplication?view=skype-ps)

--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
@@ -108,9 +108,6 @@ In this example, the application is made resilient by pairing it with another ap
 Separate invites are sent to the paired applications for the same call or meeting.
 Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
 
-**Integration of this example into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
-
 ## PARAMETERS
 
 ### -Identity
@@ -293,9 +290,6 @@ If multiple invites are accepted and at least one of the instances remains in th
 Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
 However, you cannot do both.
 Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-**Integration of this parameter into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
 
 ```yaml
 Type: ComplianceRecordingPairedApplication[]

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
@@ -1,54 +1,47 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
-online version: https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingapplication
+Module Name: Microsoft.Rtc.Management.Hosted
+online version:
 applicable: Skype for Business Online
-title: Set-CsTeamsComplianceRecordingApplication
+title : Set-CsTeamsComplianceRecordingApplication
 schema: 2.0.0
 manager: nakumar
-author: aditdalvi
-ms.author: aditd
+author: ansrin
+ms.author: ansrin
 ms.reviewer:
 ---
 
 # Set-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Modifies an existing association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
-Automatic policy-based recording is only applicable to Microsoft Teams users.
+Modifies an existing association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant. Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Identity <XdsIdentity>]
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
- [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
- [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
- [-Priority <Int32>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-ComplianceRecordingPairedApplications <>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredBeforeCallEstablishment <Boolean>]
+ [-RequiredDuringMeeting <Boolean>] [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>]
+ [-Priority <Int32>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Instance
 ```
-Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Instance <PSObject>]
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
- [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
- [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
- [-Priority <Int32>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-ComplianceRecordingPairedApplications <>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredBeforeCallEstablishment <Boolean>]
+ [-RequiredDuringMeeting <Boolean>] [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>]
+ [-Priority <Int32>] [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Policy-based recording applications are used in automatic policy-based recording scenarios.
-When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
+Policy-based recording applications are used in automatic policy-based recording scenarios. When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. Once the association is done, the Identity of these application instances becomes <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
-Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
-Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
-Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
+Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application. Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application. Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
 
 ## EXAMPLES
 
@@ -57,82 +50,151 @@ Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdle
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 1 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made optional for meetings.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
+In this example, the application is made optional for meetings. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
 
 ### Example 2
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeCallEstablishment $false -RequiredDuringCall $false
 ```
 
-The command shown in Example 2 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 2 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made optional for calls.
-Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
+In this example, the application is made optional for calls. Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
 
 ### Example 3
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ConcurrentInvitationCount 2
 ```
 
-The command shown in Example 3 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 3 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting.
-Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
+In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting. Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
 
 ### Example 4
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications @(New-CsTeamsComplianceRecordingPairedApplication -Id '39dc3ede-c80e-4f19-9153-417a65a1f144')
 ```
 
-The command shown in Example 4 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
-Separate invites are sent to the paired applications for the same call or meeting.
-Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
-
-**Integration of this example into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
+In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144. Separate invites are sent to the paired applications for the same call or meeting. Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
 
 ### Example 5
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications $null
 ```
 
-The command shown in Example 5 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 5 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application's resiliency is removed by removing the pairing it had with the application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
-Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
-
-**Integration of this example into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
+In this example, the application's resiliency is removed by removing the pairing it had with the application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144. Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
 
 ### Example 6
 ```powershell
 PS C:\> Get-CsTeamsComplianceRecordingApplication | Set-CsTeamsComplianceRecordingApplication -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 6 modifies all existing associations between application instances of policy-based recording applications and their corresponding Teams recording policy.
+The command shown in Example 6 modifies all existing associations between application instances of policy-based recording applications and their corresponding Teams compliance recording policy.
 
-In this example, all applications are made optional for meetings.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
+In this example, all applications are made optional for meetings. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
 
 ## PARAMETERS
+
+### -ComplianceRecordingPairedApplications
+Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
+
+In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
+
+```yaml
+Type: ComplianceRecordingPairedApplication[]
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConcurrentInvitationCount
+Determines the number of invites to send out to the application instance of the policy-based recording application.
+
+In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
+
+```yaml
+Type: UInt32
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Identity
 A name that uniquely identifies the application instance of the policy-based recording application.
 
-Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
-To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
-For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. To do this association correctly, the Identity of these application instances must be <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: XdsIdentity
 Parameter Sets: Identity
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: 1
 Default value: None
@@ -147,7 +209,7 @@ Allows you to pass a reference to an object to the cmdlet rather than set indivi
 Type: PSObject
 Parameter Sets: Instance
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: None
@@ -155,42 +217,19 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -RequiredBeforeMeetingJoin
-Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
+### -Priority
+This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
 
-If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting.
-The meeting will still continue for users who are in the meeting.
-
-If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
+All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies. So this parameter does not affect the order of invitations to the applications, or any other routing.
 
 ```yaml
-Type: Boolean
+Type: Int32
 Parameter Sets: (All)
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
-Default value: True
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RequiredDuringMeeting
-Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
-
-If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
-The meeting will still continue for users who are in the meeting.
-
-If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: True
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -206,7 +245,26 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
+Applicable: Skype for Business Online
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
+### -RequiredBeforeMeetingJoin
+Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
+
+If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting. The meeting will still continue for users who are in the meeting.
+
+If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: True
@@ -225,7 +283,7 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: True
@@ -233,94 +291,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ConcurrentInvitationCount
-Determines the number of invites to send out to the application instance of the policy-based recording application.
+### -RequiredDuringMeeting
+Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
 
-In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting.
-If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting. The meeting will still continue for users who are in the meeting.
 
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
-However, you cannot do both.
-Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
+If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
 
 ```yaml
-Type: UInt32
+Type: Boolean
 Parameter Sets: (All)
 Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
-Default value: 1
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ComplianceRecordingPairedApplications
-Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
-
-In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
-If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
-
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
-Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
-However, you cannot do both.
-Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-**Integration of this parameter into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
-
-```yaml
-Type: ComplianceRecordingPairedApplication[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Priority
-This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
-
-All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies.
-So this parameter does not affect the order of invitations to the applications, or any other routing.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
-For example:
+Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried. For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
 
@@ -328,45 +319,13 @@ You can return your tenant ID by running this command:
 
 Get-CsTenant | Select-Object DisplayName, TenantID
 
-If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter.
-Instead, the tenant ID will automatically be filled in for you based on your connection information.
-The Tenant parameter is primarily for use in a hybrid deployment.
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
 Parameter Sets: (All)
 Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses the display of any non-fatal error message that might arise when running the command.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: None
@@ -382,7 +341,7 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-
+Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: None
@@ -400,23 +359,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
+## NOTES
 
 ## RELATED LINKS
-
-[Get-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[New-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Set-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Grant-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/grant-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Remove-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingpolicy?view=skype-ps)
-
-[Get-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingapplication?view=skype-ps)
-
-[New-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingapplication?view=skype-ps)
-
-[Remove-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingapplication?view=skype-ps)
-
-[New-CsTeamsComplianceRecordingPairedApplication](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpairedapplication?view=skype-ps)

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
@@ -93,9 +93,6 @@ In this example, the application is made resilient by pairing it with another ap
 Separate invites are sent to the paired applications for the same call or meeting.
 Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
 
-**Integration of this example into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
-
 ### Example 5
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications $null
@@ -105,9 +102,6 @@ The command shown in Example 5 modifies an existing association between an appli
 
 In this example, the application's resiliency is removed by removing the pairing it had with the application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
 Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
-
-**Integration of this example into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
 
 ### Example 6
 ```powershell
@@ -284,9 +278,6 @@ If multiple invites are accepted and at least one of the instances remains in th
 Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
 However, you cannot do both.
 Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-**Integration of this parameter into the policy-based recording workflows is still a work in progress.**
-**This warning will be removed once the integration is complete.**
 
 ```yaml
 Type: ComplianceRecordingPairedApplication[]

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
@@ -1,47 +1,54 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
-Module Name: Microsoft.Rtc.Management.Hosted
-online version:
+online version: https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingapplication
 applicable: Skype for Business Online
-title : Set-CsTeamsComplianceRecordingApplication
+title: Set-CsTeamsComplianceRecordingApplication
 schema: 2.0.0
 manager: nakumar
-author: ansrin
-ms.author: ansrin
+author: aditdalvi
+ms.author: aditd
 ms.reviewer:
 ---
 
 # Set-CsTeamsComplianceRecordingApplication
 
 ## SYNOPSIS
-Modifies an existing association between an application instance of a policy-based recording application and a Teams compliance recording policy for administering automatic policy-based recording in your tenant. Automatic policy-based recording is only applicable to Microsoft Teams users.
+Modifies an existing association between an application instance of a policy-based recording application and a Teams recording policy for administering automatic policy-based recording in your tenant.
+Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-ComplianceRecordingPairedApplications <>]
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredBeforeCallEstablishment <Boolean>]
- [-RequiredDuringMeeting <Boolean>] [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>]
- [-Priority <Int32>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Identity <XdsIdentity>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
+ [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
+ [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
+ [-Priority <Int32>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Instance
 ```
-Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-ComplianceRecordingPairedApplications <>]
- [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredBeforeCallEstablishment <Boolean>]
- [-RequiredDuringMeeting <Boolean>] [-RequiredDuringCall <Boolean>] [-ConcurrentInvitationCount <UInt32>]
- [-Priority <Int32>] [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-CsTeamsComplianceRecordingApplication [-Tenant <System.Guid>] [-Instance <PSObject>]
+ [-RequiredBeforeMeetingJoin <Boolean>] [-RequiredDuringMeeting <Boolean>]
+ [-RequiredBeforeCallEstablishment <Boolean>] [-RequiredDuringCall <Boolean>]
+ [-ConcurrentInvitationCount <UInt32>] [-ComplianceRecordingPairedApplications <ComplianceRecordingPairedApplication[]>]
+ [-Priority <Int32>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Policy-based recording applications are used in automatic policy-based recording scenarios. When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams compliance recording policy are invited into the call or meeting to record audio, video and video-based screen sharing activity.
+Policy-based recording applications are used in automatic policy-based recording scenarios.
+When Microsoft Teams users participate in meetings or make or receive calls, the policy-based recording applications i.e. bots associated with the user's Teams recording policy are invited into the call or meeting to enforce compliance with the administrative set policy.
 
-Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams compliance recording policies.
+Instances of these applications are created using CsOnlineApplicationInstance cmdlets and are then associated with Teams recording policies.
 
-Note that application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. Once the association is done, the Identity of these application instances becomes <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Note that application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+Once the association is done, the Identity of these application instances becomes \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
-Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application. Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application. Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
+Please work with your Microsoft certified policy-based recording application provider to obtain an instance of their recording application.
+Please refer to the documentation of the CsOnlineApplicationInstance cmdlets for information on how to create an application instance of a policy-based recording application.
+Please also refer to the documentation of CsTeamsComplianceRecordingPolicy cmdlets for further information.
 
 ## EXAMPLES
 
@@ -50,151 +57,82 @@ Please work with your Microsoft certified policy-based recording application pro
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 1 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 1 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made optional for meetings. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
+In this example, the application is made optional for meetings.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
 
 ### Example 2
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -RequiredBeforeCallEstablishment $false -RequiredDuringCall $false
 ```
 
-The command shown in Example 2 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 2 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made optional for calls. Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
+In this example, the application is made optional for calls.
+Please refer to the documentation of the RequiredBeforeCallEstablishment and RequiredDuringCall parameters for more information.
 
 ### Example 3
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ConcurrentInvitationCount 2
 ```
 
-The command shown in Example 3 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 3 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting. Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
+In this example, the application is made resilient by specifying that two invites must be sent to the same application for the same call or meeting.
+Please refer to the documentation of the ConcurrentInvitationCount parameter for more information.
 
 ### Example 4
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications @(New-CsTeamsComplianceRecordingPairedApplication -Id '39dc3ede-c80e-4f19-9153-417a65a1f144')
 ```
 
-The command shown in Example 4 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 4 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144. Separate invites are sent to the paired applications for the same call or meeting. Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
+In this example, the application is made resilient by pairing it with another application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
+Separate invites are sent to the paired applications for the same call or meeting.
+Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
+
+**Integration of this example into the policy-based recording workflows is still a work in progress.**
+**This warning will be removed once the integration is complete.**
 
 ### Example 5
 ```powershell
 PS C:\> Set-CsTeamsComplianceRecordingApplication -Identity 'Tag:ContosoPartnerComplianceRecordingPolicy/d93fefc7-93cc-4d44-9a5d-344b0fff2899' -ComplianceRecordingPairedApplications $null
 ```
 
-The command shown in Example 5 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams compliance recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
+The command shown in Example 5 modifies an existing association between an application instance of a policy-based recording application with ObjectId d93fefc7-93cc-4d44-9a5d-344b0fff2899 and a Teams recording policy with the Identity ContosoPartnerComplianceRecordingPolicy.
 
-In this example, the application's resiliency is removed by removing the pairing it had with the application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144. Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
+In this example, the application's resiliency is removed by removing the pairing it had with the application instance of a policy-based recording application with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144.
+Please refer to the documentation of the ComplianceRecordingPairedApplications parameter for more information.
+
+**Integration of this example into the policy-based recording workflows is still a work in progress.**
+**This warning will be removed once the integration is complete.**
 
 ### Example 6
 ```powershell
 PS C:\> Get-CsTeamsComplianceRecordingApplication | Set-CsTeamsComplianceRecordingApplication -RequiredBeforeMeetingJoin $false -RequiredDuringMeeting $false
 ```
 
-The command shown in Example 6 modifies all existing associations between application instances of policy-based recording applications and their corresponding Teams compliance recording policy.
+The command shown in Example 6 modifies all existing associations between application instances of policy-based recording applications and their corresponding Teams recording policy.
 
-In this example, all applications are made optional for meetings. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
+In this example, all applications are made optional for meetings.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredDuringMeeting parameters for more information.
 
 ## PARAMETERS
-
-### -ComplianceRecordingPairedApplications
-Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
-
-In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
-
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-```yaml
-Type: ComplianceRecordingPairedApplication[]
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ConcurrentInvitationCount
-Determines the number of invites to send out to the application instance of the policy-based recording application.
-
-In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting. If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
-
-If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next. Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
-
-If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
-
-If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next. Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
-
-If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
-
-Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications. However, you cannot do both. Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
-
-```yaml
-Type: UInt32
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: 1
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses the display of any non-fatal error message that might arise when running the command.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Identity
 A name that uniquely identifies the application instance of the policy-based recording application.
 
-Application instances of policy-based recording applications must be associated with a Teams compliance recording policy using the CsTeamsComplianceRecordingApplication cmdlets. To do this association correctly, the Identity of these application instances must be <Identity of the associated Teams compliance recording policy>/<ObjectId of the application instance>. For example, the Identity of an application instance can be "Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams compliance recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
+Application instances of policy-based recording applications must be associated with a Teams recording policy using the CsTeamsComplianceRecordingApplication cmdlets.
+To do this association correctly, the Identity of these application instances must be \<Identity of the associated Teams recording policy\>/\<ObjectId of the application instance\>.
+For example, the Identity of an application instance can be \"Tag:ContosoPartnerComplianceRecordingPolicy/39dc3ede-c80e-4f19-9153-417a65a1f144\", which indicates that the application instance with ObjectId 39dc3ede-c80e-4f19-9153-417a65a1f144 is associated with the Teams recording policy with Identity ContosoPartnerComplianceRecordingPolicy.
 
 ```yaml
 Type: XdsIdentity
 Parameter Sets: Identity
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: 1
 Default value: None
@@ -209,7 +147,7 @@ Allows you to pass a reference to an object to the cmdlet rather than set indivi
 Type: PSObject
 Parameter Sets: Instance
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
 Default value: None
@@ -217,19 +155,42 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
-### -Priority
-This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
+### -RequiredBeforeMeetingJoin
+Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
 
-All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies. So this parameter does not affect the order of invitations to the applications, or any other routing.
+If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting.
+The meeting will still continue for users who are in the meeting.
+
+If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
 
 ```yaml
-Type: Int32
+Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
-Default value: None
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequiredDuringMeeting
+Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
+
+If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+The meeting will still continue for users who are in the meeting.
+
+If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -245,26 +206,7 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
-Required: False
-Position: Named
-Default value: True
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
-### -RequiredBeforeMeetingJoin
-Indicates whether the policy-based recording application must be in the meeting before the user is allowed to join the meeting.
-
-If this is set to True, the user will not be allowed to join the meeting if the policy-based recording application fails to join the meeting. The meeting will still continue for users who are in the meeting.
-
-If this is set to False, the user will be allowed to join the meeting even if the policy-based recording application fails to join the meeting.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Skype for Business Online
 Required: False
 Position: Named
 Default value: True
@@ -283,7 +225,7 @@ If this is set to False, call establishment will proceed normally if the policy-
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
 Default value: True
@@ -291,27 +233,94 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RequiredDuringMeeting
-Indicates whether the policy-based recording application must be in the meeting while the user is in the meeting.
+### -ConcurrentInvitationCount
+Determines the number of invites to send out to the application instance of the policy-based recording application.
 
-If this is set to True, the user will be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting. The meeting will still continue for users who are in the meeting.
+In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting.
+If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
 
-If this is set to False, the user will not be ejected from the meeting if the policy-based recording application leaves the meeting or is dropped from the meeting.
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
+However, you cannot do both.
+Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
 
 ```yaml
-Type: Boolean
+Type: UInt32
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
-Default value: True
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ComplianceRecordingPairedApplications
+Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
+
+In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
+If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
+
+If all of the invites are rejected, the application invitation process is deemed a failure and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredBeforeMeetingJoin and RequiredBeforeCallEstablishment parameters.
+
+If at least one of the invites is accepted and the others are rejected, the application invitation process is still deemed a success.
+
+If multiple invites are accepted and all of the instances leave or get dropped from the call or meeting, then the application is no longer in the call or meeting and the other flags for this application control what happens next.
+Please refer to the documentation of the RequiredDuringMeeting and RequiredDuringCall parameters.
+
+If multiple invites are accepted and at least one of the instances remains in the call or meeting, then the application is in the call or meeting.
+
+Note that application resiliency can be achieved either by sending multiple invites to the same application using ConcurrentInvitationCount or by sending invites to separate paired applications using ComplianceRecordingPairedApplications.
+However, you cannot do both.
+Please work with your Microsoft certified policy-based recording application provider to determine if application resiliency is needed for your workflows and how best to achieve application resiliency.
+
+**Integration of this parameter into the policy-based recording workflows is still a work in progress.**
+**This warning will be removed once the integration is complete.**
+
+```yaml
+Type: ComplianceRecordingPairedApplication[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Priority
+This priority determines the order in which the policy-based recording applications are displayed in the output of the Get-CsTeamsComplianceRecordingPolicy cmdlet.
+
+All policy-based recording applications are invited in parallel to ensure low call setup and meeting join latencies.
+So this parameter does not affect the order of invitations to the applications, or any other routing.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Tenant
-Globally unique identifier (GUID) of the tenant account whose Teams compliance recording policies are being queried. For example:
+Globally unique identifier (GUID) of the tenant account whose Teams recording policies are being queried.
+For example:
 
 -Tenant "38aad667-af54-4397-aaa7-e94c79ec2308"
 
@@ -319,13 +328,45 @@ You can return your tenant ID by running this command:
 
 Get-CsTenant | Select-Object DisplayName, TenantID
 
-If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter. Instead, the tenant ID will automatically be filled in for you based on your connection information. The Tenant parameter is primarily for use in a hybrid deployment.
+If you are using a remote session of Windows PowerShell and are connected only to Skype for Business Online you do not have to include the Tenant parameter.
+Instead, the tenant ID will automatically be filled in for you based on your connection information.
+The Tenant parameter is primarily for use in a hybrid deployment.
 
 ```yaml
 Type: System.Guid
 Parameter Sets: (All)
 Aliases:
-Applicable: Skype for Business Online
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
 Required: False
 Position: Named
 Default value: None
@@ -341,7 +382,7 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-Applicable: Skype for Business Online
+
 Required: False
 Position: Named
 Default value: None
@@ -359,6 +400,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
 ## RELATED LINKS
+
+[Get-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[New-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Set-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/set-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Grant-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/grant-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Remove-CsTeamsComplianceRecordingPolicy](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingpolicy?view=skype-ps)
+
+[Get-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/get-csteamscompliancerecordingapplication?view=skype-ps)
+
+[New-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingapplication?view=skype-ps)
+
+[Remove-CsTeamsComplianceRecordingApplication](https://docs.microsoft.com/powershell/module/skype/remove-csteamscompliancerecordingapplication?view=skype-ps)
+
+[New-CsTeamsComplianceRecordingPairedApplication](https://docs.microsoft.com/powershell/module/skype/new-csteamscompliancerecordingpairedapplication?view=skype-ps)


### PR DESCRIPTION
Update the New-CsTeamsComplianceRecordingApplication and Set-CsTeamsComplianceRecordinApplication cmdlet documentation - remove the warnings related to compliancerecordingpairedapplication