### PR TITLE
Adding Commandlets for Cached Structural Navigation

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheSiteState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheSiteState.md
@@ -1,0 +1,73 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Get-SPOStructuralNavigationCacheSiteState
+
+## SYNOPSIS
+Get the structural navigation caching state for a site collection.
+
+## SYNTAX
+
+```
+Get-SPOStructuralNavigationCacheSiteState -SiteUrl <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-SPOStructuralNavigationCacheSiteState cmdlet can be used to determine if structural navigation caching is enabled or disabled for a site collection. [Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-SPOStructuralNavigationCacheSiteState -weburl "https://contoso.sharepoint.com/sites/product/" 
+```
+
+This example checks if structural navigation caching is enabled for the entire site collection https://contoso.sharepoint.com/sites/product/. If caching is enabled, then it will return True. If caching is disabled, then it will return False. 
+
+## PARAMETERS
+
+### -SiteUrl
+Specifies the absolute URL for the site collection's root web being checked for its caching state. 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+    To see the examples, type: "get-help Get-SPOStructuralNavigationCacheSiteState -examples". 
+
+    For more information, type: "get-help Get-SPOStructuralNavigationCacheSiteState -detailed". 
+
+    For technical information, type: "get-help Get-SPOStructuralNavigationCacheSiteState -full". 
+
+    For online help, type: "get-help Get-SPOStructuralNavigationCacheSiteState -online" 
+
+ 
+## RELATED LINKS
+Get-SPOStructuralNavigationCacheWebState 
+
+Set-SPOStructuralNavigationCacheWebState 
+
+Set-SPOStructuralNavigationCacheSiteState 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheSiteState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheSiteState.md
@@ -7,6 +7,7 @@ applicable: SharePoint Online
 title: Get-SPOStructuralNavigationCacheSiteState
 author: paramveersisodia
 ms.author: paramsis
+manager: suyog
 ms.reviewer:
 ---
 
@@ -42,7 +43,7 @@ Specifies the absolute URL for the site collection's root web being checked for 
 Type: String
 Parameter Sets: (All)
 Aliases:
-
+Applicable: SharePoint Online
 Required: True
 Position: Named
 Default value: None

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheSiteState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheSiteState.md
@@ -3,6 +3,11 @@ external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
 online version:
 schema: 2.0.0
+applicable: SharePoint Online
+title: Get-SPOStructuralNavigationCacheSiteState
+author: paramveersisodia
+ms.author: paramsis
+ms.reviewer:
 ---
 
 # Get-SPOStructuralNavigationCacheSiteState
