### PR TITLE
Removed "Connect using an existing service principal" in app-only-auth-powershell-v2.md

### DIFF
--- a/exchange/docs-conceptual/app-only-auth-powershell-v2.md
+++ b/exchange/docs-conceptual/app-only-auth-powershell-v2.md
@@ -54,22 +54,6 @@ The following examples show how to use the Exchange Online PowerShell V2 module 
 
   When you use the _CertificateThumbPrint_ parameter, the certificate needs to be installed on the computer where you are running the command. The certificate should be installed in the user certificate store.
 
-- Connect using an existing service principal and client-secret:
-
-  1. Get an OAuth access token using Active Directory Authentication Library (ADAL) PowerShell.
-
-  2. Use the access token and username to create a PSCredential object:
-
-     ```powershell
-     $AppCredential = New-Object System.Management.Automation.PSCredential(<UPN>,<Token>)
-     ```
-
-  3. Silently pass the PSCredential object to the EXO V2 module:
-
-     ```powershell
-     Connect-ExchangeOnline -Credential $AppCredential
-     ```
-
 ## How does it work?
 
 The EXO V2 module uses the Active Directory Authentication Library to fetch an app-only token using the application Id, tenant Id (organization), and certificate thumbprint. The application object provisioned inside Azure AD has a Directory Role assigned to it, which is returned in the access token. Exchange Online configures the session RBAC using the directory role information that's available in the token.


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/office-docs-powershell/issues/6171.