### PR TITLE
Remove incorrect note about empty "password key"

### DIFF
--- a/exchange/exchange-ps/exchange/Connect-ExchangeOnline.md
+++ b/exchange/exchange-ps/exchange/Connect-ExchangeOnline.md
@@ -56,7 +56,7 @@ Connect-ExchangeOnline -Credential $UserCredential
 
 The first command gets the user credentials and stores them in the $UserCredential variable.
 
-The second command connects the current PowerShell session using the credentials in the $UserCredential, which isn't MFA enabled. Note that after the second command is complete, the password key in the $UserCredential variable becomes empty.
+The second command connects the current PowerShell session using the credentials in the $UserCredential, which isn't MFA enabled.
 
 After the Connect-ExchangeOnline command is successful, you can run ExO V2 module cmdlets and older remote PowerShell cmdlets.
 


### PR DESCRIPTION
Removing this phrase from example 1:

> Note that after the second command is complete, the password key in the $UserCredential variable becomes empty.

It's just... wrong.

Nothing about the `$UserCredential` changes and I wouldn't expect it to (so one can connect to multiple services with one credential object, say SharePoint Online PnP as well as EXO)

![Example to repro password not becoming empty](https://user-images.githubusercontent.com/6955786/83745683-05ce0a00-a6b2-11ea-9fec-1efe7d21d60d.png)
