### PR TITLE
Added AllowNDIStreaming parameter to Set/New-CsTeamsMeetingPolicy

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -26,7 +26,7 @@ New-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
  [-AllowSharedNotes <Boolean>] [-AllowWhiteboard <Boolean>] [-AllowTranscription <Boolean>]
  [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-PreferredMeetingProviderForIslandsMode <String>]
  [-VideoFiltersMode <String>] [-Identity] <XdsIdentity> [-AllowEngagementReport <String>]
- [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-AllowNDIStreaming <Boolean>] [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -466,6 +466,21 @@ Accept wildcard characters: False
 
 ### -AllowEngagementReport
 Determines whether users are allowed to download the attendee engagement report. Set this to Enabled to allow the user to download the report. Set this to Disabled to prohibit the user to download it.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowNDIStreaming
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -483,7 +483,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: String
+Type: Boolean
 Parameter Sets: (All)
 Aliases:
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -563,7 +563,7 @@ Accept wildcard characters: False
 This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: String
+Type: Boolean
 Parameter Sets: (All)
 Aliases:
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -29,8 +29,8 @@ Set-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
  [-AllowSharedNotes <Boolean>] [-AllowWhiteboard <Boolean>] [-AllowTranscription <Boolean>]
  [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-AllowPSTNUsersToBypassLobby <Boolean>]
  [-PreferredMeetingProviderForIslandsMode <string>] [[-Identity] <XdsIdentity>]
- [-VideoFiltersMode <String>] [-AllowEngagementReport <String>] [-Force] [-WhatIf] [-Confirm] 
- [<CommonParameters>]
+ [-VideoFiltersMode <String>] [-AllowEngagementReport <String>] [-AllowNDIStreaming <Boolean>]
+ [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Instance
@@ -45,8 +45,8 @@ Set-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
  [-AllowSharedNotes <Boolean>] [-AllowWhiteboard <Boolean>] [-AllowTranscription <Boolean>]
  [-MediaBitRateKb <UInt32>] [-ScreenSharingMode <String>] [-AllowPSTNUsersToBypassLobby <Boolean>]
  [-PreferredMeetingProviderForIslandsMode <string>] [-Instance <PSObject>] 
- [-VideoFiltersMode <String>] [-AllowEngagementReport <String>] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-VideoFiltersMode <String>] [-AllowEngagementReport <String>] [-AllowNDIStreaming <Boolean>]
+ [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -546,6 +546,21 @@ Accept wildcard characters: False
 
 ### -AllowEngagementReport
 Determines whether users are allowed to download the attendee engagement report. Set this to Enabled to allow the user to download the report. Set this to Disabled to prohibit the user to download it.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowNDIStreaming
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String


### PR DESCRIPTION
https://github.com/MicrosoftDocs/office-docs-powershell/issues/5652

If you try to run this parameter you get "You are not permitted to invoke Set-CsTeamsMeetingPolicy with the following parameters: AllowNDIStreaming".
The same for New-CsTeamsMeetingPolicy.