### PR TITLE
Clarifying belongs to Preview Module

### DIFF
--- a/teams/teams-ps/teams/Add-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Add-TeamChannelUser.md
@@ -23,8 +23,7 @@ Add-TeamChannelUser -GroupId <String> -DisplayName <String> -User <String> [-Rol
 
 ## DESCRIPTION
 
-> [!IMPORTANT]
-> Modules in the PS INT gallery for Microsoft Teams run on the /beta version in Microsoft Graph and are subject to change. Int modules can be install from here <https://www.poshtestgallery.com/packages/MicrosoftTeams>.
+Note: This cmdlet is part of the Public Preview version of Teams PowerShell Module, for more information see [Install Teams PowerShell public preview](https://docs.microsoft.com/microsoftteams/teams-powershell-install#install-teams-powershell-public-preview) and also see [Microsoft Teams PowerShell Release Notes](https://docs.microsoft.com/microsoftteams/teams-powershell-release-notes).
 
 ## EXAMPLES
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/office-docs-powershell/issues/6283

Replacing the note format as it is not rendered in get-help and also clarifying the state that this cmdlet belongs to the now called public preview module.

If this change is approved, will make the same change on the other cmdlets that also share this condition.