### PR TITLE
Removed double quotes under NOTES section

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOHubToHubAssociation.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOHubToHubAssociation.md
@@ -76,4 +76,4 @@ Accept wildcard characters: False
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/p/?LinkID=113216).
 
 ## NOTES
-"SPOHubToHubAssociation is just a placeholder and not yet ready for production. 
+SPOHubToHubAssociation is just a placeholder and not yet ready for production. 


### PR DESCRIPTION
Original: "SPOHubToHubAssociation is just a placeholder and not yet ready for production 

Updated: SPOHubToHubAssociation is just a placeholder and not yet ready for production