### PR TITLE
Update filters-v2.md

### DIFF
--- a/exchange/docs-conceptual/filters-v2.md
+++ b/exchange/docs-conceptual/filters-v2.md
@@ -51,6 +51,8 @@ The following operators are fully supported for all string formats in the EXO V2
 - -not
 - -lt
 - -gt
+- -like
+- -notlike
 
 The -like and -notlike operators are limited in using wildcards (*). Specifically, you can only use wildcards at the beginning of a string value, at the end of a string value, or both.
 


### PR DESCRIPTION
Like and Notlike operators have some difference as they are not fully supported in all scenarios i.e. when multiple wildcards are used, they are not supported. As it is mentioned below the operator list.

Please take a call if you would like to highlight those 2 operators differently in the list.