### PR TITLE
Moving example description

### DIFF
--- a/teams/teams-ps/teams/Remove-CsGroupPolicyAssignment.md
+++ b/teams/teams-ps/teams/Remove-CsGroupPolicyAssignment.md
@@ -27,9 +27,7 @@ When a policy assignment is removed from a group, any other group policy assignm
 
 ## EXAMPLES
 
-### Example 1
-In this example, the policy assignment with rank 2 is removed.  As a result, the policy assignment with rank 3 is updated to rank 2.
-
+### EXAMPLE 1
 ```
 Get-CsGroupPolicyAssignment -PolicyType TeamsMeetingPolicy
 
@@ -48,6 +46,8 @@ GroupId                              PolicyType         PolicyName Rank CreatedT
 d8ebfa45-0f28-4d2d-9bcc-b158a49e2d17 TeamsMeetingPolicy AllOn      1    10/29/2019 3:57:27 AM aeb7c0e7-2f6d-43ef-bf33-bfbcb93fdc64
 566b8d39-5c5c-4aaa-bc07-4f36278a1b38 TeamsMeetingPolicy Kiosk      2    11/2/2019 12:14:41 AM aeb7c0e7-2f6d-43ef-bf33-bfbcb93fdc64
 ```
+
+In this example, the policy assignment with rank 2 is removed.  As a result, the policy assignment with rank 3 is updated to rank 2.
 
 ## PARAMETERS
 


### PR DESCRIPTION
Moving example description under the code block trying to fix the formatting error which prevents the whole parameter section from showing in the published version of the article.

The output of cmdlet is not normally shown on cmdlet documentation so that could be removed later too.

@Kateyanne @yogkumgit this is regarding the email I sent.