### PR TITLE
Fixed Exchange admin role in app-only-auth-powershell-v2.md

### DIFF
--- a/exchange/docs-conceptual/app-only-auth-powershell-v2.md
+++ b/exchange/docs-conceptual/app-only-auth-powershell-v2.md
@@ -103,7 +103,7 @@ For a detailed visual flow bout creating applications in Azure AD, see <https://
    - Security reader
    - Security administrator
    - Helpdesk administrator
-   - Exchange Service administrator
+   - Exchange administrator
    - Global Reader
 
 ## Appendix


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/office-docs-powershell/issues/6079.

"In the Microsoft Graph API and Azure AD PowerShell, this role is identified as "Exchange Service Administrator." It is "Exchange Administrator" in the Azure portal. It is "Exchange Online administrator" in the Exchange admin center."
Source: https://docs.microsoft.com/azure/active-directory/users-groups-roles/directory-assign-admin-roles#exchange-administrator