### PR TITLE
Update Set-CsCallQueue.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsCallQueue.md
+++ b/skype/skype-ps/skype/Set-CsCallQueue.md
@@ -40,10 +40,10 @@ This example updates the Call Queue with identity e7e00636-47da-449c-a36b-1b3d6e
 
 ### -------------------------- Example 2 -------------------------- 
 ```
-Set-CsCallQueue -Identity e7e00636-47da-449c-a36b-1b3d6ee04440 -DistributionLists @("8521b0e3-51bd-4a4b-a8d6-b219a77a0a6a", "868dccd8-d723-4b4f-8d74-ab59e207c357") -MusicOnHoldAudioFileId 4d7361c1-5b46-4f69-b125-cf35a098a341
+Set-CsCallQueue -Identity e7e00636-47da-449c-a36b-1b3d6ee04440 -DistributionLists @("8521b0e3-51bd-4a4b-a8d6-b219a77a0a6a", "868dccd8-d723-4b4f-8d74-ab59e207c357") -MusicOnHoldAudioFileId $audioFile.Id
 ```
 
-This example updates the Call Queue with new distribution lists and references a new music on hold audio file.
+This example updates the Call Queue with new distribution lists and references a new music on hold audio file using the audio file ID  from the stored variable $audioFile created with the [Import-CsOnlineAudioFile cmdlet](https://docs.microsoft.com/en-us/powershell/module/skype/import-csonlineaudiofile?view=skype-ps)
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Set-CsCallQueue.md
+++ b/skype/skype-ps/skype/Set-CsCallQueue.md
@@ -43,7 +43,7 @@ This example updates the Call Queue with identity e7e00636-47da-449c-a36b-1b3d6e
 Set-CsCallQueue -Identity e7e00636-47da-449c-a36b-1b3d6ee04440 -DistributionLists @("8521b0e3-51bd-4a4b-a8d6-b219a77a0a6a", "868dccd8-d723-4b4f-8d74-ab59e207c357") -MusicOnHoldAudioFileId $audioFile.Id
 ```
 
-This example updates the Call Queue with new distribution lists and references a new music on hold audio file using the audio file ID  from the stored variable $audioFile created with the [Import-CsOnlineAudioFile cmdlet](https://docs.microsoft.com/en-us/powershell/module/skype/import-csonlineaudiofile?view=skype-ps)
+This example updates the Call Queue with new distribution lists and references a new music on hold audio file using the audio file ID  from the stored variable $audioFile created with the [Import-CsOnlineAudioFile cmdlet](https://docs.microsoft.com/powershell/module/skype/import-csonlineaudiofile)
 
 ## PARAMETERS
 


### PR DESCRIPTION
@kenwith cc: @roykuntz 

Updating the cmdlet sample for setting music on hold to use stored variable for the audio file ID. This is the only way to do this because there is no Get cmdlet to retrieve stored files. Also added reference to the Import-CsOnlineAudioFile cmdlet which shows using a stored variable when creating but not why or how to use it. Will add a note on that page as well to cross reference back to here.