### PR TITLE
[HOLD] ECC LiveSite Update Get-CalendarDiagnosticObjects.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-CalendarDiagnosticObjects.md
+++ b/exchange/exchange-ps/exchange/Get-CalendarDiagnosticObjects.md
@@ -376,7 +376,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/p/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable and -ShouldFetchAttendeeCollection, and -EwsID, and -ConfigurationName. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/p/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
Customers are unable to take logging output from Get-CalendarDiagnosticLog and convert valid output from Get-CalendarDiagnosticAnalysis, the latter is broken is EXO and results in a Watson OutOfRange error, open active bug linked.

Tenant Admins only workaround is to use Get-CalendarDiagnosticObjects, but by default they will only get 63 out of the 220+ available properties. 

Extra properties can be entered via the CustomPropertyNames parameter, however they are not publicly documented
Attached file has Values and Descriptions:
Excluding deprecated values for NetMeeting and those that returned InvalidSchemaProperty, requires review:
CustomProperyNameValuesAndDescriptions_ContentIdeaSubmission.csv
Shane Ferrell EEE from Calendaring Platform recommended Rob Whaley as a writer to get these updated in documentation.
See Attached email in files
RE VSO 1550318 - 193709351 - Customer Escalation Ask  Get-CalendarDiagnosticObjects - Discovering StoreProps for CustomPropertyNames.msg

Per Shane Ferrell we also need to add updates for these, or would this be a different request ? See attached email
Also need to update the Get-CalendarDiagnosticObjects documentation with regards to new parameters: 
-ShouldFetchAttendeeCollection, -EwsID, -ConfigurationName