@@ -17,7 +22,7 @@ Get-SPOStructuralNavigationCacheSiteState -SiteUrl <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-SPOStructuralNavigationCacheSiteState cmdlet can be used to determine if structural navigation caching is enabled or disabled for a site collection. [Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+The Get-SPOStructuralNavigationCacheSiteState cmdlet can be used to determine if structural navigation caching is enabled or disabled for a site collection. [Learn more](https://support.office.com/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
 
 ## EXAMPLES
 
@@ -66,8 +71,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
  
 ## RELATED LINKS
-Get-SPOStructuralNavigationCacheWebState 
+[Get-SPOStructuralNavigationCacheWebState](Get-SPOStructuralNavigationCacheWebState.md)
 
-Set-SPOStructuralNavigationCacheWebState 
+[Set-SPOStructuralNavigationCacheWebState](Set-SPOStructuralNavigationCacheWebState.md)
 
-Set-SPOStructuralNavigationCacheSiteState 
+[Set-SPOStructuralNavigationCacheSiteState](Set-SPOStructuralNavigationCacheSiteState.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheWebState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheWebState.md
@@ -7,6 +7,7 @@ applicable: SharePoint Online
 title: Get-SPOStructuralNavigationCacheWebState
 author: paramveersisodia
 ms.author: paramsis
+manager: suyog
 ms.reviewer:
 ---
 
@@ -42,7 +43,7 @@ Specifies the absolute URL for the web being checked for its caching state.
 Type: String
 Parameter Sets: (All)
 Aliases:
-
+Applicable: SharePoint Online
 Required: True
 Position: Named
 Default value: None

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheWebState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheWebState.md
@@ -1,0 +1,71 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Get-SPOStructuralNavigationCacheWebState
+
+## SYNOPSIS
+Get the structural navigation caching state for a web. 
+
+## SYNTAX
+
+```
+Get-SPOStructuralNavigationCacheWebState -WebUrl <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-SPOStructuralNavigationCacheWebState cmdlet can be used to determine if structural navigation caching is enabled or disabled for a web in a site collection. [Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-SPOStructuralNavigationCacheWebState -weburl "https://contoso.sharepoint.com/sites/product/electronics" 
+```
+
+This example checks if structural navigation caching is enabled for the web https://contoso.sharepoint.com/sites/product/electronics. If caching is enabled, then it will return True. If caching is disabled, then it will return False.
+
+## PARAMETERS
+
+### -WebUrl
+Specifies the absolute URL for the web being checked for its caching state.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+    To see the examples, type: "get-help Get-SPOStructuralNavigationCacheWebState -examples". 
+
+    For more information, type: "get-help Get-SPOStructuralNavigationCacheWebState -detailed". 
+
+    For technical information, type: "get-help Get-SPOStructuralNavigationCacheWebState -full". 
+
+    For online help, type: "get-help Get-SPOStructuralNavigationCacheWebState -online" 
+## RELATED LINKS
+Set-SPOStructuralNavigationCacheWebState 
+
+Get-SPOStructuralNavigationCacheSiteState 
+
+Set-SPOStructuralNavigationCacheSiteState 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheWebState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOStructuralNavigationCacheWebState.md
@@ -3,6 +3,11 @@ external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
 online version:
 schema: 2.0.0
+applicable: SharePoint Online
+title: Get-SPOStructuralNavigationCacheWebState
+author: paramveersisodia
+ms.author: paramsis
+ms.reviewer:
 ---
 
 # Get-SPOStructuralNavigationCacheWebState
@@ -17,7 +22,7 @@ Get-SPOStructuralNavigationCacheWebState -WebUrl <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-SPOStructuralNavigationCacheWebState cmdlet can be used to determine if structural navigation caching is enabled or disabled for a web in a site collection. [Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+The Get-SPOStructuralNavigationCacheWebState cmdlet can be used to determine if structural navigation caching is enabled or disabled for a web in a site collection. [Learn more](https://support.office.com/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
 
 ## EXAMPLES
 
@@ -64,8 +69,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
     For online help, type: "get-help Get-SPOStructuralNavigationCacheWebState -online" 
 ## RELATED LINKS
-Set-SPOStructuralNavigationCacheWebState 
+[Set-SPOStructuralNavigationCacheWebState](Set-SPOStructuralNavigationCacheWebState.md)
 
-Get-SPOStructuralNavigationCacheSiteState 
+[Get-SPOStructuralNavigationCacheSiteState](Get-SPOStructuralNavigationCacheSiteState.md)
 
-Set-SPOStructuralNavigationCacheSiteState 
+[Set-SPOStructuralNavigationCacheSiteState](Set-SPOStructuralNavigationCacheSiteState.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheSiteState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheSiteState.md
@@ -7,6 +7,7 @@ applicable: SharePoint Online
 title: Set-SPOStructuralNavigationCacheSiteState
 author: paramveersisodia
 ms.author: paramsis
+manager: suyog
 ms.reviewer:
 ---
 
@@ -49,7 +50,7 @@ $true to enable caching, $false to disable caching.
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-
+Applicable: SharePoint Online
 Required: True
 Position: Named
 Default value: None
@@ -64,7 +65,7 @@ Specifies the absolute URL for the site collection's root web that needs its cac
 Type: String
 Parameter Sets: (All)
 Aliases:
-
+Applicable: SharePoint Online
 Required: True
 Position: Named
 Default value: None

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheSiteState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheSiteState.md
@@ -1,0 +1,97 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Set-SPOStructuralNavigationCacheSiteState
+
+## SYNOPSIS
+Enable or disable caching for all webs in a site collection. 
+
+## SYNTAX
+
+```
+Set-SPOStructuralNavigationCacheSiteState -SiteUrl <String> -IsEnabled <Boolean> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-SPOStructuralNavigationCacheSiteState cmdlet can be used to enable or disable caching for all webs in a site collection.[Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-SPOStructuralNavigationCacheSiteState –IsEnabled $true -SiteUrl "https://contoso.sharepoint.com/sites/product/" 
+```
+
+This example enables caching for all webs in the site collection https://contoso.sharepoint.com/sites/product/. 
+
+### Example 2
+```powershell
+PS C:\> Set-SPOStructuralNavigationCacheSiteState –IsEnabled $false -SiteUrl "https://contoso.sharepoint.com/sites/product/"  
+```
+
+This example disables caching for all webs in the site collection https://contoso.sharepoint.com/sites/product/. 
+
+## PARAMETERS
+
+### -IsEnabled
+$true to enable caching, $false to disable caching. 
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SiteUrl
+Specifies the absolute URL for the site collection's root web that needs its caching state to be set. 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+    To see the examples, type: "get-help Set-SPOStructuralNavigationCacheSiteState -examples". 
+
+    For more information, type: "get-help Set-SPOStructuralNavigationCacheSiteState -detailed". 
+
+    For technical information, type: "get-help Set-SPOStructuralNavigationCacheSiteState -full". 
+
+    For online help, type: "get-help Set-SPOStructuralNavigationCacheSiteState -online" 
+
+ 
+## RELATED LINKS
+Get-SPOStructuralNavigationCacheWebState 
+
+Set-SPOStructuralNavigationCacheWebState 
+
+Get-SPOStructuralNavigationCacheSiteState 
+
+ 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheSiteState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheSiteState.md
@@ -3,6 +3,11 @@ external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
 online version:
 schema: 2.0.0
+applicable: SharePoint Online
+title: Set-SPOStructuralNavigationCacheSiteState
+author: paramveersisodia
+ms.author: paramsis
+ms.reviewer:
 ---
 
 # Set-SPOStructuralNavigationCacheSiteState
@@ -17,7 +22,7 @@ Set-SPOStructuralNavigationCacheSiteState -SiteUrl <String> -IsEnabled <Boolean>
 ```
 
 ## DESCRIPTION
-The Set-SPOStructuralNavigationCacheSiteState cmdlet can be used to enable or disable caching for all webs in a site collection.[Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+The Set-SPOStructuralNavigationCacheSiteState cmdlet can be used to enable or disable caching for all webs in a site collection. [Learn more](https://support.office.com/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
 
 ## EXAMPLES
 
@@ -88,10 +93,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
  
 ## RELATED LINKS
-Get-SPOStructuralNavigationCacheWebState 
+[Get-SPOStructuralNavigationCacheWebState](Get-SPOStructuralNavigationCacheWebState.md)
 
-Set-SPOStructuralNavigationCacheWebState 
+[Set-SPOStructuralNavigationCacheWebState](Set-SPOStructuralNavigationCacheWebState.md)
 
-Get-SPOStructuralNavigationCacheSiteState 
-
+[Get-SPOStructuralNavigationCacheSiteState](Get-SPOStructuralNavigationCacheSiteState.md)
  

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheWebState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheWebState.md
@@ -7,6 +7,7 @@ applicable: SharePoint Online
 title: Set-SPOStructuralNavigationCacheWebState
 author: paramveersisodia
 ms.author: paramsis
+manager: suyog
 ms.reviewer:
 ---
 
@@ -48,7 +49,7 @@ $true to enable caching, $false to disable caching.
 Type: Boolean
 Parameter Sets: (All)
 Aliases:
-
+Applicable: SharePoint Online
 Required: True
 Position: Named
 Default value: None
@@ -63,7 +64,7 @@ Specifies the absolute URL for the web that needs its caching state to be set.
 Type: String
 Parameter Sets: (All)
 Aliases:
-
+Applicable: SharePoint Online
 Required: True
 Position: Named
 Default value: None

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheWebState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheWebState.md
@@ -1,0 +1,93 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Set-SPOStructuralNavigationCacheWebState
+
+## SYNOPSIS
+Enable or disable caching for a web in a site collection. 
+
+## SYNTAX
+
+```
+Set-SPOStructuralNavigationCacheWebState -WebUrl <String> -IsEnabled <Boolean> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-SPOStructuralNavigationCacheWebState cmdlet can be used to enable or disable caching for a web in a site collection.[Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-SPOStructuralNavigationCacheWebState -IsEnabled $true -WebUrl "https://contoso.sharepoint.com/sites/product/electronics" 
+```
+
+This example enables caching for the web https://contoso.sharepoint.com/sites/product/electronics. 
+
+### Example 2
+```powershell
+Set-SPOStructuralNavigationCacheWebState -IsEnabled $false -WebUrl "https://contoso.sharepoint.com/sites/product/electronics" 
+```
+
+This example disables caching for the web https://contoso.sharepoint.com/sites/product/electronics. 
+## PARAMETERS
+
+### -IsEnabled
+$true to enable caching, $false to disable caching. 
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WebUrl
+Specifies the absolute URL for the web that needs its caching state to be set. 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+    To see the examples, type: "get-help Set-SPOStructuralNavigationCacheWebState -examples". 
+
+    For more information, type: "get-help Set-SPOStructuralNavigationCacheWebState -detailed". 
+
+    For technical information, type: "get-help Set-SPOStructuralNavigationCacheWebState -full". 
+
+    For online help, type: "get-help Set-SPOStructuralNavigationCacheWebState -online" 
+    
+## RELATED LINKS
+Get-SPOStructuralNavigationCacheWebState 
+
+Get-SPOStructuralNavigationCacheSiteState 
+
+Set-SPOStructuralNavigationCacheSiteState 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheWebState.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOStructuralNavigationCacheWebState.md
@@ -3,6 +3,11 @@ external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
 online version:
 schema: 2.0.0
+applicable: SharePoint Online
+title: Set-SPOStructuralNavigationCacheWebState
+author: paramveersisodia
+ms.author: paramsis
+ms.reviewer:
 ---
 
 # Set-SPOStructuralNavigationCacheWebState
@@ -17,7 +22,7 @@ Set-SPOStructuralNavigationCacheWebState -WebUrl <String> -IsEnabled <Boolean> [
 ```
 
 ## DESCRIPTION
-The Set-SPOStructuralNavigationCacheWebState cmdlet can be used to enable or disable caching for a web in a site collection.[Learn more](https://support.office.com/en-us/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
+The Set-SPOStructuralNavigationCacheWebState cmdlet can be used to enable or disable caching for a web in a site collection. [Learn more](https://support.office.com/article/structural-navigation-and-performance-f163053f-8eca-4b9c-b973-36b395093b43). 
 
 ## EXAMPLES
 
@@ -86,8 +91,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
     For online help, type: "get-help Set-SPOStructuralNavigationCacheWebState -online" 
     
 ## RELATED LINKS
-Get-SPOStructuralNavigationCacheWebState 
+[Get-SPOStructuralNavigationCacheWebState](Get-SPOStructuralNavigationCacheWebState.md)
 
-Get-SPOStructuralNavigationCacheSiteState 
+[Get-SPOStructuralNavigationCacheSiteState](Get-SPOStructuralNavigationCacheSiteState.md)
 
-Set-SPOStructuralNavigationCacheSiteState 
+[Set-SPOStructuralNavigationCacheSiteState](Set-SPOStructuralNavigationCacheSiteState.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/sharepoint-online.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/sharepoint-online.md
@@ -191,6 +191,14 @@ The following cmdlet references are for SharePoint Online.
 
 {{Manually Enter Get-SPOSiteScript Description Here}}
 
+### [Get-SPOStructuralNavigationCacheSiteState](Get-SPOStructuralNavigationCacheSiteState.md)
+
+{{Manually Enter Get-SPOSiteScript Description Here}}
+
+### [Get-SPOStructuralNavigationCacheWebState](Get-SPOStructuralNavigationCacheWebState.md)
+
+{{Manually Enter Get-SPOSiteScript Description Here}}
+
 ### [Get-SPOTenant](Get-SPOTenant.md)
 
 {{Manually Enter Get-SPOTenant Description Here}}
@@ -456,6 +464,14 @@ The following cmdlet references are for SharePoint Online.
 {{Manually Enter Set-SPOSiteGroup Description Here}}
 
 ### [Set-SPOSiteScript](Set-SPOSiteScript.md)
+
+{{Manually Enter Set-SPOSiteScript Description Here}}
+
+### [Set-SPOStructuralNavigationCacheSiteState](Set-SPOStructuralNavigationCacheSiteState.md)
+
+{{Manually Enter Set-SPOSiteScript Description Here}}
+
+### [Set-SPOStructuralNavigationCacheWebState](Set-SPOStructuralNavigationCacheWebState.md)
 
 {{Manually Enter Set-SPOSiteScript Description Here}}
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/sharepoint-online.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/sharepoint-online.md
@@ -193,11 +193,11 @@ The following cmdlet references are for SharePoint Online.
 
 ### [Get-SPOStructuralNavigationCacheSiteState](Get-SPOStructuralNavigationCacheSiteState.md)
 
-{{Manually Enter Get-SPOSiteScript Description Here}}
+{{Manually Enter Get-SPOStructuralNavigationCacheSiteState Description Here}}
 
 ### [Get-SPOStructuralNavigationCacheWebState](Get-SPOStructuralNavigationCacheWebState.md)
 
-{{Manually Enter Get-SPOSiteScript Description Here}}
+{{Manually Enter Get-SPOStructuralNavigationCacheWebState Description Here}}
 
 ### [Get-SPOTenant](Get-SPOTenant.md)
 
@@ -469,11 +469,11 @@ The following cmdlet references are for SharePoint Online.
 
 ### [Set-SPOStructuralNavigationCacheSiteState](Set-SPOStructuralNavigationCacheSiteState.md)
 
-{{Manually Enter Set-SPOSiteScript Description Here}}
+{{Manually Enter Set-SPOStructuralNavigationCacheSiteState Description Here}}
 
 ### [Set-SPOStructuralNavigationCacheWebState](Set-SPOStructuralNavigationCacheWebState.md)
 
-{{Manually Enter Set-SPOSiteScript Description Here}}
+{{Manually Enter Set-SPOStructuralNavigationCacheWebState Description Here}}
 
 ### [Set-SPOTenant](Set-SPOTenant.md)
 


### PR DESCRIPTION
These commandlets allow tenant admins to enable/disable caching for webs where structural navigation is enabled to boost page load performance