### PR TITLE
Update Get-MessageTrace.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-MessageTrace.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTrace.md
@@ -44,9 +44,7 @@ Get-MessageTrace
 ## DESCRIPTION
 You can use this cmdlet to search message data for the last 10 days. If you run this cmdlet without any parameters, only data from the last 48 hours is returned.
 
-If you enter a start date that is greater than 10 days and less than or equal to 30 days, only 10 days of data will be returned.
-
-If you enter a start date that is older than 30 days, you will receive an error and the command will return no results.
+If you enter a start date that is older than 10 days, you will receive an error and the command will return no results.
 
 To search for message data that is greater than 10 days old, use the Start-HistoricalSearch and Get-HistoricalSearch cmdlets.
 


### PR DESCRIPTION
The Get-MessageTrace cmdlet was recently changed to only support 10 days of data, as is specified in the "to search for message data that is greater than 10 days old" sentence - but the sentence mentioning data older than 10 but younger than 30 was not removed.

This change is to remove the confusion still left in the documentation.