### PR TITLE
Updated WinRM requirements to connect to EXO

### DIFF
--- a/exchange/docs-conceptual/exchange-eop/connect-to-exchange-online-protection-powershell.md
+++ b/exchange/docs-conceptual/exchange-eop/connect-to-exchange-online-protection-powershell.md
@@ -50,15 +50,12 @@ In standalone Exchange Online Protection (EOP) organizations without Exchange On
   Set-ExecutionPolicy RemoteSigned
   ```
 
-- Windows Remote Management (WinRM) needs to be enabled (it's not enabled by default in Windows 7, 8.1 and 10). To enable it, run this command **in a Command Prompt**:
-
-  ```dos
-  winrm quickconfig
-  ```
-
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:
+  
+  > [!NOTE]
+  > You must temporarily enable WinRM to run the following commands. You can enable it by running "winrm quickconfig".
 
   ```dos
   winrm get winrm/config/client/auth

--- a/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/connect-to-exchange-online-powershell.md
@@ -57,15 +57,12 @@ Exchange Online PowerShell allows you to manage your Exchange Online settings fr
   Set-ExecutionPolicy RemoteSigned
   ```
 
-- Windows Remote Management (WinRM) needs to be enabled (it's not enabled by default in Windows 7, 8.1 and 10). To enable it, run this command **in a Command Prompt**:
-
-  ```dos
-  winrm quickconfig
-  ```
-
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:
+  
+  > [!NOTE]
+  > You must temporarily enable WinRM to run the following commands. You can enable it by running "winrm quickconfig".
 
   ```dos
   winrm get winrm/config/client/auth

--- a/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md
@@ -42,15 +42,12 @@ If you want to use multi-factor authentication (MFA) to connect to Exchange Onli
 
   <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Installing the .NET Framework](https://go.microsoft.com/fwlink/p/?LinkId=257868), [Windows Management Framework 3.0](https://go.microsoft.com/fwlink/p/?LinkId=272757), [Windows Management Framework 4.0](https://go.microsoft.com/fwlink/p/?LinkId=391344), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
-- Windows Remote Management (WinRM) needs to be enabled (it's not enabled by default in Windows 7, 8.1 and 10). To enable it, run this command **in a Command Prompt**:
-
-  ```dos
-  winrm quickconfig
-  ```
-
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:
+  
+  > [!NOTE]
+  > You must temporarily enable WinRM to run the following commands. You can enable it by running "winrm quickconfig".
 
   ```dos
   winrm get winrm/config/client/auth

--- a/exchange/docs-conceptual/exchange-online/exchange-online-powershell-v2/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online/exchange-online-powershell-v2/exchange-online-powershell-v2.md
@@ -84,12 +84,6 @@ You can download the EXO V2 module from the PowerShell gallery [here](https://ww
 
   <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then the Windows Management Framework 5.1. For more information, see [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
-- Windows Remote Management (WinRM) needs to be enabled (it's not enabled by default in Windows 7, 8.1 and 10). To enable it, run this command **in a Command Prompt**:
-
-  ```dos
-  winrm quickconfig
-  ```
-
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:

--- a/exchange/docs-conceptual/exchange-online/exchange-online-powershell-v2/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online/exchange-online-powershell-v2/exchange-online-powershell-v2.md
@@ -87,6 +87,9 @@ You can download the EXO V2 module from the PowerShell gallery [here](https://ww
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:
+  
+  > [!NOTE]
+  > You must temporarily enable WinRM to run the following commands. You can enable it by running "winrm quickconfig".
 
   ```dos
   winrm get winrm/config/client/auth

--- a/exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/connect-to-scc-powershell.md
@@ -56,15 +56,12 @@ For more information about the Security & Compliance Center, see [Security & Com
   Set-ExecutionPolicy RemoteSigned
   ```
 
-- Windows Remote Management (WinRM) needs to be enabled (it's not enabled by default in Windows 7, 8.1 and 10). To enable it, run this command **in a Command Prompt**:
-
-  ```dos
-  winrm quickconfig
-  ```
-
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:
+  
+  > [!NOTE]
+  > You must temporarily enable WinRM to run the following commands. You can enable it by running "winrm quickconfig".
 
   ```dos
   winrm get winrm/config/client/auth

--- a/exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/mfa-connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/mfa-connect-to-scc-powershell.md
@@ -42,15 +42,12 @@ If your account uses multi-factor authentication (MFA) or federated authenticati
 
   <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Installing the .NET Framework](https://go.microsoft.com/fwlink/p/?LinkId=257868), [Windows Management Framework 3.0](https://go.microsoft.com/fwlink/p/?LinkId=272757), [Windows Management Framework 4.0](https://go.microsoft.com/fwlink/p/?LinkId=391344), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
-- Windows Remote Management (WinRM) needs to be enabled (it's not enabled by default in Windows 7, 8.1 and 10). To enable it, run this command **in a Command Prompt**:
-
-  ```dos
-  winrm quickconfig
-  ```
-
 - WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt**:
+  
+  > [!NOTE]
+  > You must temporarily enable WinRM to run the following commands. You can enable it by running "winrm quickconfig".
 
   ```dos
   winrm get winrm/config/client/auth


### PR DESCRIPTION
https://github.com/MicrosoftDocs/office-docs-powershell/issues/5765
https://github.com/MicrosoftDocs/office-docs-powershell/issues/5515

WinRM is not required, it could be disabled. WinRM basic auth must be enabled, but you cannot run "winrm get" and "winrm set" if WinRM is disabled.

Tested it on a new Win 10 machine, I can connect to EXO PS without any intervention. WinRM was disabled but WinRM basic auth was enabled. I couldn´t run "winrm get" and "winrm set".

Tested it on a new Win 8.1 machine, I can connect to EXO PS  without any intervention. WinRM was enabled and WinRM basic auth was enabled. I can run "winrm get" and "winrm set".

I´m thinking that we can also move "If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:" between the first sentence about WinRM basic auth and the second sentence because it´s enabled by default.

Maybe something like:

- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.

  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:

  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.

  To enable Basic authentication for WinRM, run the following commands **in a Command Prompt**:

  ```dos
  winrm quickconfig
  winrm set winrm/config/client/auth @{Basic="true"}
  ```

  > Note: WinRM service can be disabled after you enable Basic authentication.

What do you think @chrisda?