### PR TITLE
Removing global word from role

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOTenantCdnOrigin.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOTenantCdnOrigin.md
@@ -26,7 +26,7 @@ Add-SPOTenantCdnOrigin -CdnType <SPOTenantCdnType> [-Confirm] -OriginUrl <String
 
 Configures a new origin to public or private CDN, on either Tenant level or on a single Site level. Effectively, a tenant admin points out to a document library, or a folder in the document library and requests that content in that library should be retrievable by using a CDN.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You must have the SharePoint Admin role or Global Administrator role and be a site collection administrator to run the cmdlet.
 
 ## EXAMPLES
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOTenantCdnOrigin.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOTenantCdnOrigin.md
@@ -26,7 +26,7 @@ Add-SPOTenantCdnOrigin -CdnType <SPOTenantCdnType> [-Confirm] -OriginUrl <String
 
 Configures a new origin to public or private CDN, on either Tenant level or on a single Site level. Effectively, a tenant admin points out to a document library, or a folder in the document library and requests that content in that library should be retrievable by using a CDN.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 ## EXAMPLES
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOUser.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOUser.md
@@ -24,7 +24,7 @@ Add-SPOUser -Group <String> -LoginName <String> -Site <SpoSitePipeBind> [<Common
 
 ## DESCRIPTION
 
-Along with the group memberships that are normally required to run Windows PowerShell, you must be a SharePoint Online administrator and a site collection administrator to use the `Add-SPOUser` cmdlet.
+Along with the group memberships that are normally required to run Windows PowerShell, you must have the SharePoint Admin role or Global Administrator role and be a site collection administrator to use the `Add-SPOUser` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOUser.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOUser.md
@@ -24,7 +24,7 @@ Add-SPOUser -Group <String> -LoginName <String> -Site <SpoSitePipeBind> [<Common
 
 ## DESCRIPTION
 
-Along with the group memberships that are normally required to run Windows PowerShell, you must be a SharePoint Online global administrator and a site collection administrator to use the `Add-SPOUser` cmdlet.
+Along with the group memberships that are normally required to run Windows PowerShell, you must be a SharePoint Online administrator and a site collection administrator to use the `Add-SPOUser` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Connect-SPOService.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Connect-SPOService.md
@@ -14,7 +14,7 @@ ms.reviewer:
 
 ## SYNOPSIS
 
-Connects a SharePoint Online administrator to a SharePoint Online connection (the SharePoint Online Administration Center).
+Connects a SharePoint Online administrator or Global Administrator to a SharePoint Online connection (the SharePoint Online Administration Center).
 This cmdlet must be run before any other SharePoint Online cmdlets can run.
 
 ## SYNTAX
@@ -35,7 +35,7 @@ Connect-SPOService [-ClientTag <String>] [-Credential <CredentialCmdletPipeBind>
 
 ## DESCRIPTION
 
-The `Connect-SPOService` cmdlet connects a SharePoint Online administrator to the SharePoint Online Administration Center.
+The `Connect-SPOService` cmdlet connects a SharePoint Online administrator or Global Administrator to the SharePoint Online Administration Center.
 
 Only a single SharePoint Online service connection is maintained from any single Windows PowerShell session.
 In other words, this is a per-organization administrator connection.
@@ -44,7 +44,7 @@ The Windows PowerShell session will be set to serve the new SharePoint Online ad
 
 A delegated partner administrator has to swap connections for different organizations within the same Windows PowerShell session.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 
@@ -56,7 +56,7 @@ For permissions and the most current information about Windows PowerShell for Sh
 Connect-SPOService -Url https://contoso-admin.sharepoint.com -credential admin@contoso.com
 ```
 
-Example 1 shows how a SharePoint Online administrator with credential admin@contoso.com connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
+Example 1 shows how a SharePoint Online administrator or Global Administrator with credential admin@contoso.com connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
 
 ### -----------------------EXAMPLE 2-----------------------------
 
@@ -67,7 +67,7 @@ $cred = New-Object -TypeName System.Management.Automation.PSCredential -argument
 Connect-SPOService -Url https://contoso-admin.sharepoint.com -Credential $cred
 ```
 
-Example 2 shows how a SharePoint Online administrator with a username and password connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
+Example 2 shows how a SharePoint Online administrator or Global Administrator with a username and password connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
 
 ### -----------------------EXAMPLE 3-----------------------------
 
@@ -115,7 +115,7 @@ Accept wildcard characters: False
 
 ### -Credential
 
-Specifies the credentials to use to connect. If no credentials are presented, a dialog will prompt for the credentials. The credentials must be those of a SharePoint Online administrator who can access the SharePoint Online Administration Center site.
+Specifies the credentials to use to connect. If no credentials are presented, a dialog will prompt for the credentials. The credentials must be those of a SharePoint Online administrator or Global Administrator who can access the SharePoint Online Administration Center site.
 
 ```yaml
 Type: CredentialCmdletPipeBind

--- a/sharepoint/sharepoint-ps/sharepoint-online/Connect-SPOService.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Connect-SPOService.md
@@ -14,7 +14,7 @@ ms.reviewer:
 
 ## SYNOPSIS
 
-Connects a SharePoint Online global administrator to a SharePoint Online connection (the SharePoint Online Administration Center).
+Connects a SharePoint Online administrator to a SharePoint Online connection (the SharePoint Online Administration Center).
 This cmdlet must be run before any other SharePoint Online cmdlets can run.
 
 ## SYNTAX
@@ -35,16 +35,16 @@ Connect-SPOService [-ClientTag <String>] [-Credential <CredentialCmdletPipeBind>
 
 ## DESCRIPTION
 
-The `Connect-SPOService` cmdlet connects a SharePoint Online global administrator to the SharePoint Online Administration Center.
+The `Connect-SPOService` cmdlet connects a SharePoint Online administrator to the SharePoint Online Administration Center.
 
 Only a single SharePoint Online service connection is maintained from any single Windows PowerShell session.
 In other words, this is a per-organization administrator connection.
 Running the `Connect-SPOService` cmdlet twice implicitly disconnects the previous connection.
-The Windows PowerShell session will be set to serve the new SharePoint Online global administrator specified.
+The Windows PowerShell session will be set to serve the new SharePoint Online administrator specified.
 
 A delegated partner administrator has to swap connections for different organizations within the same Windows PowerShell session.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 
@@ -56,7 +56,7 @@ For permissions and the most current information about Windows PowerShell for Sh
 Connect-SPOService -Url https://contoso-admin.sharepoint.com -credential admin@contoso.com
 ```
 
-Example 1 shows how a SharePoint Online global administrator with credential admin@contoso.com connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
+Example 1 shows how a SharePoint Online administrator with credential admin@contoso.com connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
 
 ### -----------------------EXAMPLE 2-----------------------------
 
@@ -67,7 +67,7 @@ $cred = New-Object -TypeName System.Management.Automation.PSCredential -argument
 Connect-SPOService -Url https://contoso-admin.sharepoint.com -Credential $cred
 ```
 
-Example 2 shows how a SharePoint Online global administrator with a username and password connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
+Example 2 shows how a SharePoint Online administrator with a username and password connects to a SharePoint Online Administration Center that has the URL <https://contoso-admin.sharepoint.com.>
 
 ### -----------------------EXAMPLE 3-----------------------------
 
@@ -115,7 +115,7 @@ Accept wildcard characters: False
 
 ### -Credential
 
-Specifies the credentials to use to connect. If no credentials are presented, a dialog will prompt for the credentials. The credentials must be those of a SharePoint Online global administrator who can access the SharePoint Online Administration Center site.
+Specifies the credentials to use to connect. If no credentials are presented, a dialog will prompt for the credentials. The credentials must be those of a SharePoint Online administrator who can access the SharePoint Online Administration Center site.
 
 ```yaml
 Type: CredentialCmdletPipeBind

--- a/sharepoint/sharepoint-ps/sharepoint-online/Disconnect-SPOService.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Disconnect-SPOService.md
@@ -32,7 +32,7 @@ For more information, see `Connect-SPOService`.
 Even after a connection is terminated, operations that were started before the connection is terminated will run to completion.
 In other words, long-running operations will not be terminated by running the `Disconnect-SPOService` cmdlet or the `Connect-SPOService` cmdlet.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Disconnect-SPOService.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Disconnect-SPOService.md
@@ -32,7 +32,7 @@ For more information, see `Connect-SPOService`.
 Even after a connection is terminated, operations that were started before the connection is terminated will run to completion.
 In other words, long-running operations will not be terminated by running the `Disconnect-SPOService` cmdlet or the `Connect-SPOService` cmdlet.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppErrors.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppErrors.md
@@ -34,7 +34,7 @@ Date time values that are older than 50 years or later than 20 years from today 
 Each error includes the error message, time in UTC that error happened, the site where the error happened, and the error type.
 Values for error type are as follows: 0 - None, 1 - Install Error, 2 - Upgrade Error, 3 - Runtime Error.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppErrors.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppErrors.md
@@ -34,7 +34,7 @@ Date time values that are older than 50 years or later than 20 years from today 
 Each error includes the error message, time in UTC that error happened, the site where the error happened, and the error type.
 Values for error type are as follows: 0 - None, 1 - Install Error, 2 - Upgrade Error, 3 - Runtime Error.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
@@ -30,7 +30,7 @@ Either ProductId or Name must be given. Name is ignored if ProductId is specifie
 
 The returned collection of installed applications contains Product ID (GUID), Product name and Source. Values for source type are as follows: 0 = App Catalog and 1 = Marketplace.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOAppInfo.md
@@ -30,7 +30,7 @@ Either ProductId or Name must be given. Name is ignored if ProductId is specifie
 
 The returned collection of installed applications contains Product ID (GUID), Product name and Source. Values for source type are as follows: 0 = App Catalog and 1 = Marketplace.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPODeletedSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPODeletedSite.md
@@ -44,7 +44,7 @@ This action does not restore these returned sites or site collection.
 It only returns their properties so that you can see what sites or site collections have been deleted.
 To restore the site or site collections, forward the results to the `Restore-SPODeletedSite` cmdlet in the pipeline.
 
-You must be a SharePoint Online administrator and a site collection administrator for the deleted site collections to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator for the deleted site collections to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPODeletedSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPODeletedSite.md
@@ -44,7 +44,7 @@ This action does not restore these returned sites or site collection.
 It only returns their properties so that you can see what sites or site collections have been deleted.
 To restore the site or site collections, forward the results to the `Restore-SPODeletedSite` cmdlet in the pipeline.
 
-You must be a SharePoint Online global administrator and a site collection administrator for the deleted site collections to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator for the deleted site collections to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -52,7 +52,7 @@ The Detailed parameter has been deprecated. It will continue to work with earlie
 > [!NOTE]
 > Site collections in the Recycle Bin will not be retrieved by using the `Get-SPOSite` cmdlet.  
 
-You need to be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You need to be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at [Intro to SharePoint Online Management Shell](https://docs.microsoft.com/powershell/sharepoint/sharepoint-online/introduction-sharepoint-online-management-shell?view=sharepoint-ps).
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -52,7 +52,7 @@ The Detailed parameter has been deprecated. It will continue to work with earlie
 > [!NOTE]
 > Site collections in the Recycle Bin will not be retrieved by using the `Get-SPOSite` cmdlet.  
 
-You need to be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You need to be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at [Intro to SharePoint Online Management Shell](https://docs.microsoft.com/powershell/sharepoint/sharepoint-online/introduction-sharepoint-online-management-shell?view=sharepoint-ps).
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSiteGroup.md
@@ -26,7 +26,7 @@ Get-SPOSiteGroup [-Group <String>] [-Limit <Int32>] -Site <SpoSitePipeBind> [<Co
 
 Use the `Get-SPOSiteGroup` cmdlet to get all the groups on the specified site collection by using the Site parameter.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at [SharePoint Online PowerShell](https://docs.microsoft.com/powershell/module/sharepoint-online/index).
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenant.md
@@ -28,7 +28,7 @@ The `Get-SPOTenant` cmdlet returns organization-level site collection properties
 
 Currently, there are no parameters for this cmdlet.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenant.md
@@ -28,7 +28,7 @@ The `Get-SPOTenant` cmdlet returns organization-level site collection properties
 
 Currently, there are no parameters for this cmdlet.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogEntry.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogEntry.md
@@ -50,7 +50,7 @@ For Beta 2, the only company logs available are for Business Connectivity Servic
 > [!NOTE]
 > If you do not use any parameter, the first 1000 rows in descending time range are returned.  
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogEntry.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogEntry.md
@@ -50,7 +50,7 @@ For Beta 2, the only company logs available are for Business Connectivity Servic
 > [!NOTE]
 > If you do not use any parameter, the first 1000 rows in descending time range are returned.  
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogLastAvailableTimeInUtc.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogLastAvailableTimeInUtc.md
@@ -27,7 +27,7 @@ Get-SPOTenantLogLastAvailableTimeInUtc [<CommonParameters>]
 This cmdlet retrieves the time in Coordinated Universal Time (UTC) when the logs were last collected.
 After you know the time, you can use the `Get-SPOTenantLogEntry` cmdlet to retrieve the logs.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogLastAvailableTimeInUtc.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantLogLastAvailableTimeInUtc.md
@@ -27,7 +27,7 @@ Get-SPOTenantLogLastAvailableTimeInUtc [<CommonParameters>]
 This cmdlet retrieves the time in Coordinated Universal Time (UTC) when the logs were last collected.
 After you know the time, you can use the `Get-SPOTenantLogEntry` cmdlet to retrieve the logs.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantSyncClientRestriction.md
@@ -24,7 +24,7 @@ Get-SPOTenantSyncClientRestriction [<CommonParameters>]
 
 ## DESCRIPTION
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information on how to connect to the tenant, see `Connect-SPOService`.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantSyncClientRestriction.md
@@ -24,7 +24,7 @@ Get-SPOTenantSyncClientRestriction [<CommonParameters>]
 
 ## DESCRIPTION
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information on how to connect to the tenant, see `Connect-SPOService`.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOUser.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOUser.md
@@ -44,7 +44,7 @@ For more information about how to use parameter sets, see [Cmdlet Parameter Sets
 
 The `Get-SPOUser` cmdlet matches one and only one user or security group.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the `Get-SPOUser` cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the `Get-SPOUser` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832>.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOUser.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOUser.md
@@ -44,7 +44,7 @@ For more information about how to use parameter sets, see [Cmdlet Parameter Sets
 
 The `Get-SPOUser` cmdlet matches one and only one user or security group.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the `Get-SPOUser` cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the `Get-SPOUser` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832>.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOWebTemplate.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOWebTemplate.md
@@ -27,7 +27,7 @@ Get-SPOWebTemplate [[-LocaleId] <UInt32>] [-CompatibilityLevel <Int32>] [-Name <
 
 The `Get-SPOWebTemplate` cmdlet displays all site templates that match the given identity and are available in SharePoint Online.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOWebTemplate.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOWebTemplate.md
@@ -27,7 +27,7 @@ Get-SPOWebTemplate [[-LocaleId] <UInt32>] [-CompatibilityLevel <Int32>] [-Name <
 
 The `Get-SPOWebTemplate` cmdlet displays all site templates that match the given identity and are available in SharePoint Online.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
@@ -29,7 +29,7 @@ New-SPOSite [-CompatibilityLevel <Int32>] [-LocaleId <UInt32>] [-NoWait] -Owner 
 The `New-SPOSite` cmdlet creates a new site collection for the current company.
 However, creating a new SharePoint Online site collection fails if a deleted site with the same URL exists in the Recycle Bin.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832>.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSite.md
@@ -29,7 +29,7 @@ New-SPOSite [-CompatibilityLevel <Int32>] [-LocaleId <UInt32>] [-NoWait] -Owner 
 The `New-SPOSite` cmdlet creates a new site collection for the current company.
 However, creating a new SharePoint Online site collection fails if a deleted site with the same URL exists in the Recycle Bin.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832>.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSiteGroup.md
@@ -27,7 +27,7 @@ New-SPOSiteGroup -Group <String> -PermissionLevels <String[]> -Site <SpoSitePipe
 A SharePoint group is a set of individual users.
 SharePoint groups enable you to manage sets of users instead of individual users.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOSiteGroup.md
@@ -27,7 +27,7 @@ New-SPOSiteGroup -Group <String> -PermissionLevels <String[]> -Site <SpoSitePipe
 A SharePoint group is a set of individual users.
 SharePoint groups enable you to manage sets of users instead of individual users.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOGeoAdministrator.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOGeoAdministrator.md
@@ -30,7 +30,7 @@ For more information about how to use parameter sets, see Cmdlet Parameter Sets 
 
 The `Remove-SPOGeoAdministrator` cmdlet matches a user or a security group and remove the GeoAdministrator privileges in the SharePoint Organization.
 
-You must be a SharePoint Online global administrator, and you must have a Multi-Geo Tenant to run the `Remove-SPOGeoAdministrator` cmdlet successfully.
+You must be a SharePoint Online administrator, and you must have a Multi-Geo Tenant to run the `Remove-SPOGeoAdministrator` cmdlet successfully.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOGeoAdministrator.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOGeoAdministrator.md
@@ -30,7 +30,7 @@ For more information about how to use parameter sets, see Cmdlet Parameter Sets 
 
 The `Remove-SPOGeoAdministrator` cmdlet matches a user or a security group and remove the GeoAdministrator privileges in the SharePoint Organization.
 
-You must be a SharePoint Online administrator, and you must have a Multi-Geo Tenant to run the `Remove-SPOGeoAdministrator` cmdlet successfully.
+You must be a SharePoint Online administrator or Global Administrator, and you must have a Multi-Geo Tenant to run the `Remove-SPOGeoAdministrator` cmdlet successfully.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSite.md
@@ -29,7 +29,7 @@ Instead, the removed site collection is moved to the Recycle Bin.
 You can use the `Restore-SPODeletedSite`cmdlet to restore a site collection from the Recycle Bin.
 To delete a site collection permanently, first move the site collection to the Recycle Bin by using the `Remove-SPOSite` cmdlet and then delete it from the Recycle Bin by using the `Remove-SPODeletedSite` cmdlet.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSite.md
@@ -29,7 +29,7 @@ Instead, the removed site collection is moved to the Recycle Bin.
 You can use the `Restore-SPODeletedSite`cmdlet to restore a site collection from the Recycle Bin.
 To delete a site collection permanently, first move the site collection to the Recycle Bin by using the `Remove-SPOSite` cmdlet and then delete it from the Recycle Bin by using the `Remove-SPODeletedSite` cmdlet.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSiteGroup.md
@@ -26,7 +26,7 @@ Remove-SPOSiteGroup -Identity <String> -Site <SpoSitePipeBind> [<CommonParameter
 
 Use the `Remove-SPOSiteGroup` cmdlet to remove a group from a site collection by specifying the name of the group in the Identity parameter.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the `Remove-SPOSiteGroup` cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the `Remove-SPOSiteGroup` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOSiteGroup.md
@@ -26,7 +26,7 @@ Remove-SPOSiteGroup -Identity <String> -Site <SpoSitePipeBind> [<CommonParameter
 
 Use the `Remove-SPOSiteGroup` cmdlet to remove a group from a site collection by specifying the name of the group in the Identity parameter.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the `Remove-SPOSiteGroup` cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the `Remove-SPOSiteGroup` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantSyncClientRestriction.md
@@ -24,7 +24,7 @@ Remove-SPOTenantSyncClientRestriction [<CommonParameters>]
 
 ## DESCRIPTION
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information on how to connect to the tenant, see `Connect-SPOService`.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantSyncClientRestriction.md
@@ -24,7 +24,7 @@ Remove-SPOTenantSyncClientRestriction [<CommonParameters>]
 
 ## DESCRIPTION
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information on how to connect to the tenant, see `Connect-SPOService`.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOUser.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOUser.md
@@ -24,7 +24,7 @@ Remove-SPOUser [-Group <String>] -LoginName <String> -Site <SpoSitePipeBind> [<C
 
 ## DESCRIPTION
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the `Remove-SPOUser` cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the `Remove-SPOUser` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOUser.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOUser.md
@@ -24,7 +24,7 @@ Remove-SPOUser [-Group <String>] -LoginName <String> -Site <SpoSitePipeBind> [<C
 
 ## DESCRIPTION
 
-You must be a SharePoint Online administrator and a site collection administrator to run the `Remove-SPOUser` cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the `Remove-SPOUser` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Repair-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Repair-SPOSite.md
@@ -32,7 +32,7 @@ The cmdlet reports the health check rules with a summary of the results.
 The rules might not support automatic repair.
 Tests without repair mode can be initiated by running the `Test-SPOSite` cmdlet.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Repair-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Repair-SPOSite.md
@@ -32,7 +32,7 @@ The cmdlet reports the health check rules with a summary of the results.
 The rules might not support automatic repair.
 Tests without repair mode can be initiated by running the `Test-SPOSite` cmdlet.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Request-SPOUpgradeEvaluationSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Request-SPOUpgradeEvaluationSite.md
@@ -25,12 +25,12 @@ Request-SPOUpgradeEvaluationSite [-Confirm] -Identity <SpoSitePipeBind> [-NoEmai
 
 ## DESCRIPTION
 
-The `Request-SPOUpgradeEvaluationSite` cmdlet lets the SharePoint Online global administrator request a copy of an existing site collection for the purposes of validating the effects of upgrade without affecting the original site.
+The `Request-SPOUpgradeEvaluationSite` cmdlet lets the SharePoint Online administrator request a copy of an existing site collection for the purposes of validating the effects of upgrade without affecting the original site.
 
 A request for an upgrade evaluation site is not automatically processed.
 Instead, it is scheduled to occur on the background when it causes the least effect on the service.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 
@@ -50,7 +50,7 @@ Example 1 requests a site upgrade evaluation for the marketing site <https://con
 Request-SPOUpgradeEvaluationSite https://contoso.sharepoint.com/sites/marketing -NoEmail $true -NoUpgrade $true
 ```
 
-This example requests a site upgrade evaluation for the marketing site <https://contoso.sharepoint.com/sites/marketing.> It specifies to not send email messages and not automatically try upgrade of the evaluation site. By using the cmdlet in this way, a SharePoint Online global administrator can make changes to the upgrade evaluation site before starting the actual upgrade.
+This example requests a site upgrade evaluation for the marketing site <https://contoso.sharepoint.com/sites/marketing.> It specifies to not send email messages and not automatically try upgrade of the evaluation site. By using the cmdlet in this way, a SharePoint Online administrator can make changes to the upgrade evaluation site before starting the actual upgrade.
 
 ## PARAMETERS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Request-SPOUpgradeEvaluationSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Request-SPOUpgradeEvaluationSite.md
@@ -30,7 +30,7 @@ The `Request-SPOUpgradeEvaluationSite` cmdlet lets the SharePoint Online adminis
 A request for an upgrade evaluation site is not automatically processed.
 Instead, it is scheduled to occur on the background when it causes the least effect on the service.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 
@@ -50,7 +50,7 @@ Example 1 requests a site upgrade evaluation for the marketing site <https://con
 Request-SPOUpgradeEvaluationSite https://contoso.sharepoint.com/sites/marketing -NoEmail $true -NoUpgrade $true
 ```
 
-This example requests a site upgrade evaluation for the marketing site <https://contoso.sharepoint.com/sites/marketing.> It specifies to not send email messages and not automatically try upgrade of the evaluation site. By using the cmdlet in this way, a SharePoint Online administrator can make changes to the upgrade evaluation site before starting the actual upgrade.
+This example requests a site upgrade evaluation for the marketing site <https://contoso.sharepoint.com/sites/marketing.> It specifies to not send email messages and not automatically try upgrade of the evaluation site. By using the cmdlet in this way, a SharePoint Online administrator or Global Administrator can make changes to the upgrade evaluation site before starting the actual upgrade.
 
 ## PARAMETERS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Restore-SPODeletedSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Restore-SPODeletedSite.md
@@ -24,7 +24,7 @@ Restore-SPODeletedSite -Identity <SpoSitePipeBind> [-NoWait] [<CommonParameters>
 
 ## DESCRIPTION
 
-You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Restore-SPODeletedSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Restore-SPODeletedSite.md
@@ -24,7 +24,7 @@ Restore-SPODeletedSite -Identity <SpoSitePipeBind> [-NoWait] [<CommonParameters>
 
 ## DESCRIPTION
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Revoke-SPOUserSession.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Revoke-SPOUserSession.md
@@ -24,7 +24,7 @@ Revoke-SPOUserSession [-User] <String> [-Confirm] [-WhatIf] [<CommonParameters>]
 
 ## DESCRIPTION
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information about how to connect to the tenant, see `Connect-SPOService`.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Revoke-SPOUserSession.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Revoke-SPOUserSession.md
@@ -24,7 +24,7 @@ Revoke-SPOUserSession [-User] <String> [-Confirm] [-WhatIf] [<CommonParameters>]
 
 ## DESCRIPTION
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information about how to connect to the tenant, see `Connect-SPOService`.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -66,7 +66,7 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [
 
 For any parameters that are passed in, the `Set-SPOSite` cmdlet sets or updates the setting for the site collection identified by parameter Identity.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -66,7 +66,7 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [
 
 For any parameters that are passed in, the `Set-SPOSite` cmdlet sets or updates the setting for the site collection identified by parameter Identity.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832.>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteGroup.md
@@ -25,7 +25,7 @@ Set-SPOSiteGroup -Identity <String> [-Name <String>] [-Owner <String>] [-Permiss
 
 ## DESCRIPTION
 
-You must be a SharePoint Online administrator and a site collection administrator to run the `Set-SPOSiteGroup` cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the `Set-SPOSiteGroup` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteGroup.md
@@ -25,7 +25,7 @@ Set-SPOSiteGroup -Identity <String> [-Name <String>] [-Owner <String>] [-Permiss
 
 ## DESCRIPTION
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the `Set-SPOSiteGroup` cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the `Set-SPOSiteGroup` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 Specifies the permission levels to grant to the group.
 
 > [!NOTE]
-> Permission levels are defined by SharePoint Online global administrators from SharePoint Online Administration Center.  
+> Permission levels are defined by SharePoint Online administrators from SharePoint Online Administration Center.  
 
 ```yaml
 Type: String[]
@@ -121,7 +121,7 @@ Accept wildcard characters: False
 Specifies the permission levels to remove from the group.
 
 > [!NOTE]
-> Permission levels are defined by SharePoint Online global administrators from SharePoint Online Administration Center.  
+> Permission levels are defined by SharePoint Online administrators from SharePoint Online Administration Center.  
 
 ```yaml
 Type: String[]

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteOffice365Group.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteOffice365Group.md
@@ -32,7 +32,7 @@ Set-SPOSiteOffice365Group
 
 ## DESCRIPTION
 
-Connects a top-level SPO site collection to a new Office 365 Group.  You must be a SharePoint Online administrator to run the cmdlet.
+Connects a top-level SPO site collection to a new Office 365 Group.  You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 > [!IMPORTANT]
 > This cmdlet is currently in preview and is subject to change. It is not currently supported for use in production environments.

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteOffice365Group.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSiteOffice365Group.md
@@ -32,7 +32,7 @@ Set-SPOSiteOffice365Group
 
 ## DESCRIPTION
 
-Connects a top-level SPO site collection to a new Office 365 Group.  You must be a SharePoint Online global administrator to run the cmdlet.
+Connects a top-level SPO site collection to a new Office 365 Group.  You must be a SharePoint Online administrator to run the cmdlet.
 
 > [!IMPORTANT]
 > This cmdlet is currently in preview and is subject to change. It is not currently supported for use in production environments.

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -102,7 +102,7 @@ Set-SPOTenant [-ApplyAppEnforcedRestrictionsToAdHocRecipients <Boolean>]
 You can use the `Set-SPOTenant` cmdlet to enable external services and to specify the versions in which site collections can be created.
 You can also use the `Set-SPOSite` cmdlet together with the `Set-SPOTenant` cmdlet to block access to a site in your organization and redirect traffic to another site.
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 ## EXAMPLES
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -102,7 +102,7 @@ Set-SPOTenant [-ApplyAppEnforcedRestrictionsToAdHocRecipients <Boolean>]
 You can use the `Set-SPOTenant` cmdlet to enable external services and to specify the versions in which site collections can be created.
 You can also use the `Set-SPOSite` cmdlet together with the `Set-SPOTenant` cmdlet to block access to a site in your organization and redirect traffic to another site.
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 ## EXAMPLES
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantSyncClientRestriction.md
@@ -46,7 +46,7 @@ Set-SPOTenantSyncClientRestriction [-GrooveBlockOption <String>] [<CommonParamet
 
 This cmdlet contains more than one parameter set. You may only use parameters from one parameter set, and you may not combine parameters from different parameter sets. For more information about how to use parameter sets, see [Cmdlet Parameter Sets](https://msdn.microsoft.com/library/dd878348(VS.85).aspx).
 
-You must be a SharePoint Online administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 Requires a valid Connect-SPOService context to identify the tenant. For information on how to connect to the tenant, see [Connect-SPOService](Connect-SPOService.md)
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantSyncClientRestriction.md
@@ -46,7 +46,7 @@ Set-SPOTenantSyncClientRestriction [-GrooveBlockOption <String>] [<CommonParamet
 
 This cmdlet contains more than one parameter set. You may only use parameters from one parameter set, and you may not combine parameters from different parameter sets. For more information about how to use parameter sets, see [Cmdlet Parameter Sets](https://msdn.microsoft.com/library/dd878348(VS.85).aspx).
 
-You must be a SharePoint Online global administrator to run the cmdlet.
+You must be a SharePoint Online administrator to run the cmdlet.
 
 Requires a valid Connect-SPOService context to identify the tenant. For information on how to connect to the tenant, see [Connect-SPOService](Connect-SPOService.md)
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Test-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Test-SPOSite.md
@@ -28,7 +28,7 @@ The `Test-SPOSite` cmdlet runs one or all site collection health checks on the s
 Tests are intended not to make any changes except in repair mode, which can be initiated by running the `Repair-SPOSite` cmdlet.
 This cmdlet reports the rules together with a summary of the results.
 
-You must be a SharePoint Online global administrator to run the `Test-SPOSite` cmdlet.
+You must be a SharePoint Online administrator to run the `Test-SPOSite` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Test-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Test-SPOSite.md
@@ -28,7 +28,7 @@ The `Test-SPOSite` cmdlet runs one or all site collection health checks on the s
 Tests are intended not to make any changes except in repair mode, which can be initiated by running the `Repair-SPOSite` cmdlet.
 This cmdlet reports the rules together with a summary of the results.
 
-You must be a SharePoint Online administrator to run the `Test-SPOSite` cmdlet.
+You must be a SharePoint Online administrator or Global Administrator to run the `Test-SPOSite` cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Upgrade-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Upgrade-SPOSite.md
@@ -32,7 +32,7 @@ When upgrade is initiated, it can either be a build-to-build or version-to-versi
 The default is build-to-build upgrade.
 When in version-to-version upgrade, site collection health checks are first run in repair mode to ensure that the site collection can be upgraded successfully.
 
-You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator or Global Administrator and be a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Upgrade-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Upgrade-SPOSite.md
@@ -32,7 +32,7 @@ When upgrade is initiated, it can either be a build-to-build or version-to-versi
 The default is build-to-build upgrade.
 When in version-to-version upgrade, site collection health checks are first run in repair mode to ensure that the site collection can be upgraded successfully.
 
-You must be a SharePoint Online global administrator and a site collection administrator to run the cmdlet.
+You must be a SharePoint Online administrator and a site collection administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at <https://go.microsoft.com/fwlink/p/?LinkId=251832> (<https://go.microsoft.com/fwlink/p/?LinkId=251832).>
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/office-docs-powershell/issues/5482

_SharePoint Online global administrator_

 role does not exists from available roles.