### PR TITLE
Remove wildcard support on Get-EXOCasMailbox.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-EXOCasMailbox.md
+++ b/exchange/exchange-ps/exchange/Get-EXOCasMailbox.md
@@ -209,7 +209,7 @@ Accept wildcard characters: False
 ```
 
 ### -Properties
-The Properties parameter specifies the properties that are returned in the output of this cmdlet. You can specify multiple values separated by commas. Wildcards ( * ) are supported.
+The Properties parameter specifies the properties that are returned in the output of this cmdlet. You can specify multiple values separated by commas.
 
 For more information about the available properties, see [Get-EXOCasMailbox property sets](https://docs.microsoft.com/powershell/exchange/exchange-online/exchange-online-powershell-v2/cmdlet-property-sets#get-exocasmailbox-property-sets).
 
@@ -245,7 +245,7 @@ The PropertySets parameter specifies a logical grouping of properties that are r
 
 - All
 
-You can specify multiple values separated by commas. Wildcards ( * ) are supported.
+You can specify multiple values separated by commas.
 
 For more information about the properties that are included in each property set, see [Get-EXOCasMailbox property sets](https://docs.microsoft.com/powershell/exchange/exchange-online/exchange-online-powershell-v2/cmdlet-property-sets#get-exocasmailbox-property-sets).
 


### PR DESCRIPTION
https://github.com/MicrosoftDocs/office-docs-powershell/issues/5644

Wildcard are not working on -Properties and -Propertysets parameters:
![image](https://user-images.githubusercontent.com/33589238/82674468-b996ba80-9c19-11ea-8769-6877285a8a3a.png)
![image](https://user-images.githubusercontent.com/33589238/82674523-d03d1180-9c19-11ea-998a-6def60700095.png)
