### PR TITLE
Update notes for -EnableUnauthenticatedSender

### DIFF
--- a/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
@@ -368,6 +368,17 @@ The EnableUnauthenticatedSender parameter enables or disables unauthenticate
 
 - $false: Unauthenticated sender identification is disabled.
 
+To prevent these identifiers from being added to messages from specific senders, you have the following options:
+
+  - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](https://docs.microsoft.com/microsoft-365/security/office-365-security/learn-about-spoof-intelligence).
+
+  - [Configure email authentication](https://docs.microsoft.com/microsoft-365/security/office-365-security/email-validation-and-authentication#configure-email-authentication-for-domains-you-own) for the sender domain.
+  
+    - For the question mark in the sender's photo, SPF or DKIM are the most important.
+    - For the via tag, confirm the domain in the DKIM signature or the **MAIL FROM** address matches (or is a subdomain of) the domain in the From address.
+
+  For more information, see [Identify suspicious messages in Outlook.com and Outlook on the web](https://support.microsoft.com/office/3d44102b-6ce3-4f7c-a359-b623bec82206)
+
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
@@ -380,16 +391,6 @@ Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
- To prevent these identifiers from being added to messages from specific senders, you have the following options:
-
-  - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](https://docs.microsoft.com/microsoft-365/security/office-365-security/learn-about-spoof-intelligence).
-
-  - [Configure email authentication](https://docs.microsoft.com/microsoft-365/security/office-365-security/email-validation-and-authentication#configure-email-authentication-for-domains-you-own) for the sender domain.
-  
-    - For the question mark in the sender's photo, SPF or DKIM are the most important.
-    - For the via tag, confirm the domain in the DKIM signature or the **MAIL FROM** address matches (or is a subdomain of) the domain in the From address.
-
-  For more information, see [Identify suspicious messages in Outlook.com and Outlook on the web](https://support.microsoft.com/office/3d44102b-6ce3-4f7c-a359-b623bec82206)
 
 ### -EnableUnusualCharactersSafetyTips
 This setting is part of impersonation protection and is only available in Advanced Threat Protection.

--- a/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
@@ -382,7 +382,7 @@ Accept wildcard characters: False
 ```
  To prevent these identifiers from being added to messages from specific senders, you have the following options:
 
-  - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](learn-about-spoof-intelligence.md).
+  - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](https://docs.microsoft.com/microsoft-365/security/office-365-security/learn-about-spoof-intelligence).
 
   - [Configure email authentication](https://docs.microsoft.com/microsoft-365/security/office-365-security/email-validation-and-authentication#configure-email-authentication-for-domains-you-own) for the sender domain.
   

--- a/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
@@ -380,6 +380,16 @@ Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+ To prevent these identifiers from being added to messages from specific senders, you have the following options:
+
+  - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](learn-about-spoof-intelligence.md).
+
+  - [Configure email authentication](email-validation-and-authentication.md#configure-email-authentication-for-domains-you-own) for the sender domain.
+  
+    - For the question mark in the sender's photo, SPF or DKIM are the most important.
+    - For the via tag, confirm the domain in the DKIM signature or the **MAIL FROM** address matches (or is a subdomain of) the domain in the From address.
+
+  For more information, see [Identify suspicious messages in Outlook.com and Outlook on the web](https://support.microsoft.com/office/3d44102b-6ce3-4f7c-a359-b623bec82206)
 
 ### -EnableUnusualCharactersSafetyTips
 This setting is part of impersonation protection and is only available in Advanced Threat Protection.

--- a/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
@@ -384,7 +384,7 @@ Accept wildcard characters: False
 
   - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](learn-about-spoof-intelligence.md).
 
-  - [Configure email authentication](email-validation-and-authentication.md#configure-email-authentication-for-domains-you-own) for the sender domain.
+  - [Configure email authentication](https://docs.microsoft.com/microsoft-365/security/office-365-security/email-validation-and-authentication#configure-email-authentication-for-domains-you-own) for the sender domain.
   
     - For the question mark in the sender's photo, SPF or DKIM are the most important.
     - For the via tag, confirm the domain in the DKIM signature or the **MAIL FROM** address matches (or is a subdomain of) the domain in the From address.


### PR DESCRIPTION
Notes to be added: 
 To prevent these identifiers from being added to messages from specific senders, you have the following options:

  - Allow the sender to spoof in the spoof intelligence policy. For instructions, see [Configure spoof intelligence in Microsoft 365](learn-about-spoof-intelligence.md).

  - [Configure email authentication](email-validation-and-authentication.md#configure-email-authentication-for-domains-you-own) for the sender domain.
  
    - For the question mark in the sender's photo, SPF or DKIM are the most important.
    - For the via tag, confirm the domain in the DKIM signature or the **MAIL FROM** address matches (or is a subdomain of) the domain in the From address.

  For more information, see [Identify suspicious messages in Outlook.com and Outlook on the web](https://support.microsoft.com/office/3d44102b-6ce3-4f7c-a359-b623bec82206)

The notes that appear on the below documentation also need to be shown on this documentation. 
https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/set-up-anti-phishing-policies?view=o365-worldwide

Customers are confused on the feature otherwise - Ref. customer escalation https://o365exchange.visualstudio.com/DefaultCollection/IP%20Engineering/_workitems/edit/1596890