### PR TITLE
Updated applicable to information for the SystemUpdate switch parameter

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPFolderPermission.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPFolderPermission.md
@@ -168,7 +168,7 @@ Accept pipeline input: False
 ### -SystemUpdate
 Update the folder permissions without creating a new version or triggering MS Flow.
 
-Only applicable to: SharePoint Online
+Only applicable to: SharePoint 2013, SharePoint 2016 and SharePoint 2019
 
 ```yaml
 Type: SwitchParameter

--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPListItem.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPListItem.md
@@ -109,7 +109,7 @@ Accept pipeline input: True
 ### -SystemUpdate
 Update the item without creating a new version.
 
-Only applicable to: SharePoint Online
+Only applicable to: SharePoint 2013, SharePoint 2016 and SharePoint 2019
 
 ```yaml
 Type: SwitchParameter

--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPListItemPermission.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Set-PnPListItemPermission.md
@@ -168,7 +168,7 @@ Accept pipeline input: False
 ### -SystemUpdate
 Update the item permissions without creating a new version or triggering MS Flow.
 
-Only applicable to: SharePoint Online
+Only applicable to: SharePoint 2013, SharePoint 2016 and SharePoint 2019
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Updated the documentation regarding the SystemUpdate switch parameter to clarify that it's only applicable to the On-premises versions of SharePoint and not applicable to SharePoint online.

This PR is intended to resolve issue #5932,