### PR TITLE
Update Remove-TeamUser.md

### DIFF
--- a/teams/teams-ps/teams/Remove-TeamUser.md
+++ b/teams/teams-ps/teams/Remove-TeamUser.md
@@ -39,7 +39,7 @@ In this example, the user "dmx" is removed the role Owner but stays as a team me
 ```
 Remove-TeamUser -GroupId 31f1ff6c-d48c-4f8a-b2e1-abca7fd399df -User dmx@example.com
 ```
-In this example, the user "dmx" is removed from the team.
+In this example, the user "dmx" is removed as an member from the team but the owner rights are still active. You need to run also "example 1" to completely remove the user from the team. 
 
 ## PARAMETERS
 


### PR DESCRIPTION
The documentation is not clear enough, removing a member from the team does not remove the owner rights. You need to combine those commands to completely remove a user from a team. This PR is to update the documentation to make it more clear for people.