### PR TITLE
Fixed Exchange broken links per request build report

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -6512,8 +6512,8 @@
     },
     {
       "source_path": "exchange/docs-conceptual/office-365-scc/connect-to-scc-powershell/mfa-connect-to-scc-powershell.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/exchange/mfa-connect-to-scc-powershell",
-      "redirect_document_id": true
+      "redirect_url": "https://docs.microsoft.com/powershell/exchange/connect-to-scc-powershell",
+      "redirect_document_id": false
     },
     {
       "source_path": "exchange/docs-conceptual/exchange-server/connect-to-exchange-servers-using-remote-powershell.md",
@@ -6582,8 +6582,8 @@
     },
     {
       "source_path": "exchange/docs-conceptual/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell.md",
-      "redirect_url": "https://docs.microsoft.com/powershell/exchange/mfa-connect-to-exchange-online-powershell",
-      "redirect_document_id": true
+      "redirect_url": "https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell",
+      "redirect_document_id": false
     },
     {
       "source_path": "exchange/docs-conceptual/exchange-online/exchange-online-powershell-v2/app-only-auth-powershell-v2.md",
@@ -6614,6 +6614,16 @@
       "source_path": "exchange/docs-conceptual/exchange-eop/exchange-online-protection-powershell.md",
       "redirect_url": "https://docs.microsoft.com/powershell/exchange/exchange-online-protection-powershell",
       "redirect_document_id": true
+    },
+    {
+      "source_path": "exchange/docs-conceptual/mfa-connect-to-exchange-online-powershell.md",
+      "redirect_url": "https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell",
+      "redirect_document_id": false
+    },
+    {
+      "source_path": "exchange/docs-conceptual/mfa-connect-to-scc-powershell.md",
+      "redirect_url": "https://docs.microsoft.com/powershell/exchange/connect-to-scc-powershell",
+      "redirect_document_id": false
     }
   ] 
   }

--- a/exchange/docs-conceptual/app-only-auth-powershell-v2.md
+++ b/exchange/docs-conceptual/app-only-auth-powershell-v2.md
@@ -20,19 +20,7 @@ description: "Learn about using the Exchange Online V2 module in scripts and oth
 # App-only authentication for unattended scripts in the EXO V2 module
 
 > [!NOTE]
-> This feature is currently in Public Preview, and is available in the Preview release of Exchange Online PowerShell V2 Module.
-
-To install the Preview release of the EXO V2 module, run the same [steps to install the stable version](exchange-online-powershell-v2.md#install-and-maintain-the-exchange-online-powershell-v2-module) but instead step 4 run the following command:
-
-```powershell
-Install-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.3-Preview -AllowPrerelease
-```
-
-To update from an earlier version of the EXO V2 module to the preview release of EXO V2 module, run the following command:
-
-```powershell
-Update-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.3-Preview -AllowPrerelease
-```
+> This feature is currently in Public Preview, and is available in the `2.0.3-Preview` release of Exchange Online PowerShell V2 Module. For instructions on how to install or update to this version of the module, see [Install and maintain the EXO V2 module](exchange-online-powershell-v2.md#install-and-maintain-the-exo-v2-module).
 
 Auditing and reporting scenarios in Exchange Online often involve scripts that run unattended. In most cases, these unattended scripts access Exchange Online PowerShell using Basic authentication (a username and password). Even when the connection to Exchange Online PowerShell uses modern authentication, the credentials are stored in a local file or a secret vault that's accessed at run-time.
 

--- a/exchange/docs-conceptual/basic-auth-connect-to-eop-powershell.md
+++ b/exchange/docs-conceptual/basic-auth-connect-to-eop-powershell.md
@@ -1,0 +1,149 @@
+---
+title: "Basic auth - Connect to Exchange Online Protection PowerShell"
+ms.author: chrisda
+author: chrisda
+manager: dansimp
+ms.date:
+ms.audience: Admin
+ms.topic: article
+ms.service: eop
+localization_priority: Normal
+ms.assetid:
+ROBOTS: NOINDEX
+description: "Use remote PowerShell to connect to a standalone Exchange Online Protection (EOP) organization without mailboxes in Exchange Online."
+---
+
+# Bssic auth - Connect to Exchange Online Protection PowerShell
+
+> [!NOTE]
+> The connection instructions in this topic [will eventually be deprecated](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-july-update/ba-p/1530163) due to the security concerns around Basic authentication. Instead, you should use the Exchange Online PowerShell V2 module (the EXO V2 module) to connect to Exchange Online Protection PowerShell. For instructions, see [Connect to Exchange Online Protection PowerShell](connect-to-exchange-online-protection-powershell.md).
+
+In standalone Exchange Online Protection (EOP) organizations without Exchange Online mailboxes, standalone EOP PowerShell allows you to manage your EOP organization from the command line. You use Windows PowerShell on your local computer to create a remote PowerShell session to EOP. It's a simple three-step process where you enter your Microsoft 365 credentials, provide the required connection settings, and then import the EOP cmdlets into your local Windows PowerShell session so that you can use them.
+
+The following introductory video shows you how to connect to and use Exchange Online Protection PowerShell:
+
+[Use Exchange Online Protection PowerShell](https://videoplayercdn.osi.office.net/hub/?csid=ux-cms-en-us-msoffice&uuid=9cb28006-c2cb-45b6-b72e-eeed8767dee7&AutoPlayVideo=false)
+
+**Note:** This video applies to Exchange Online PowerShell and EOP PowerShell. When you connect to your organization, be sure to specify the correct URL (*ConnectionUri* value). The required URL is different for Exchange Online and standalone EOP organizations.
+
+## What do you need to know before you begin?
+
+- Estimated time to complete: 5 minutes
+
+- **The procedures in this topic are only for EOP organizations that don't have Exchange Online mailboxes** (for example, you have a standalone EOP subscription that protects your on-premises email environment). If you have a Microsoft 365 subscription includes Exchange Online mailboxes, you can't connect to Exchange Online Protection PowerShell. The same features are available in [Exchange Online PowerShell](exchange-online-powershell.md).
+
+- You can use the following versions of Windows:
+
+  - Windows 10
+  - Windows 8.1
+  - Windows Server 2019
+  - Windows Server 2016
+  - Windows Server 2012 or Windows Server 2012 R2
+  - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
+  - Windows Server 2008 R2 SP1<sup>*</sup>
+
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+
+- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
+
+  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
+
+  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
+
+  ```powershell
+  Set-ExecutionPolicy RemoteSigned
+  ```
+
+  For more information about execution policies, see [About Execution Policies](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+
+- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to send the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+
+  **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
+
+  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in Windows PowerShell):
+  
+  ```dos
+  winrm get winrm/config/client/auth
+  ```
+
+  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in Windows PowerShell) to enable Basic authentication for WinRM:
+
+  ```dos
+  winrm set winrm/config/client/auth @{Basic="true"}
+  ```
+
+  **Note**: If you'd rather run the command in Windows PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
+
+  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
+
+  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
+
+> [!TIP]
+> Having problems? Ask for help in the [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351) forum.
+
+## Connect to Exchange Online Protection
+
+1. On your local computer, open Windows PowerShell and run the following command:
+
+    ```powershell
+    $UserCredential = Get-Credential
+    ```
+
+    In the **Windows PowerShell Credential Request** dialog box, type your work or school account and password, and then click **OK**.
+
+2. Run the following command:
+
+    ```powershell
+    $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.protection.outlook.com/powershell-liveid/ -Credential $UserCredential -Authentication Basic -AllowRedirection
+    ```
+
+    **Notes**:
+
+   - For Office 365 Germany, use the _ConnectionUri_ value: `https://ps.protection.outlook.de/powershell-liveid/`
+
+   - For on-premises Exchange organization with Exchange Enterprise CAL with Services licenses, use the _ConnectionUri_ value: `https://outlook.office365.com/powershell-liveid/`
+
+3. Run the following command:
+
+   ```powershell
+   Import-PSSession $Session -DisableNameChecking
+   ```
+
+   > [!NOTE]
+   > Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command:
+
+   ```powershell
+   Remove-PSSession $Session
+   ```
+
+## How do you know this worked?
+
+After Step 3, the Exchange Online Protection cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online Protection cmdlet, for example, **Get-TransportRule**, and see the results.
+
+If you receive errors, check the following requirements:
+
+- A common problem is an incorrect password. Run the three steps again and pay close attention to the user name and password you enter in Step 1.
+
+- To help prevent denial-of-service (DoS) attacks, you're limited to three open remote PowerShell connections to your Exchange Online Protection organization.
+
+- TCP port 80 traffic needs to be open between your local computer and Microsoft 365. It's probably open, but it's something to consider if your organization has a restrictive Internet access policy.
+
+- The account you use to connect to Exchange Online Protection PowerShell must be represented as a [mail user in EOP](https://docs.microsoft.com/microsoft-365/security/office-365-security/manage-mail-users-in-eop) (created manually or by directory synchronization). If the account is not visible in the Exchange admin center (EAC) as a mail user at **Recipients** \> **Contacts**, you'll receive the following error when you try to connect:
+
+  > Import-PSSession : Running the Get-Command command in a remote session reported the following error: Processing data for a remote command failed with the following error message: The request for the Windows Remote Shell with ShellId <GUID> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
+
+- The **New-PSSession** command (Step 2) might fail to connect if your client IP address changes during the connection request. This can happen if your organization uses a source network address translation (SNAT) pool that contains multiple IP addresses. The connection error looks like this:
+
+  > The request for the Windows Remote Shell with ShellId <ID> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
+
+  To fix the issue, use an SNAT pool that contains a single IP address, or force the use of a specific IP address for connections to the Exchange Online Protection PowerShell endpoint.
+
+## See also
+
+The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
+
+- [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
+- [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
+- [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
+- [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
+- [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)

--- a/exchange/docs-conceptual/basic-auth-connect-to-exo-powershell.md
+++ b/exchange/docs-conceptual/basic-auth-connect-to-exo-powershell.md
@@ -1,0 +1,155 @@
+---
+title: "Basic auth - Connect to Exchange Online PowerShell"
+ms.author: chrisda
+author: chrisda
+manager: dansimp
+ms.date:
+ms.audience: Admin
+ms.topic: article
+ms.service: exchange-online
+localization_priority: Priority
+ms.collection: Strat_EX_Admin
+ms.custom:
+ms.assetid:
+ROBOTS: NOINDEX
+search.appverid: MET150
+description: "Learn how to use remote PowerShell to connect to Exchange Online with Basic authentication."
+---
+
+# Basic auth - Connect to Exchange Online PowerShell
+
+> [!NOTE]
+> The connection instructions in this topic [will eventually be deprecated](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-july-update/ba-p/1530163) due to the security concerns around Basic authentication. Instead, you should use the Exchange Online PowerShell V2 module (the EXO V2 module) to connect to Exchange Online PowerShell. For instructions, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
+
+Exchange Online PowerShell allows you to manage your Exchange Online settings from the command line. You use Windows PowerShell on your local computer to create a remote PowerShell session to Exchange Online. It's a simple three-step process where you enter your Microsoft 365 credentials, provide the required connection settings, and then import the Exchange Online cmdlets into your local Windows PowerShell session so that you can use them.
+
+The following introductory video shows you how to connect to and use Exchange Online PowerShell:
+
+[Use Exchange Online PowerShell](https://videoplayercdn.osi.office.net/hub/?csid=ux-cms-en-us-msoffice&uuid=9cb28006-c2cb-45b6-b72e-eeed8767dee7&AutoPlayVideo=false)
+
+**Note:** This video applies to Exchange Online PowerShell and EOP PowerShell. When you connect to your organization, be sure to specify the correct URL (*ConnectionUri* value). The required URL is different for Exchange Online and standalone EOP organizations.
+
+## What do you need to know before you begin?
+
+- Estimated time to complete: 5 minutes
+
+- If your on-premises Exchange organization has Exchange Enterprise CAL with Services licenses, you can use the instructions in this topic to connect to your EOP organization.
+
+- You can use the following versions of Windows:
+
+  - Windows 10
+  - Windows 8.1
+  - Windows Server 2019
+  - Windows Server 2016
+  - Windows Server 2012 or Windows Server 2012 R2
+  - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
+  - Windows Server 2008 R2 SP1<sup>*</sup>
+
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+
+- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
+
+  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
+
+  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
+
+  ```powershell
+  Set-ExecutionPolicy RemoteSigned
+  ```
+
+  For more information about execution policies, see [About Execution Policies](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+
+- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to send the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+
+  **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
+
+  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in Windows PowerShell):
+  
+  ```dos
+  winrm get winrm/config/client/auth
+  ```
+
+  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in Windows PowerShell) to enable Basic authentication for WinRM:
+
+  ```dos
+  winrm set winrm/config/client/auth @{Basic="true"}
+  ```
+
+  **Note**: If you'd rather run the command in Windows PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
+
+  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
+
+  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
+
+> [!TIP]
+> Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
+
+## Connect to Exchange Online PowerShell
+
+1. On your local computer, open Windows PowerShell and run the following command.
+
+   ```powershell
+   $UserCredential = Get-Credential
+   ```
+
+   In the **Windows PowerShell Credential Request** dialog box, type your work or school account and password, and then click **OK**.
+
+2. Run the following command:
+
+   ```powershell
+   $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $UserCredential -Authentication Basic -AllowRedirection
+   ```
+
+   **Notes**:
+
+   - For Office 365 operated by 21Vianet, use the _ConnectionUri_ value: `https://partner.outlook.cn/PowerShell`
+   - For Office 365 Germany, use the _ConnectionUri_ value: `https://outlook.office.de/powershell-liveid/`
+   - For Microsoft 365 GCC High, use the _ConnectionUri_ value: `https://outlook.office365.us/powershell-liveid/`
+   - For Microsoft 365 DoD, use the _ConnectionUri_ value: `https://webmail.apps.mil/powershell-liveid`
+
+   - If you're behind a proxy server, run this command first: `$ProxyOptions = New-PSSessionOption -ProxyAccessType <Value>`, where \<Value\> is `IEConfig`, `WinHttpConfig`, or `AutoDetect`.
+
+     Then, add the following parameter and value to the end of the $Session = ... command: `-SessionOption $ProxyOptions`.
+
+     For more information, see [New-PSSessionOption](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionoption).
+
+3. Run the following command:
+
+   ```powershell
+   Import-PSSession $Session -DisableNameChecking
+   ```
+
+> [!NOTE]
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
+
+```powershell
+Remove-PSSession $Session
+```
+
+## How do you know this worked?
+
+After Step 3, the Exchange Online cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online cmdlet, for example, **Get-Mailbox**, and see the results.
+
+If you receive errors, check the following requirements:
+
+- A common problem is an incorrect password. Run the three steps again and pay close attention to the user name and password you enter in Step 1.
+
+- To help prevent denial-of-service (DoS) attacks, you're limited to three open remote PowerShell connections to your Exchange Online organization.
+
+- The account you use to connect to Exchange Online must be enabled for remote PowerShell. For more information, see [Enable or disable access to Exchange Online PowerShell](disable-access-to-exchange-online-powershell.md).
+
+- TCP port 80 traffic needs to be open between your local computer and Microsoft 365. It's probably open, but it's something to consider if your organization has a restrictive internet access policy.
+
+- If your organization uses federated authentication, and your identity provider (IDP) and/or security token service (STS) isn't publicly available, you can't use a federated account to connect to Exchange Online PowerShell. Instead, create and use a non-federated account in Microsoft 365 to connect to Exchange Online PowerShell.
+
+## See also
+
+The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
+
+- [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
+- [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
+- [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
+- [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
+- [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)
+
+For more information about managing Microsoft 365, see [Manage Microsoft 365 and Office 365](https://docs.microsoft.com/Office365/).

--- a/exchange/docs-conceptual/basic-auth-connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/basic-auth-connect-to-scc-powershell.md
@@ -1,0 +1,154 @@
+---
+title: "Basic auth - Connect to Security & Compliance Center PowerShell"
+ms.author: chrisda
+author: chrisda
+manager: dansimp
+ms.date:
+ms.audience: Admin
+ms.topic: article
+ms.service: o365-security-and-compliance
+localization_priority: Normal
+ms.assetid:
+ROBOTS: NOINDEX
+search.appverid: MET150
+description: "Learn how to connect to Security & Compliance Center PowerShell."
+---
+
+# Basic auth - Connect to Security & Compliance Center PowerShell
+
+> [!NOTE]
+> The connection instructions in this topic [will eventually be deprecated](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-july-update/ba-p/1530163) due to the security concerns around Basic authentication. Instead, you should use the Exchange Online PowerShell V2 module (the EXO V2 module) to connect to Security & Compliance Center PowerShell. For instructions, see [Connect to Security & Compliance Center PowerShell](connect-to-scc-powershell.md).
+
+Security & Compliance Center PowerShell allows you to manage your Security & Compliance Center settings from the command line. You use Windows PowerShell on your local computer to create a remote PowerShell session to the Security & Compliance Center. It's a simple three-step process where you enter your Microsoft 365 credentials, provide the required connection settings, and then import the Security & Compliance Center cmdlets into your local Windows PowerShell session so that you can use them.
+
+> [!NOTE]
+> The procedures in this topic won't work if:
+> 
+> - Your account uses multi-factor authentication (MFA).
+> 
+> - Your organization uses federated authentication.
+> 
+> - A location condition in an Azure Active Directory conditional access policy restricts your access to trusted IPs.
+> 
+> In these scenarios, you need to download and use the Exchange Online PowerShell V2 module (EXO V2 module) to connect to Security & Compliance Center PowerShell. For instructions, see [Connect to Security & Compliance Center PowerShell using the EXO V2 module](connect-to-scc-powershell.md).
+> 
+> Some features in the Security & Compliance Center (for example, mailbox archiving) link to existing functionality in Exchange Online. To use PowerShell with these features, you need to connect to Exchange Online PowerShell instead of Security & Compliance Center PowerShell. For instructions, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
+
+## What do you need to know before you begin?
+
+- Estimated time to complete: 5 minutes
+
+- Microsoft 365 global admins have access to the Security & Compliance Center, but everyone else needs to have their access configured for them. For details, see [Give users access to the Security & Compliance Center](https://docs.microsoft.com/microsoft-365/security/office-365-security/grant-access-to-the-security-and-compliance-center).
+
+- You can use the following versions of Windows:
+
+  - Windows 10
+  - Windows 8.1
+  - Windows Server 2019
+  - Windows Server 2016
+  - Windows Server 2012 or Windows Server 2012 R2
+  - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
+  - Windows Server 2008 R2 SP1<sup>*</sup>
+
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+
+- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
+
+  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
+
+  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
+
+  ```powershell
+  Set-ExecutionPolicy RemoteSigned
+  ```
+
+  For more information about execution policies, see [About Execution Policies](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+
+- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to send the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+
+  **Note** You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
+
+  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in Windows PowerShell):
+
+  ```dos
+  winrm get winrm/config/client/auth
+  ```
+
+  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in Windows PowerShell) to enable Basic authentication for WinRM:
+
+  ```dos
+  winrm set winrm/config/client/auth @{Basic="true"}
+  ```
+
+  **Note**: If you'd rather run the command in Windows PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
+
+  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
+
+  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
+
+## Connect to the Security & Compliance Center
+
+1. On your local computer, open Windows PowerShell and run the following command:
+
+   ```powershell
+   $UserCredential = Get-Credential
+   ```
+
+   In the **Windows PowerShell Credential Request** dialog box that appears, type your work or school account and password, and then click **OK**.
+
+2. Run the following command:
+
+   ```powershell
+   $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.compliance.protection.outlook.com/powershell-liveid/ -Credential $UserCredential -Authentication Basic -AllowRedirection
+   ```
+
+   **Notes**:
+
+   - For Office 365 Germany, use the _ConnectionUri_ value: `https://ps.compliance.protection.outlook.de/powershell-liveid/`.
+   - For Microsoft 365 GCC High, use the _ConnectionUri_ value: `https://ps.compliance.protection.office365.us/powershell-liveid/`.
+   - For Microsoft 365 DoD, use the _ConnectionUri_ value: `https://l5.ps.compliance.protection.office365.us/powershell-liveid/`.
+
+3. Run the following command:
+
+   ```powershell
+   Import-PSSession $Session -DisableNameChecking
+   ```
+
+   If you want to connect to Security & Compliance Center PowerShell in the same window as an active Exchange Online PowerShell connection, you need to add the Prefix parameter and value (for example, `-Prefix "CC"`) to the end of this command to prevent cmdlet name collisions (both environments share some cmdlets with the same names).
+
+> [!NOTE]
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command:
+
+```powershell
+Remove-PSSession $Session
+```
+
+## How do you know this worked?
+
+After Step 3, the Security & Compliance Center cmdlets are imported into your local Windows PowerShell session as tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run a Security & Compliance Center cmdlet, for example, **Get-RetentionCompliancePolicy**, and see the results.
+
+If you receive errors, check the following requirements:
+
+- A common problem is an incorrect password. Run the three steps again and pay close attention to the user name and password you enter in Step 1.
+
+- Verify that your account has permission to access the Security & Compliance Center. For details, see [Give users access to the Security & Compliance Center](https://docs.microsoft.com/microsoft-365/security/office-365-security/grant-access-to-the-security-and-compliance-center).
+
+- To help prevent denial-of-service (DoS) attacks, you're limited to three open remote PowerShell connections to the Security & Compliance Center.
+
+- TCP port 80 traffic needs to be open between your local computer and Microsoft 365. It's probably open, but it's something to consider if your organization has a restrictive Internet access policy.
+
+- The **New-PSSession** command (Step 2) might fail to connect if your client IP address changes during the connection request. This can happen if your organization uses a source network address translation (SNAT) pool that contains multiple IP addresses. The connection error looks like this:
+
+  > The request for the Windows Remote Shell with ShellId <ID> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
+
+  To fix the issue, use an SNAT pool that contains a single IP address, or force the use of a specific IP address for connections to the Security & Compliance Center PowerShell endpoint.
+
+## See also
+
+The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
+
+- [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
+- [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
+- [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
+- [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
+- [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)

--- a/exchange/docs-conceptual/cmdlet-property-sets.md
+++ b/exchange/docs-conceptual/cmdlet-property-sets.md
@@ -13,22 +13,23 @@ ms.collection: Strat_EX_Admin
 ms.custom:
 ms.assetid:
 search.appverid: MET150
-description: "Learn about the available property sets in the Exchange Online PowerShell V2 module."
+description: "Admins can lear about the property sets that are available in the Get-EXO* cmdlets in the Exchange Online PowerShell V2 module."
 ---
 
 # Property sets in Exchange Online PowerShell V2 cmdlets
 
-This topic describes the property sets that are available in the new cmdlets in the [Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md). For more information about property sets, see [Properties and property sets in the EXO V2 module](exchange-online-powershell-v2.md#properties-and-property-sets-in-the-exo-v2-module).
+This topic describes the property sets that are available in the **Get-EXO\*** cmdlets in the [Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md). For more information about property sets, see [Properties and property sets in the EXO V2 module](exchange-online-powershell-v2.md#properties-and-property-sets-in-the-exo-v2-module).
 
-For more information about filtering in the EXO V2 module, see [Filters in the Exchange Online V2 module](filters-v2.md).
+For more information about filtering in the EXO V2 module, see [Filters in the EXO V2 module](filters-v2.md).
 
 ## Get-EXOCasMailbox property sets
 
 The available property sets for the **Get-EXOCasMailbox** cmdlet and the properties they contain are described in the following table:
 
-|||
-|:-----|:-----|
-|**PropertySet**|**Properties**|
+****
+
+|PropertySet|Properties|
+|---|---|
 |**Minimum**|ActiveSyncEnabled <br/> DisplayName <br/> ECPEnabled <br/> EmailAddresses <br/> EwsEnabled <br/> ExchangeVersion <br/> Guid <br/> Identity <br/> ImapEnabled <br/> MAPIEnabled <br/> Name <br/> OWAEnabled <br/> OrganizationId <br/> PopEnabled <br/> PrimarySmtpAddress <br/> ServerLegacyDN|
 |**ActiveSync**|ActiveSyncAllowedDeviceIDs <br/> ActiveSyncBlockedDeviceIDs <br/> ActiveSyncEnabled <br/> ActiveSyncMailboxPolicy <br/> ActiveSyncMailboxPolicyIsDefaulted <br/> ActiveSyncSuppressReadReceipt <br/> ExternalDirectoryObjectId <br/> Guid <br/> HasActiveSyncDevicePartnership <br/> Identity <br/> Name <br/> OrganizationId|
 |**Ews**|EwsAllowMacOutlook <br/> EwsAllowOutlook <br/> EwsEnabled <br/> ExternalDirectoryObjectId <br/> Guid <br/> Identity <br/> Name <br/> OrganizationId|
@@ -36,30 +37,28 @@ The available property sets for the **Get-EXOCasMailbox** cmdlet and the propert
 |**Mapi**|ExternalDirectoryObjectId <br/> Guid <br/> Identity <br/> MAPIBlockOutlookExternalConnectivity <br/> MAPIBlockOutlookNonCachedMode <br/> MAPIBlockOutlookRpcHttp <br/> MAPIBlockOutlookVersions <br/> MAPIEnabled <br/> MapiHttpEnabled <br/> Name <br/> OrganizationId|
 |**Pop**|ExternalDirectoryObjectId <br/> Guid <br/> Identity <br/> Name <br/> OrganizationId <br/> PopEnableExactRFC822Size <br/> PopEnabled <br/> PopMessagesRetrievalMimeFormat <br/> PopSuppressReadReceipt <br/> PopUseProtocolDefaults|
 |**ProtocolSettings**|ExternalDirectoryObjectId <br/> ExternalImapSettings <br/> ExternalPopSettings <br/> ExternalSmtpSettings <br/> Guid <br/> Identity <br/> InternalImapSettings <br/> InternalPopSettings <br/> InternalSmtpSettings <br/> Name <br/> OrganizationId|
+|
 
 **Note**: The following **Get-CasMailbox** parameters aren't available on **Get-EXOCasMailbox**:
 
 - *ActiveSyncDebugLogging*
-
 - *IgnoreDefaultScope*
-
 - *ReadIsOptimizedForAccessibility*
-
 - *SortBy*
 
 For more information, see:
 
 - [Get-EXOCASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exocasmailbox)
-
 - [Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)
 
 ## Get-EXOMailbox property sets
 
 The available property sets for the **Get-EXOMailbox** cmdlet and the properties they contain are described in the following table:
 
+****
+
+|PropertySet|Properties|
 |||
-|:-----|:-----|
-|**PropertySet**|**Properties**|
 |**Minimum**|Alias <br/> DisplayName <br/> DistinguishedName <br/> EmailAddresses <br/> ExchangeVersion <br/> ExternalDirectoryObjectId <br/> Guid <br/> Id <br/> Name <br/> OrganizationId <br/> PrimarySmtpAddress <br/> RecipientType <br/> RecipientTypeDetails <br/> UserPrincipalName|
 |**AddressList**|AddressBookPolicy <br/> AddressListMembership <br/> ExternalDirectoryObjectId <br/> GeneratedOfflineAddressBooks <br/> HiddenFromAddressListsEnabled <br/> OfflineAddressBook|
 |**Archive**|ArchiveDatabase <br/> ArchiveDomain <br/> ArchiveGuid <br/> ArchiveName <br/> ArchiveQuota <br/> ArchiveRelease <br/> ArchiveState <br/> ArchiveStatus <br/> ArchiveWarningQuota <br/> AutoExpandingArchiveEnabled <br/> DisabledArchiveDatabase <br/> DisabledArchiveGuid <br/> ExternalDirectoryObjectId <br/> JournalArchiveAddress|
@@ -77,37 +76,52 @@ The available property sets for the **Get-EXOMailbox** cmdlet and the properties
 |**SCL**|AntispamBypassEnabled <br/> ExternalDirectoryObjectId <br/> SCLDeleteEnabled <br/> SCLDeleteThreshold <br/> SCLJunkEnabled <br/> SCLJunkThreshold <br/> SCLQuarantineEnabled <br/> SCLQuarantineThreshold <br/> SCLRejectEnabled <br/> SCLRejectThreshold|
 |**SoftDelete**|ExternalDirectoryObjectId <br/> IncludeInGarbageCollection <br/> IsInactiveMailbox <br/> IsSoftDeletedByDisable <br/> IsSoftDeletedByRemove <br/> WhenSoftDeleted|
 |**StatisticsSeed**|ArchiveDatabaseGuid <br/> DatabaseGuid <br/> ExchangeGuid <br/> ExternalDirectoryObjectId|
+|
 
 **Note**: The following **Get-Mailbox** parameters aren't available on **Get-EXOMailbox**:
 
 - *Async*
-
 - *GroupMailbox*
-
 - *Migration*
-
 - *PublicFolder*
-
 - *SortBy*
 
 For more information, see:
 
 - [Get-EXOMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exomailbox)
-
 - [Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)
+
+## Get-EXOMailboxStatistics property sets
+
+The available property sets for the **Get-EXOMailboxStatistics** cmdlet and the properties they contain are described in the following table:
+
+****
+
+|PropertySet|Properties|
+|||
+|**Minimum**|DeletedItemCount <br/> DisplayName <br/> ItemCount <br/> MailboxGuid <br/> TotalDeletedItemSize <br/> TotalItemSize|
+|**All**|AssociatedItemCount <br/> AttachmentTableAvailableSize <br/> AttachmentTableTotalSize <br/> DatabaseIssueWarningQuota <br/> DatabaseName <br/> DatabaseProhibitSendQuota <br/> DatabaseProhibitSendReceiveQuota <br/> DeletedItemCount <br/> DisconnectDate <br/> DisconnectReason <br/> DisplayName <br/> DumpsterMessagesPerFolderCountReceiveQuota <br/> DumpsterMessagesPerFolderCountWarningQuota <br/> ExternalDirectoryOrganizationId <br/> FastIsEnabled <br/> FolderHierarchyChildrenCountReceiveQuota <br/> FolderHierarchyChildrenCountWarningQuota <br/> FolderHierarchyDepthReceiveQuota <br/> FolderHierarchyDepthWarningQuota <br/> FoldersCountReceiveQuota <br/> FoldersCountWarningQuota <br/> IsAbandonedMoveDestination <br/> IsArchiveMailbox <br/> IsDatabaseCopyActive <br/> IsHighDensityShard <br/> IsMoveDestination <br/> IsQuarantined <br/> ItemCount <br/> LastLoggedOnUserAccount <br/> LastLogoffTime <br/> LastLogonTime <br/> LegacyDN <br/> MailboxGuid <br/> MailboxMessagesPerFolderCountReceiveQuota <br/> MailboxMessagesPerFolderCountWarningQuota <br/> MailboxType <br/> MailboxTypeDetail <br/> MessageTableAvailableSize <br/> MessageTableTotalSize <br/> NamedPropertiesCountQuota <br/> NeedsToMove <br/> OtherTablesAvailableSize <br/> OtherTablesTotalSize <br/> OwnerADGuid <br/> QuarantineClients <br/> QuarantineDescription <br/> QuarantineEnd <br/> QuarantineFileVersion <br/> QuarantineLastCrash <br/> ResourceUsageRollingAvgDatabaseReads <br/> ResourceUsageRollingAvgRop <br/> ResourceUsageRollingClientTypes <br/> ServerName <br/> StorageLimitStatus <br/> SystemMessageCount <br/> SystemMessageSize <br/> SystemMessageSizeShutoffQuota <br/> SystemMessageSizeWarningQuota <br/> TotalDeletedItemSize <br/> TotalItemSize|
+|
+
+For more information, see:
+
+- [Get-EXOMailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxstatistics)
+- [Get-MailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mailboxstatistics)
 
 ## Get-EXORecipient property sets
 
 The available property sets for the **Get-EXORecipient** cmdlet and the properties they contain are described in the following table:
 
+****
+
+|PropertySet|Properties|
 |||
-|:-----|:-----|
-|**PropertySet**|**Properties**|
-|Minimum|ExchangeVersion <br/> ExternalDirectoryObjectID <br/> Name <br/> OrganizationId <br/> RecipientType <br/> RecipientTypeDetails|
-|Archive|ArchiveDatabase <br/> ArchiveGuid <br/> ArchiveRelease <br/> ArchiveState <br/> ArchiveStatus|
-|Custom|CustomAttribute1 <br/> CustomAttribute2 <br/> CustomAttribute3 <br/> CustomAttribute4 <br/> CustomAttribute5 <br/> CustomAttribute6 <br/> CustomAttribute7 <br/> CustomAttribute8 <br/> CustomAttribute9 <br/> CustomAttribute10 <br/> CustomAttribute11 <br/> CustomAttribute12 <br/> CustomAttribute13 <br/> CustomAttribute14 <br/> CustomAttribute15 <br/> ExtensionCustomAttribute1 <br/> ExtensionCustomAttribute2 <br/> ExtensionCustomAttribute3 <br/> ExtensionCustomAttribute4 <br/> ExtensionCustomAttribute5|
-|MailboxMove|MailboxMoveBatchName <br/> MailboxMoveFlags <br/> MailboxMoveRemoteHostName <br/> MailboxMoveSourceMDB <br/> MailboxMoveStatus <br/> MailboxMoveTargetMDB|
-|Policy|ActiveSyncMailboxPolicy <br/> ActiveSyncMailboxPolicyIsDefaulted <br/> AddressBookPolicy <br/> EmailAddressPolicyEnabled <br/> ManagedFolderMailboxPolicy <br/> OwaMailboxPolicy <br/> PoliciesExcluded <br/> PoliciesIncluded <br/> RetentionPolicy <br/> SharingPolicy <br/> ShouldUseDefaultRetentionPolicy <br/> UMMailboxPolicy|
+|**Minimum**|ExchangeVersion <br/> ExternalDirectoryObjectID <br/> Name <br/> OrganizationId <br/> RecipientType <br/> RecipientTypeDetails|
+|**Archive**|ArchiveDatabase <br/> ArchiveGuid <br/> ArchiveRelease <br/> ArchiveState <br/> ArchiveStatus|
+|**Custom**|CustomAttribute1 <br/> CustomAttribute2 <br/> CustomAttribute3 <br/> CustomAttribute4 <br/> CustomAttribute5 <br/> CustomAttribute6 <br/> CustomAttribute7 <br/> CustomAttribute8 <br/> CustomAttribute9 <br/> CustomAttribute10 <br/> CustomAttribute11 <br/> CustomAttribute12 <br/> CustomAttribute13 <br/> CustomAttribute14 <br/> CustomAttribute15 <br/> ExtensionCustomAttribute1 <br/> ExtensionCustomAttribute2 <br/> ExtensionCustomAttribute3 <br/> ExtensionCustomAttribute4 <br/> ExtensionCustomAttribute5|
+|**MailboxMove**|MailboxMoveBatchName <br/> MailboxMoveFlags <br/> MailboxMoveRemoteHostName <br/> MailboxMoveSourceMDB <br/> MailboxMoveStatus <br/> MailboxMoveTargetMDB|
+|**Policy**|ActiveSyncMailboxPolicy <br/> ActiveSyncMailboxPolicyIsDefaulted <br/> AddressBookPolicy <br/> EmailAddressPolicyEnabled <br/> ManagedFolderMailboxPolicy <br/> OwaMailboxPolicy <br/> PoliciesExcluded <br/> PoliciesIncluded <br/> RetentionPolicy <br/> SharingPolicy <br/> ShouldUseDefaultRetentionPolicy <br/> UMMailboxPolicy|
+|
 
 **Note**: The following **Get-Recipient** parameters aren't available on **Get-EXORecipient**:
 
@@ -116,21 +130,4 @@ The available property sets for the **Get-EXORecipient** cmdlet and the properti
 For more information, see:
 
 - [Get-EXORecipient](https://docs.microsoft.com/powershell/module/exchange/get-exorecipient)
-
 - [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)
-
-### Get-EXOMailboxStatistics property sets
-
-The available property sets for the **Get-EXOMailboxStatistics** cmdlet and the properties they contain are described in the following table:
-
-|||
-|:-----|:-----|
-|**PropertySet**|**Properties**|
-|Minimum|DeletedItemCount <br/> DisplayName <br/> ItemCount <br/> MailboxGuid <br/> TotalDeletedItemSize <br/> TotalItemSize|
-|All|AssociatedItemCount <br/> AttachmentTableAvailableSize <br/> AttachmentTableTotalSize <br/> DatabaseIssueWarningQuota <br/> DatabaseName <br/> DatabaseProhibitSendQuota <br/> DatabaseProhibitSendReceiveQuota <br/> DeletedItemCount <br/> DisconnectDate <br/> DisconnectReason <br/> DisplayName <br/> DumpsterMessagesPerFolderCountReceiveQuota <br/> DumpsterMessagesPerFolderCountWarningQuota <br/> ExternalDirectoryOrganizationId <br/> FastIsEnabled <br/> FolderHierarchyChildrenCountReceiveQuota <br/> FolderHierarchyChildrenCountWarningQuota <br/> FolderHierarchyDepthReceiveQuota <br/> FolderHierarchyDepthWarningQuota <br/> FoldersCountReceiveQuota <br/> FoldersCountWarningQuota <br/> IsAbandonedMoveDestination <br/> IsArchiveMailbox <br/> IsDatabaseCopyActive <br/> IsHighDensityShard <br/> IsMoveDestination <br/> IsQuarantined <br/> ItemCount <br/> LastLoggedOnUserAccount <br/> LastLogoffTime <br/> LastLogonTime <br/> LegacyDN <br/> MailboxGuid <br/> MailboxMessagesPerFolderCountReceiveQuota <br/> MailboxMessagesPerFolderCountWarningQuota <br/> MailboxType <br/> MailboxTypeDetail <br/> MessageTableAvailableSize <br/> MessageTableTotalSize <br/> NamedPropertiesCountQuota <br/> NeedsToMove <br/> OtherTablesAvailableSize <br/> OtherTablesTotalSize <br/> OwnerADGuid <br/> QuarantineClients <br/> QuarantineDescription <br/> QuarantineEnd <br/> QuarantineFileVersion <br/> QuarantineLastCrash <br/> ResourceUsageRollingAvgDatabaseReads <br/> ResourceUsageRollingAvgRop <br/> ResourceUsageRollingClientTypes <br/> ServerName <br/> StorageLimitStatus <br/> SystemMessageCount <br/> SystemMessageSize <br/> SystemMessageSizeShutoffQuota <br/> SystemMessageSizeWarningQuota <br/> TotalDeletedItemSize <br/> TotalItemSize|
-
-For more information, see:
-
-- [Get-EXOMailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxstatistics)
-
-- [Get-MailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mailboxstatistics)

--- a/exchange/docs-conceptual/connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/connect-to-exchange-online-powershell.md
@@ -1,137 +1,178 @@
 ---
-title: "Connect to Exchange Online PowerShell with Basic authentication"
-ms.author: chrisda
+title: Connect to Exchange Online PowerShell
 author: chrisda
 manager: dansimp
-ms.date: 7/10/2017
+ms.date:
 ms.audience: Admin
 ms.topic: article
 ms.service: exchange-online
+ms.reviewer: navgupta
 localization_priority: Priority
 ms.collection: Strat_EX_Admin
 ms.custom:
-ms.assetid: c8bea338-6c1a-4bdf-8de0-7895d427ee5b
+ms.assetid:
 search.appverid: MET150
-description: "Learn how to use remote PowerShell to connect to Exchange Online with Basic authentication."
+description: "Learn how to use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell with modern authentication and/or multi-factor authentication (MFA)."
 ---
 
-# Connect to Exchange Online PowerShell with Basic authentication
+# Connect to Exchange Online PowerShell
 
-Exchange Online PowerShell allows you to manage your Exchange Online settings from the command line. You use Windows PowerShell on your local computer to create a remote PowerShell session to Exchange Online. It's a simple three-step process where you enter your Microsoft 365 credentials, provide the required connection settings, and then import the Exchange Online cmdlets into your local Windows PowerShell session so that you can use them.
+The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) uses modern authentication and works with multi-factor authentication (MFA) for connecting to all Exchange-related PowerShell environments in Microsoft 365: Exchange Online PowerShell, Security & Compliance PowerShell, and standalone Exchange Online Protection (EOP) PowerShell. For more information about the EXO V2 module, see [About the Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md).
 
-> [!NOTE]
-> 
-> - We're eventually going to [disable Basic authentication in Exchange Online](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-april-2020-update/ba-p/1275508), and the connection method described in this topic uses Basic authentication. We recommend that you use the [Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md) to connect to Exchange Online PowerShell, because it uses modern authentication in all scenarios.
-> 
-> - The Exchange Online PowerShell V2 module works with multi-factor authentication (MFA). For MFA connection instructions using the older Exchange Online Remote PowerShell Module, see [Connect to Exchange Online PowerShell using multi-factor authentication](mfa-connect-to-exchange-online-powershell.md).
-> 
-> - If you're a standalone Exchange Online Protection (EOP) customer (for example, you're using EOP to protect your on-premises email environment), use the connection instructions in [Connect to Exchange Online Protection PowerShell](connect-to-exchange-online-protection-powershell.md). If your on-premises Exchange organization has Exchange Enterprise CAL with Services licenses, EOP is one of the included services, and the connection instructions in this topic will work for you.
+**This topic contains instructions for how to connect to Exchange Online PowerShell using the EXO V2 module with or without MFA.**
+
+To use the older, less secure remote PowerShell connection instructions that [will eventually be deprecated](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-july-update/ba-p/1530163), see [Basic auth - Connect to Exchange Online PowerShell](basic-auth-connect-to-exo-powershell.md).
+
+To use the older Exchange Online Remote PowerShell Module to connect to Exchange Online PowerShell using MFA, see [V1 module - Connect to Exchange Online PowerShell using MFA](v1-module-mfa-connect-to-exo-powershell.md). Note that this older version of the module will eventually be retired.
 
 ## What do you need to know before you begin?
 
-- Estimated time to complete: 5 minutes
+- The requirements for installing and using the EXO V2 module are described in [Install and maintain the EXO V2 module](exchange-online-powershell-v2.md#install-and-maintain-the-exo-v2-module).
 
-- You can use the following versions of Windows:
+- The required _ConnectionUri_ and _AzureADAuthorizationEndPointUri_ parameter values depend on the nature of your Microsoft 365 organization as described in the following table:
 
-  - Windows 10
+  ****
 
-  - Windows 8.1
+  |Microsoft 365 offering|_ConnectionUri_ value|_AzureADAuthorizationEndPointUri_ value|
+  |---|---|---|
+  |Microsoft 365 or Microsoft 365 GCC|Not used|Not used|
+  |Office 365 Germany|`https://outlook.office.de/PowerShell-LiveID`|`https://login.microsoftonline.de/common`|
+  |Office 365 operated by 21Vianet|`https://partner.outlook.cn/PowerShell`|n/a|
+  |Microsoft 365 GCC High|`https://outlook.office365.us/powershell-liveid`|`https://login.microsoftonline.us/common`|
+  |Microsoft 365 DoD|`https://webmail.apps.mil/powershell-liveid`|`https://login.microsoftonline.us/common`|
+  |
 
-  - Windows Server 2019
-
-  - Windows Server 2016
-
-  - Windows Server 2012 or Windows Server 2012 R2
-
-  - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
-
-  - Windows Server 2008 R2 SP1<sup>*</sup>
-
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
-
-- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
-
-  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
-
-  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
-
-  ```PowerShell
-  Set-ExecutionPolicy RemoteSigned
-  ```
-
-- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
-
-  **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
-
-  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in Windows PowerShell):
-  
-  ```dos
-  winrm get winrm/config/client/auth
-  ```
-
-  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in Windows PowerShell) to enable Basic authentication for WinRM:
-
-  ```dos
-  winrm set winrm/config/client/auth @{Basic="true"}
-  ```
-
-  **Note**: If you'd rather run the command in Windows PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
-
-  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
-
-  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
+- The _DelegatedOrganization_ parameter specifies the customer organization that you want to manage as an authorized Microsoft Partner. For more information, see [Partners](https://docs.microsoft.com/office365/servicedescriptions/office-365-platform-service-description/partners).
 
 > [!TIP]
-> Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
+> Having problems? Ask in the [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542) forum.
 
-## Connect to Exchange Online
+## Connect to Exchange Online PowerShell using MFA
 
-1. On your local computer, open Windows PowerShell and run the following command.
+If you account uses multi-factor authentication, use the steps in this section. Otherwise, skip to the [Connect to Exchange Online PowerShell without using MFA](#connect-to-exchange-online-powershell-without-using-mfa) section.
 
-   ```PowerShell
-   $UserCredential = Get-Credential
+1. In a Windows PowerShell window, load the EXO V2 module by running the following command:
+
+   ```powershell
+   Import-Module ExchangeOnlineManagement
    ```
 
-   In the **Windows PowerShell Credential Request** dialog box, type your work or school account and password, and then click **OK**.
+2. The command that you need to run uses the following syntax:
 
-2. Run the following command:
-
-   ```PowerShell
-   $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $UserCredential -Authentication Basic -AllowRedirection
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName <UPN> -ShowProgress $true [-ConnectionUri <URL>] [-AzureADAuthorizationEndPointUri <URL>] [-DelegatedOrganization <String>]
    ```
 
-   **Notes**:
+   - _\<UPN\>_ is your account in user principal name format (for example, `navin@contoso.com`).
+   - The _ConnectionUri_ and _AzureADAuthorizationEndPointUrl_ values are described in the table in the [What do you need to know before you begin?](#what-do-you-need-to-know-before-you-begin) section.
 
-   - For Office 365 operated by 21Vianet, use the _ConnectionUri_ value: `https://partner.outlook.cn/PowerShell`
+   **This example connects to Exchange Online PowerShell in a Microsoft 365 or Microsoft 365 GCC organization**:
 
-   - For Office 365 Germany, use the _ConnectionUri_ value: `https://outlook.office.de/powershell-liveid/`
-
-   - For Microsoft 365 GCC High, use the _ConnectionUri_ value: `https://outlook.office365.us/powershell-liveid/`
-
-   - For Microsoft 365 DoD, use the _ConnectionUri_ value: `https://webmail.apps.mil/powershell-liveid`
-
-   - If you're behind a proxy server, run this command first: `$ProxyOptions = New-PSSessionOption -ProxyAccessType <Value>`, where \<Value\> is `IEConfig`, `WinHttpConfig`, or `AutoDetect`.
-
-     Then, add the following parameter and value to the end of the $Session = ... command: `-SessionOption $ProxyOptions`.
-
-     For more information, see [New-PSSessionOption](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssessionoption).
-
-3. Run the following command:
-
-   ```PowerShell
-   Import-PSSession $Session -DisableNameChecking
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName navin@contoso.com -ShowProgress $true
    ```
+
+   **This example connects to Exchange Online PowerShell in an Office 365 Germany organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName lukas@fabrikam.de -ShowProgress $true -ConnectionUri https://outlook.office.de/PowerShell-LiveID -AzureADAuthorizationEndPointUri https://login.microsoftonline.de/common
+   ```
+
+   **This example connects to Exchange Online PowerShell in a Microsoft GCC High organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName laura@blueyonderairlines.us -ShowProgress $true -ConnectionUri https://outlook.office365.us/powershell-liveid -AzureADAuthorizationEndPointUri https://login.microsoftonline.us/common
+   ```
+
+   **This example connects to Exchange Online PowerShell in a Microsoft 365 DoD organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName julia@adatum.mil -ShowProgress $true -ConnectionUri https://webmail.apps.mil/powershell-liveid -AzureADAuthorizationEndPointUri https://login.microsoftonline.us/common
+   ```
+
+   **This example connects to Exchange Online PowerShell to manage another tenant**:
+
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName chris@contoso.com -DelegatedOrganization adatum.onmicrosoft.com
+   ```
+
+For detailed syntax and parameter information, see [Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
 
 > [!NOTE]
 > Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
 
-```PowerShell
-Remove-PSSession $Session
+```powershell
+Disconnect-ExchangeOnline
+```
+
+## Connect to Exchange Online PowerShell without using MFA
+
+If your account doesn't use multi-factor authentication, use the steps in this section.
+
+1. In a Windows PowerShell window, load the EXO V2 module by running the following command:
+
+   ```powershell
+   Import-Module ExchangeOnlineManagement
+   ```
+
+2. Run the following command:
+
+   ```powershell
+   $UserCredential = Get-Credential
+   ```
+
+   In the **Windows PowerShell Credential Request** dialog box that appears, type your work or school account and password, and then click **OK**.
+
+3. The command that you need to run uses the following syntax:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential = Get-Credential -ShowProgress $true [-ConnectionUri <URL>] [-DelegatedOrganization <String>]
+   ```
+
+   The _ConnectionUri_ values are described in the table in the [What do you need to know before you begin?](#what-do-you-need-to-know-before-you-begin) section.
+
+   **Connect to Exchange Online PowerShell in a Microsoft 365 or Microsoft 365 GCC organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential -ShowProgress $true
+   ```
+
+   **Connect to Exchange Online PowerShell in an Office 365 Germany organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential -ShowProgress $true -ConnectionUri https://outlook.office.de/powershell-liveid/
+   ```
+
+   **Connect to Exchange Online PowerShell in an Office 365 operated by 21Vianet organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential -ShowProgress $true -ConnectionUri https://partner.outlook.cn/PowerShell
+   ```
+
+   **Connect to Exchange Online PowerShell in a Microsoft 365 GCC High organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential -ShowProgress $true -ConnectionUri https://outlook.office365.us/powershell-liveid/
+   ```
+
+   **Connect to Exchange Online PowerShell in a Microsoft 365 DoD organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential -ShowProgress $true -ConnectionUri https://webmail.apps.mil/powershell-liveid
+   ```
+
+For detailed syntax and parameter information, see [Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
+
+> [!NOTE]
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
+
+```powershell
+Disconnect-ExchangeOnline
 ```
 
 ## How do you know this worked?
 
-After Step 3, the Exchange Online cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online cmdlet, for example, **Get-Mailbox**, and see the results.
+The Exchange Online cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online PowerShell cmdlet, for example, **Get-Mailbox**, and see the results.
 
 If you receive errors, check the following requirements:
 
@@ -139,24 +180,8 @@ If you receive errors, check the following requirements:
 
 - To help prevent denial-of-service (DoS) attacks, you're limited to three open remote PowerShell connections to your Exchange Online organization.
 
-- The account you use to connect to Exchange Online must be enabled for remote PowerShell. For more information, see [Enable or disable access to Exchange Online PowerShell](disable-access-to-exchange-online-powershell.md).
+- The account you use to connect to must be enabled for remote PowerShell. For more information, see [Enable or disable access to Exchange Online PowerShell](disable-access-to-exchange-online-powershell.md).
 
 - TCP port 80 traffic needs to be open between your local computer and Microsoft 365. It's probably open, but it's something to consider if your organization has a restrictive internet access policy.
 
 - If your organization uses federated authentication, and your identity provider (IDP) and/or security token service (STS) isn't publicly available, you can't use a federated account to connect to Exchange Online PowerShell. Instead, create and use a non-federated account in Microsoft 365 to connect to Exchange Online PowerShell.
-
-## See also
-
-The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
-
-- [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
-
-- [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
-
-- [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
-
-- [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
-
-- [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)
-
-For more information about managing Microsoft 365, see [Manage Microsoft 365 and Office 365](https://docs.microsoft.com/Office365/).

--- a/exchange/docs-conceptual/connect-to-exchange-online-protection-powershell.md
+++ b/exchange/docs-conceptual/connect-to-exchange-online-protection-powershell.md
@@ -1,118 +1,150 @@
 ---
-title: "Connect to Exchange Online Protection PowerShell"
-ms.author: chrisda
+title: Connect to Exchange Online Protection PowerShell
 author: chrisda
 manager: dansimp
 ms.date:
 ms.audience: Admin
 ms.topic: article
-ms.service: eop
-localization_priority: Normal
-ms.assetid: 054e0fd7-d465-4572-93f8-a00a9136e4d1
-description: "Use remote PowerShell to connect to a standalone Exchange Online Protection (EOP) organization without mailboxes in Exchange Online."
+ms.service: exchange-online
+ms.reviewer: navgupta
+localization_priority: Priority
+ms.collection: Strat_EX_Admin
+ms.custom:
+ms.assetid:
+search.appverid: MET150
+description: "Learn how to use the Exchange Online PowerShell V2 module to connect to standalone Exchange Online Protection PowerShell with modern authentication and/or multi-factor authentication (MFA)."
 ---
 
 # Connect to Exchange Online Protection PowerShell
 
-In standalone Exchange Online Protection (EOP) organizations without Exchange Online mailboxes, standalone EOP PowerShell allows you to manage your EOP organization from the command line. You use Windows PowerShell on your local computer to create a remote PowerShell session to EOP. It's a simple three-step process where you enter your Microsoft 365 credentials, provide the required connection settings, and then import the EOP cmdlets into your local Windows PowerShell session so that you can use them.
+The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) uses modern authentication and works with multi-factor authentication (MFA) for connecting to all Exchange-related PowerShell environments in Microsoft 365: Exchange Online PowerShell, Security & Compliance PowerShell, and standalone Exchange Online Protection (EOP) PowerShell. For more information about the EXO V2 module, see [About the Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md).
+
+**This topic contains instructions for how to connect to Exchange Online Protection PowerShell using the EXO V2 module with or without using MFA.**
+
+To use the older, less secure remote PowerShell connection instructions that [will eventually be deprecated](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-july-update/ba-p/1530163), see [Bssic auth - Connect to Exchange Online Protection PowerShell](basic-auth-connect-to-eop-powershell.md).
 
 ## What do you need to know before you begin?
 
-- Estimated time to complete: 5 minutes
+- **The procedures in this topic are only for EOP organizations that don't have Exchange Online mailboxes** (for example, you have a standalone EOP subscription that protects your on-premises email environment). If you have a Microsoft 365 subscription includes Exchange Online mailboxes, you can't connect to Exchange Online Protection PowerShell. The same features are available in [Exchange Online PowerShell](exchange-online-powershell.md).
 
-- The instructions in this topic are for organizations without Exchange Online mailboxes (for example, you have a standalone EOP subscription to protect your on-premises email environment). If you have a Microsoft 365 subscription that includes Exchange Online mailboxes, the same features are available in [Exchange Online PowerShell](exchange-online-powershell.md).
+- The requirements for installing and using the EXO V2 module are described in [Install and maintain the EXO V2 module](exchange-online-powershell-v2.md#install-and-maintain-the-exo-v2-module).
 
-- You can use the following versions of Windows:
+- The required cmdlet and _ConnectionUri_ and _AzureADAuthorizationEndPointUri_ parameter values depend on the nature of your Microsoft 365 organization as described in the following table:
 
-  - Windows 10
+  ****
 
-  - Windows 8.1
-
-  - Windows Server 2019
-
-  - Windows Server 2016
-
-  - Windows Server 2012 or Windows Server 2012 R2
-
-  - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
-
-  - Windows Server 2008 R2 SP1<sup>*</sup>
-
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
-
-- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
-
-  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
-
-  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
-
-  ```PowerShell
-  Set-ExecutionPolicy RemoteSigned
-  ```
-
-- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
-
-  **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
-
-  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in Windows PowerShell):
-  
-  ```dos
-  winrm get winrm/config/client/auth
-  ```
-
-  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in Windows PowerShell) to enable Basic authentication for WinRM:
-
-  ```dos
-  winrm set winrm/config/client/auth @{Basic="true"}
-  ```
-
-  **Note**: If you'd rather run the command in Windows PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
-
-  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
-
-  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
+  |Microsoft 365 offering|Cmdlet|_ConnectionUri_ value|_AzureADAuthorizationEndPointUri_ value|
+  |---|---|---|---|
+  |Microsoft 365|**Connect-IPPSSession**|https://ps.protection.outlook.com/powershell-liveid/|Not used|
+  |Office 365 Germany|**Connect-IPPSSession**|`https://outlook.office.de/PowerShell-LiveID`|`https://login.microsoftonline.de/common`|
+  |Exchange Enterprise CAL with Services licenses (on-premises Exchange)|**Connect-ExchangeOnline**|Not used|Not used|
+  |
 
 > [!TIP]
 > Having problems? Ask for help in the [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351) forum.
 
-## Connect to Exchange Online Protection
+## Connect to Exchange Online Protection PowerShell using MFA
 
-1. On your local computer, open Windows PowerShell and run the following command:
+If you account uses multi-factor authentication, use the steps in this section. Otherwise, skip to the [Connect to Exchange Online Protection PowerShell without using MFA](#connect-to-exchange-online-protection-powershell-without-using-mfa) section.
 
-    ```PowerShell
-    $UserCredential = Get-Credential
-    ```
+1. In a Windows PowerShell window, load the EXO V2 module by running the following command:
 
-    In the **Windows PowerShell Credential Request** dialog box, type your work or school account and password, and then click **OK**.
+   ```powershell
+   Import-Module ExchangeOnlineManagement
+   ```
+
+2. The command that you need to run uses the following syntax:
+
+   ```powershell
+   <Connect-IPPSSession | Connect-ExchangeOnline> -UserPrincipalName <UPN> -ShowProgress $true [-ConnectionUri <URL>] [-AzureADAuthorizationEndPointUri <URL>]
+   ```
+
+   - _\<UPN\>_ is your account in user principal name format (for example, `navin@contoso.com`).
+   - The required cmdlet and _ConnectionUri_ and _AzureADAuthorizationEndPointUri_ parameter values are described in the table in the [What do you need to know before you begin?](#what-do-you-need-to-know-before-you-begin) section.
+
+   **This example connects to Exchange Online Protection PowerShell in a Microsoft 365 organization**:
+
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName navin@contoso.com -ShowProgress $true -ConnectionUri https://ps.protection.outlook.com/powershell-liveid/
+   ```
+
+   **This example connects to Exchange Online Protection PowerShell in an Office 365 Germany organization**:
+
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName lukas@fabrikam.com -ShowProgress $true -ConnectionUri https://ps.protection.outlook.de/powershell-liveid/ -AzureADAuthorizationEndPointUri https://login.microsoftonline.de/common
+   ```
+
+   **This example connects to Exchange Online Protection PowerShell in an Exchange Enterprise CAL with Services organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -UserPrincipalName chris@tailspintoys.com
+   ```
+
+For detailed syntax and parameter information, see [Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline) and [Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
+
+> [!NOTE]
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
+
+```powershell
+Disconnect-ExchangeOnline
+```
+
+## Connect to Exchange Online Protection PowerShell without using MFA
+
+If your account doesn't use multi-factor authentication, use the steps in this section.
+
+1. In a Windows PowerShell window, load the EXO V2 module by running the following command:
+
+   ```powershell
+   Import-Module ExchangeOnlineManagement
+   ```
 
 2. Run the following command:
 
-    ```PowerShell
-    $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.protection.outlook.com/powershell-liveid/ -Credential $UserCredential -Authentication Basic -AllowRedirection
-    ```
-
-    **Notes**:
-
-   - For Office 365 Germany, use the _ConnectionUri_ value: `https://ps.protection.outlook.de/powershell-liveid/`
-
-   - For on-premises Exchange organization with Exchange Enterprise CAL with Services licenses, use the _ConnectionUri_ value: `https://outlook.office365.com/powershell-liveid/`
-
-3. Run the following command:
-
-   ```PowerShell
-   Import-PSSession $Session -DisableNameChecking
+   ```powershell
+   $UserCredential = Get-Credential
    ```
 
-   > [!NOTE]
-   > Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command:
+   In the **Windows PowerShell Credential Request** dialog box that appears, type your work or school account and password, and then click **OK**.
 
-   ```PowerShell
-   Remove-PSSession $Session
+3. The command that you need to run uses the following syntax:
+
+   ```powershell
+   <Connect-IPPSSession | Connect-ExchangeOnline> -Credential $UserCredential -ShowProgress $true -ConnectionUri <URL>
    ```
+
+  The required cmdlet and _ConnectionUri_ parameter values are described in the table in the [What do you need to know before you begin?](#what-do-you-need-to-know-before-you-begin) section.
+
+   **This example connects to Exchange Online Protection PowerShell in a Microsoft 365 organization**:
+
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri https://ps.protection.outlook.com/powershell-liveid/
+   ```
+
+   **This example connects to Exchange Online Protection PowerShell in an Office 365 Germany organization**:
+
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri https://ps.protection.outlook.de/powershell-liveid/
+   ```
+
+   **This example connects to Exchange Online Protection PowerShell in an Exchange Enterprise CAL with Services organization**:
+
+   ```powershell
+   Connect-ExchangeOnline -Credential $UserCredential
+   ```
+
+For detailed syntax and parameter information, see [Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline) and [Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
+
+> [!NOTE]
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
+
+```powershell
+Disconnect-ExchangeOnline
+```
 
 ## How do you know this worked?
 
-After Step 3, the Exchange Online Protection cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online Protection cmdlet, for example, **Get-TransportRule**, and see the results.
+The Exchange Online Protection Protection cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run an Exchange Online Protection cmdlet, for example, **Get-TransportRule**, and see the results.
 
 If you receive errors, check the following requirements:
 
@@ -126,22 +158,8 @@ If you receive errors, check the following requirements:
 
   > Import-PSSession : Running the Get-Command command in a remote session reported the following error: Processing data for a remote command failed with the following error message: The request for the Windows Remote Shell with ShellId <GUID> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
 
-- The **New-PSSession** command (Step 2) might fail to connect if your client IP address changes during the connection request. This can happen if your organization uses a source network address translation (SNAT) pool that contains multiple IP addresses. The connection error looks like this:
+- You might fail to connect if your client IP address changes during the connection request. This can happen if your organization uses a source network address translation (SNAT) pool that contains multiple IP addresses. The connection error looks like this:
 
   > The request for the Windows Remote Shell with ShellId <ID> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
 
   To fix the issue, use an SNAT pool that contains a single IP address, or force the use of a specific IP address for connections to the Exchange Online Protection PowerShell endpoint.
-
-## See also
-
-The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
-
-- [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
-
-- [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
-
-- [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
-
-- [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
-
-- [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)

--- a/exchange/docs-conceptual/connect-to-exchange-servers-using-remote-powershell.md
+++ b/exchange/docs-conceptual/connect-to-exchange-servers-using-remote-powershell.md
@@ -19,7 +19,10 @@ description: "Use Windows PowerShell on a local computer to connect to an Exchan
 If you don't have the Exchange management tools installed on your local computer, you can use Windows PowerShell to create a remote PowerShell session to an Exchange server. It's a simple three-step process, where you enter your credentials, provide the required connection settings, and then import the Exchange cmdlets into your local Windows PowerShell session so that you can use them.
 
 > [!NOTE]
-> We recommend that you use the Exchange Management Shell on any computer that you use to extensively administer Exchange servers. You'll get the Exchange Management Shell by installing the Exchange management tools. For more information, see [Install the Exchange Server Management Tools](https://docs.microsoft.com/Exchange/plan-and-deploy/post-installation-tasks/install-management-tools) and [Open the Exchange Management Shell](open-the-exchange-management-shell.md). For more information about the Exchange Management Shell, see [Exchange Server PowerShell (Exchange Management Shell)](exchange-management-shell.md). <br/><br/> The **Get-ExchangeCertificate** cmdlet does not fully support remote PowerShell. We recommend that you use the Exchange Management Shell instead to get all the properties of this cmdlet.
+> 
+> - We recommend that you use the Exchange Management Shell on any computer that you use to extensively administer Exchange servers. You get the Exchange Management Shell by installing the Exchange management tools. For more information, see [Install the Exchange Server Management Tools](https://docs.microsoft.com/Exchange/plan-and-deploy/post-installation-tasks/install-management-tools) and [Open the Exchange Management Shell](open-the-exchange-management-shell.md). For more information about the Exchange Management Shell, see [Exchange Server PowerShell (Exchange Management Shell)](exchange-management-shell.md).
+> 
+> - The **Get-ExchangeCertificate** cmdlet does not fully support remote PowerShell. We recommend that you use the Exchange Management Shell instead to get all the properties of this cmdlet.
 
 ## What do you need to know before you begin?
 
@@ -28,20 +31,14 @@ If you don't have the Exchange management tools installed on your local computer
 - You can use the following versions of Windows:
 
   - Windows 10
-
   - Windows 8.1
-
   - Windows Server 2019
-
   - Windows Server 2016
-
   - Windows Server 2012 or Windows Server 2012 R2
-
   - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
-
   - Windows Server 2008 R2 SP1<sup>*</sup>
 
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
 - Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
 
@@ -49,11 +46,11 @@ If you don't have the Exchange management tools installed on your local computer
 
   To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
 
-  ```PowerShell
+  ```powershell
   Set-ExecutionPolicy RemoteSigned
   ```
 
-    You need to configure this setting only once on your computer, not every time you connect.
+  For more information about execution policies, see [About Execution Policies](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies).
 
 > [!TIP]
 > Having problems? Ask for help in the [Exchange Server](https://go.microsoft.com/fwlink/p/?linkId=60612) forum.
@@ -62,7 +59,7 @@ If you don't have the Exchange management tools installed on your local computer
 
 1. On your local computer, open Windows PowerShell, and run the following command:
 
-   ```PowerShell
+   ```powershell
    $UserCredential = Get-Credential
    ```
 
@@ -70,7 +67,7 @@ If you don't have the Exchange management tools installed on your local computer
 
 2. Replace `<ServerFQDN>` with the fully qualified domain name of your Exchange server (for example, `mailbox01.contoso.com`) and run the following command:
 
-   ```PowerShell
+   ```powershell
    $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri http://<ServerFQDN>/PowerShell/ -Authentication Kerberos -Credential $UserCredential
    ```
 
@@ -78,14 +75,14 @@ If you don't have the Exchange management tools installed on your local computer
 
 3. Run the following command:
 
-   ```PowerShell
+   ```powershell
    Import-PSSession $Session -DisableNameChecking
    ```
 
 > [!NOTE]
 > Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command:
 
-```PowerShell
+```powershell
 Remove-PSSession $Session
 ```
 
@@ -106,11 +103,7 @@ If you receive errors, check the following requirements:
 The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
 
 - [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
-
 - [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
-
 - [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
-
 - [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
-
 - [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)

--- a/exchange/docs-conceptual/connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/connect-to-scc-powershell.md
@@ -1,160 +1,173 @@
 ---
-title: "Connect to Security & Compliance Center PowerShell"
-ms.author: chrisda
+title: Connect to Security & Compliance Center PowerShell using the EXO V2 module
 author: chrisda
 manager: dansimp
 ms.date:
 ms.audience: Admin
 ms.topic: article
-ms.service: o365-security-and-compliance
-localization_priority: Normal
-ms.assetid: 45a5242d-95b7-4a6a-9794-095bb6d8d9d0
+ms.service: exchange-online
+ms.reviewer: navgupta
+localization_priority: Priority
+ms.collection: Strat_EX_Admin
+ms.custom:
+ms.assetid:
 search.appverid: MET150
-description: "Learn how to connect to Security & Compliance Center PowerShell."
+description: "Learn how to use the Exchange Online PowerShell V2 module to connect to Security & Compliance Center PowerShell with modern authentication and/or multi-factor authentication (MFA)."
 ---
 
 # Connect to Security & Compliance Center PowerShell
 
-Security & Compliance Center PowerShell allows you to manage your Security & Compliance Center settings from the command line. You use Windows PowerShell on your local computer to create a remote PowerShell session to the Security & Compliance Center. It's a simple three-step process where you enter your Microsoft 365 credentials, provide the required connection settings, and then import the Security & Compliance Center cmdlets into your local Windows PowerShell session so that you can use them.
+The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) uses modern authentication and works with multi-factor authentication (MFA) for connecting to all Exchange-related PowerShell environments in Microsoft 365: Exchange Online PowerShell, Security & Compliance PowerShell, and standalone Exchange Online Protection (EOP) PowerShell. For more information about the EXO V2 module, see [About the Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md).
 
-> [!NOTE]
-> The procedures in this topic won't work if:
-> 
-> - Your account uses multi-factor authentication (MFA).
-> 
-> - Your organization uses federated authentication.
-> 
-> - A location condition in an Azure Active Directory conditional access policy restricts your access to trusted IPs.
-> 
-> In these scenarios, you need to download and use the Exchange Online Remote PowerShell Module to connect to Security & Compliance Center PowerShell. For instructions, see [Connect to Security & Compliance Center PowerShell using multi-factor authentication](mfa-connect-to-scc-powershell.md).
-> 
-> Some features in the Security & Compliance Center (for example, mailbox archiving) link to existing functionality in the Exchange admin center (EAC). To use PowerShell with these features, you need to connect to Exchange Online PowerShell instead of Security & Compliance Center PowerShell. For instructions, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
+**This topic contains instructions for how to connect to Security & Compliance Center PowerShell using the EXO V2 module with or without MFA.**
+
+To use the older, less secure remote PowerShell connection instructions that [will eventually be deprecated](https://techcommunity.microsoft.com/t5/exchange-team-blog/basic-authentication-and-exchange-online-july-update/ba-p/1530163), see [Basic auth - Connect to Security & Compliance Center PowerShell](basic-auth-connect-to-scc-powershell.md).
+
+To use the older Exchange Online Remote PowerShell Module to connect to Security & Compliance Center PowerShell using MFA, see [V1 module - Connect to Security & Compliance Center PowerShell using MFA](v1-module-mfa-connect-to-scc-powershell.md). Note that this older version of the module will eventually be retired.
 
 ## What do you need to know before you begin?
 
-- Estimated time to complete: 5 minutes
+- The requirements for installing and using the EXO V2 module are described in [Install and maintain the EXO V2 module](exchange-online-powershell-v2.md#install-and-maintain-the-exo-v2-module).
 
-- Microsoft 365 global admins have access to the Security & Compliance Center, but everyone else needs to have their access configured for them. For details, see [Give users access to the Security & Compliance Center](https://docs.microsoft.com/microsoft-365/security/office-365-security/grant-access-to-the-security-and-compliance-center).
+- The required _ConnectionUri_ and _AzureADAuthorizationEndPointUri_ parameter values depend on the nature of your Microsoft 365 organization as described in the following table:
 
-- You can use the following versions of Windows:
+  ****
 
-  - Windows 10
+  |Microsoft 365 offering|_ConnectionUri_ value|_AzureADAuthorizationEndPointUri_ value|
+  |---|---|---|
+  |Microsoft 365 or Microsoft 365 GCC|`https://ps.compliance.protection.outlook.com/powershell-liveid/`|Not used|
+  |Microsoft 365 GCC High|`https://ps.compliance.protection.office365.us/powershell-liveid/`|`https://login.microsoftonline.us/common`|
+  |Microsoft 365 DoD|`https://l5.ps.compliance.protection.office365.us/powershell-liveid/`|`https://login.microsoftonline.us/common`|
+  |Office 365 Germany|`https://ps.compliance.protection.outlook.de/PowerShell-LiveID`|`https://login.microsoftonline.de/common`|
+  |
 
-  - Windows 8.1
+## Connect to Security & Compliance PowerShell using MFA
 
-  - Windows Server 2019
+If you account uses multi-factor authentication, use the steps in this section. Otherwise, skip to the [Connect to Security & Compliance Center PowerShell without using MFA](#connect-to-security--compliance-center-powershell-without-using-mfa) section.
 
-  - Windows Server 2016
+1. In a Windows PowerShell window, load the EXO V2 module by running the following command:
 
-  - Windows Server 2012 or Windows Server 2012 R2
+   ```powershell
+   Import-Module ExchangeOnlineManagement
+   ```
 
-  - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
+2. The command that you need to run uses the following syntax:
 
-  - Windows Server 2008 R2 SP1<sup>*</sup>
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName <UPN> -ShowProgress $true [-ConnectionUri <URL>] [-AzureADAuthorizationEndPointUri <URL>]
+   ```
 
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+   - \<UPN\> is your account in user principal name format (for example, `navin@contoso.com`).
+   - The required _ConnectionUri_ and _AzureADAuthorizationEndPointUri_ parameter values are described in the table in the [What do you need to know before you begin?](#what-do-you-need-to-know-before-you-begin) section.
 
-- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
+   **This example connects to Security & Compliance Center PowerShell in a Microsoft 365 or Microsoft 365 GCC organization**.
 
-  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName chris@contoso.com -ShowProgress $true -ConnectionUri https://ps.compliance.protection.outlook.com/powershell-liveid/
+   ```
 
-  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
+   **This example connects to Security & Compliance Center PowerShell in an Office 365 Germany organization**.
 
-  ```PowerShell
-  Set-ExecutionPolicy RemoteSigned
-  ```
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName lukas@fabrikam.de -ShowProgress $true -ConnectionUri https://ps.compliance.protection.outlook.de/PowerShell-LiveID -AzureADAuthorizationEndPointUri https://login.microsoftonline.de/common
+   ```
 
-- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+   **This example connects to Security & Compliance Center PowerShell in a Microsoft GCC High organization**.
 
-  **Note** You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName laura@blueyonderairlines.us -ShowProgress $true -ConnectionUri https://l5.ps.compliance.protection.office365.us/powershell-liveid/ -AzureADAuthorizationEndPointUri https://login.microsoftonline.us/common
+   ```
 
-  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in Windows PowerShell):
+   **This example connects to Security & Compliance Center PowerShell in a Microsoft 365 DoD organization**.
 
-  ```dos
-  winrm get winrm/config/client/auth
-  ```
+   ```powershell
+   Connect-IPPSSession -UserPrincipalName julia@adatum.mil -ShowProgress $true -ConnectionUri https://l5.ps.compliance.protection.office365.us/powershell-liveid/ -AzureADAuthorizationEndPointUri https://login.microsoftonline.us/common
+   ```
 
-  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in Windows PowerShell) to enable Basic authentication for WinRM:
+For detailed syntax and parameter information, see [Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
 
-  ```dos
-  winrm set winrm/config/client/auth @{Basic="true"}
-  ```
+> [!NOTE]
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
 
-  **Note**: If you'd rather run the command in Windows PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
+```powershell
+Disconnect-ExchangeOnline
+```
 
-  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
+## Connect to Security & Compliance Center PowerShell without using MFA
 
-  > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
+If your account doesn't use multi-factor authentication, use the steps in this section.
 
-## Connect to the Security & Compliance Center
+1. In a Windows PowerShell window, load the EXO V2 module by running the following command:
 
-1. On your local computer, open Windows PowerShell and run the following command:
+   ```powershell
+   Import-Module ExchangeOnlineManagement
+   ```
 
-   ```PowerShell
+2. Run the following command:
+
+   ```powershell
    $UserCredential = Get-Credential
    ```
 
    In the **Windows PowerShell Credential Request** dialog box that appears, type your work or school account and password, and then click **OK**.
 
-2. Run the following command:
+3. The command that you need to run uses the following syntax:
 
-   ```PowerShell
-   $Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.compliance.protection.outlook.com/powershell-liveid/ -Credential $UserCredential -Authentication Basic -AllowRedirection
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri <URL>
    ```
 
-   **Notes**:
+   The _ConnectionUri_ values are described in the table in the [What do you need to know before you begin?](#what-do-you-need-to-know-before-you-begin) section.
 
-   - For Office 365 Germany, use the _ConnectionUri_ value: `https://ps.compliance.protection.outlook.de/powershell-liveid/`.
+   **This example connects to Security & Compliance Center PowerShell in a Microsoft 365 or Microsoft 365 GCC organization**.
 
-   - For Microsoft 365 GCC High, use the _ConnectionUri_ value: `https://ps.compliance.protection.office365.us/powershell-liveid/`.
-
-   - For Microsoft 365 DoD, use the _ConnectionUri_ value: `https://l5.ps.compliance.protection.office365.us/powershell-liveid/`.
-
-3. Run the following command:
-
-   ```PowerShell
-   Import-PSSession $Session -DisableNameChecking
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri https://ps.compliance.protection.outlook.com/powershell-liveid/
    ```
 
-   If you want to connect to Security & Compliance Center PowerShell in the same window as an active Exchange Online PowerShell connection, you need to add the Prefix parameter and value (for example, `-Prefix "CC"`) to the end of this command to prevent cmdlet name collisions (both environments share some cmdlets with the same names).
+   **This example connects to Security & Compliance Center PowerShell in an Office 365 Germany organization**.
+
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri https://ps.compliance.protection.outlook.de/
+   ```
+
+   **This example connects to Security & Compliance Center PowerShell in a Microsoft GCC High organization**.
+
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri https://l5.ps.compliance.protection.office365.us/powershell-liveid/
+   ```
+
+   **This example connects to Security & Compliance Center PowerShell in a Microsoft 365 DoD organization**.
+
+   ```powershell
+   Connect-IPPSSession -Credential $UserCredential -ShowProgress $true -ConnectionUri https://l5.ps.compliance.protection.office365.us/powershell-liveid/
+   ```
+
+For detailed syntax and parameter information, see [Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
 
 > [!NOTE]
-> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command:
+> Be sure to disconnect the remote PowerShell session when you're finished. If you close the Windows PowerShell window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect the remote PowerShell session, run the following command.
 
-```PowerShell
-Remove-PSSession $Session
+```powershell
+Disconnect-ExchangeOnline
 ```
 
 ## How do you know this worked?
 
-After Step 3, the Security & Compliance Center cmdlets are imported into your local Windows PowerShell session as tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run a Security & Compliance Center cmdlet, for example, **Get-RetentionCompliancePolicy**, and see the results.
+The Security & Compliance Center cmdlets are imported into your local Windows PowerShell session and tracked by a progress bar. If you don't receive any errors, you connected successfully. A quick test is to run a Security & Compliance Center cmdlet, for example, **Get-RetentionCompliancePolicy**, and see the results.
 
 If you receive errors, check the following requirements:
 
 - A common problem is an incorrect password. Run the three steps again and pay close attention to the user name and password you enter in Step 1.
 
-- Verify that your account has permission to access the Security & Compliance Center. For details, see [Give users access to the Security & Compliance Center](https://docs.microsoft.com/microsoft-365/security/office-365-security/grant-access-to-the-security-and-compliance-center).
+- To help prevent denial-of-service (DoS) attacks, you're limited to three open remote PowerShell connections to your Exchange Online organization.
 
-- To help prevent denial-of-service (DoS) attacks, you're limited to three open remote PowerShell connections to the Security & Compliance Center.
+- The account you use to connect must be enabled for remote PowerShell. For more information, see [Enable or disable access to Exchange Online PowerShell](disable-access-to-exchange-online-powershell.md).
 
-- TCP port 80 traffic needs to be open between your local computer and Microsoft 365. It's probably open, but it's something to consider if your organization has a restrictive Internet access policy.
+- TCP port 80 traffic needs to be open between your local computer and Microsoft 365. It's probably open, but it's something to consider if your organization has a restrictive internet access policy.
 
-- The **New-PSSession** command (Step 2) might fail to connect if your client IP address changes during the connection request. This can happen if your organization uses a source network address translation (SNAT) pool that contains multiple IP addresses. The connection error looks like this:
+- You might fail to connect if your client IP address changes during the connection request. This can happen if your organization uses a source network address translation (SNAT) pool that contains multiple IP addresses. The connection error looks like this:
 
-  > The request for the Windows Remote Shell with ShellId <ID> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
+  > The request for the Windows Remote Shell with ShellId \<ID\> failed because the shell was not found on the server. Possible causes are: the specified ShellId is incorrect or the shell no longer exists on the server. Provide the correct ShellId or create a new shell and retry the operation.
 
-  To fix the issue, use an SNAT pool that contains a single IP address, or force the use of a specific IP address for connections to the Security & Compliance Center PowerShell endpoint.
-
-## See also
-
-The cmdlets that you use in this topic are Windows PowerShell cmdlets. For more information about these cmdlets, see the following topics.
-
-- [Get-Credential](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/get-credential)
-
-- [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)
-
-- [Import-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/import-pssession)
-
-- [Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)
-
-- [Set-ExecutionPolicy](https://docs.microsoft.com/powershell/module/microsoft.powershell.security/set-executionpolicy)
+  To fix the issue, use an SNAT pool that contains a single IP address, or force the use of a specific IP address for connections to the Security & Compliance PowerShell endpoint.

--- a/exchange/docs-conceptual/control-remote-powershell-access-to-exchange-servers.md
+++ b/exchange/docs-conceptual/control-remote-powershell-access-to-exchange-servers.md
@@ -37,13 +37,13 @@ For additional management tasks related to remote PowerShell, see [Connect to Ex
 
 This example disables remote PowerShell access for the user named Therese Lindqvist.
 
-```PowerShell
+```powershell
 Set-User "Therese Lindqvist" -RemotePowerShellEnabled $false
 ```
 
 This example enables remote PowerShell access for the user named Sirirat Kitjakarn.
 
-```PowerShell
+```powershell
 Set-User "Sirirat Kitjakarn" -RemotePowerShellEnabled $true
 ```
 
@@ -59,21 +59,21 @@ To prevent remote PowerShell access for a specific group of existing users, you 
 
 To disable access to remote PowerShell for any number of users based on an existing attribute, use the following syntax:
 
-```PowerShell
+```powershell
 $<VariableName> = <Get-Mailbox | Get-User> -ResultSize unlimited -Filter <Filter>
 ```
 
-```PowerShell
+```powershell
 $<VariableName> | foreach {Set-User -RemotePowerShellEnabled $false}
 ```
 
 This example removes access to remote PowerShell for all users whose **Title** attribute contains the value "Sales Associate".
 
-```PowerShell
+```powershell
 $DSA = Get-User -ResultSize unlimited -Filter "(RecipientType -eq 'UserMailbox') -and (Title -like '*Sales Associate*')"
 ```
 
-```PowerShell
+```powershell
 $DSA | foreach {Set-User -RemotePowerShellEnabled $false}
 ```
 
@@ -81,11 +81,11 @@ $DSA | foreach {Set-User -RemotePowerShellEnabled $false}
 
 To disable access to remote PowerShell for a list of specific users, use the following syntax:
 
-```PowerShell
+```powershell
 $<VariableName> = Get-Content <text file>
 ```
 
-```PowerShell
+```powershell
 $<VariableName> | foreach {Set-User -RemotePowerShellEnabled $false
 ```
 
@@ -95,11 +95,11 @@ This example uses the text file C:\My Documents\NoPowerShell.txt to identify the
 
 After you populate the text file with the user accounts you want to update, run the following commands:
 
-```PowerShell
+```powershell
 $NPS = Get-Content "C:\My Documents\NoPowerShell.txt"
 ```
 
-```PowerShell
+```powershell
 $NPS | foreach {Set-User -RemotePowerShellEnabled $false}
 ```
 
@@ -107,30 +107,30 @@ $NPS | foreach {Set-User -RemotePowerShellEnabled $false}
 
 To view the remote PowerShell access status for a specific user, use the following syntax:
 
-```PowerShell
+```powershell
 Get-User -Identity <UserIdentity> | Format-List RemotePowerShellEnabled
 ```
 
 This example displays the remote PowerShell access status of the user named Sarah Jones.
 
-```PowerShell
+```powershell
 Get-User -Identity "Sarah Jones" | Format-List RemotePowerShellEnabled
 ```
 
 To display the remote PowerShell access status for all users, run the following command:
 
-```PowerShell
+```powershell
 Get-User -ResultSize unlimited | Format-Table -Auto Name,DisplayName,RemotePowerShellEnabled
 ```
 
 To display only those users who don't have access to remote PowerShell, run the following command:
 
-```PowerShell
+```powershell
 Get-User -ResultSize unlimited -Filter 'RemotePowerShellEnabled -eq $false'
 ```
 
 To display only those users who have access to remote PowerShell, run the following command:
 
-```PowerShell
+```powershell
 Get-User -ResultSize unlimited -Filter 'RemotePowerShellEnabled -eq $true'
 ```

--- a/exchange/docs-conceptual/disable-access-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/disable-access-to-exchange-online-powershell.md
@@ -23,9 +23,11 @@ Exchange Online PowerShell enables you to manage your Exchange Online organizati
 
 - Microsoft 365 global admins have access to Exchange Online PowerShell, and can use the procedures in this topic to configure Exchange Online PowerShell access for other users. For more information about permissions in Exchange Online, see [Feature Permissions in Exchange Online](https://docs.microsoft.com/exchange/permissions-exo/feature-permissions).
 
-- You can only use Exchange Online PowerShell to perform this procedure. To learn how to use Windows PowerShell to connect to Exchange Online, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
+- You can only use Exchange Online PowerShell to perform this procedure. To connect to Exchange Online PowerShell, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
 
 - For detailed information about OPath filter syntax in Exchange Online, see [Additional OPATH syntax information](recipient-filters.md#additional-opath-syntax-information).
+
+- You can also use Client Access Rules to block PowerShell access to Exchange Online. For details, see [Client Access Rules in Exchange Online](https://docs.microsoft.com/Exchange/clients-and-mobile-in-exchange-online/client-access-rules/client-access-rules).
 
 > [!TIP]
 > Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
@@ -34,13 +36,13 @@ Exchange Online PowerShell enables you to manage your Exchange Online organizati
 
 This example disables access to Exchange Online PowerShell for the user david@contoso.com.
 
-```PowerShell
+```powershell
 Set-User -Identity david@contoso.com -RemotePowerShellEnabled $false
 ```
 
 This example enables access to Exchange Online PowerShell for the user david@contoso.com.
 
-```PowerShell
+```powershell
 Set-User -Identity david@contoso.com -RemotePowerShellEnabled $true
 ```
 
@@ -56,21 +58,21 @@ To prevent access to Exchange Online PowerShell for a specific group of existing
 
 To disable access to Exchange Online PowerShell for any number of users based on an existing attribute, use the following syntax:
 
-```PowerShell
+```powershell
 $<VariableName> = <Get-Mailbox | Get-User> -ResultSize unlimited -Filter <Filter>
 ```
 
-```PowerShell
+```powershell
 $<VariableName> | foreach {Set-User -Identity $_ -RemotePowerShellEnabled $false}
 ```
 
 This example removes access to Exchange Online PowerShell for all users whose **Title** attribute contains the value "Sales Associate".
 
-```PowerShell
+```powershell
 $DSA = Get-User -ResultSize unlimited -Filter "(RecipientType -eq 'UserMailbox') -and (Title -like '*Sales Associate*')"
 ```
 
-```PowerShell
+```powershell
 $DSA | foreach {Set-User -Identity $_ -RemotePowerShellEnabled $false}
 ```
 
@@ -78,11 +80,11 @@ $DSA | foreach {Set-User -Identity $_ -RemotePowerShellEnabled $false}
 
 To disable access to Exchange Online PowerShell for a list of specific users, use the following syntax:
 
-```PowerShell
+```powershell
 $<VariableName> = Get-Content <text file>
 ```
 
-```PowerShell
+```powershell
 $<VariableName> | foreach {Set-User -Identity $_ -RemotePowerShellEnabled $false}
 ```
 
@@ -92,11 +94,11 @@ This example uses the text file C:\My Documents\NoPowerShell.txt to identify the
 
 After you populate the text file with the user accounts you want to update, run the following commands:
 
-```PowerShell
+```powershell
 $NPS = Get-Content "C:\My Documents\NoPowerShell.txt"
 ```
 
-```PowerShell
+```powershell
 $NPS | foreach {Set-User -Identity $_.MicrosoftOnlineServicesID -RemotePowerShellEnabled $false}
 ```
 
@@ -104,30 +106,30 @@ $NPS | foreach {Set-User -Identity $_.MicrosoftOnlineServicesID -RemotePowerShel
 
 To view the Exchange Online PowerShell access status for a specific user, use the following syntax:
 
-```PowerShell
+```powershell
 Get-User -Identity <UserIdentity> | Format-List RemotePowerShellEnabled
 ```
 
 This example displays the Exchange Online PowerShell access status of the user named Sarah Jones.
 
-```PowerShell
+```powershell
 Get-User -Identity "Sarah Jones" | Format-List RemotePowerShellEnabled
 ```
 
 To display the Exchange Online PowerShell access status for all users, run the following command:
 
-```PowerShell
+```powershell
 Get-User -ResultSize unlimited | Format-Table -Auto Name,DisplayName,RemotePowerShellEnabled
 ```
 
 To display only those users who don't have access to Exchange Online PowerShell, run the following command:
 
-```PowerShell
+```powershell
 Get-User -ResultSize unlimited -Filter 'RemotePowerShellEnabled -eq $false'
 ```
 
 To display only those users who have access to Exchange Online PowerShell, run the following command:
 
-```PowerShell
+```powershell
 Get-User -ResultSize unlimited -Filter 'RemotePowerShellEnabled -eq $true'
 ```

--- a/exchange/docs-conceptual/exchange-cmdlet-syntax.md
+++ b/exchange/docs-conceptual/exchange-cmdlet-syntax.md
@@ -17,9 +17,7 @@ description: "Learn about the structure and syntax of cmdlets in Exchange PowerS
 Exchange cmdlet reference topics use a standardized method that describes key aspects about the cmdlet. For example:
 
 - Parameters that are available on the cmdlet.
-
 - Values that each parameter accepts.
-
 - Parameters that can be used together, and parameters that need to be used separately.
 
 This topic explains these conventions, and also the syntax that's required to run commands in Exchange PowerShell.
@@ -28,12 +26,13 @@ This topic explains these conventions, and also the syntax that's required to ru
 
 Exchange PowerShell help follows conventions that indicate what's required or optional, and how to enter parameters and values when you run a command. These command conventions are listed in the following table.
 
-|**Symbol**|**Description**|
-|:-----|:-----|
-| - |A hyphen indicates a parameter. For example, `-Identity`.|
-|\< \>|Angle brackets indicate the possible values for a parameter. For example, `-Location <ServerName>` or -Enabled \<$true \| $false\>.|
-|[ ]|Square brackets indicate optional parameters and their values. For example, `[-WhatIf]` or `[-ResultSize <Unlimited>]`. <br/> Parameter-value pairs that aren't enclosed in square brackets are required. For example, `-Password <SecureString>`. <br/> If the parameter name itself is enclosed in square brackets, that indicates the parameter is a _positional_ parameter (you can use the parameter value without specifying the parameter), and positional parameters can be required or optional. <br/> For example, `Get-Mailbox [[-Identity] <MailboxIdParameter>]` means the _Identity_ parameter is positional (because it's enclosed in square brackets) and optional (because the whole parameter-value pair is enclosed in square brackets), so you can use `Get-Mailbox -Identity <MailboxIdParameter>` or `Get-Mailbox <MailboxIdParameter>`. Similarly, `Set-Mailbox [-Identity] <MailboxIdParameter>` means the _Identity_ parameter is positional (because it's enclosed in square brackets) and required (because the whole parameter-value pair is not enclosed in square brackets), so you can use `Set-Mailbox -Identity <MailboxIdParameter>` or `Set-Mailbox <MailboxIdParameter>`.|
-|\||Pipe symbols in parameter values indicate a choice between values. For example, -Enabled \<$true \| $false\> indicates the _Enabled_ parameter can have the value `$true` or `$false`.|
+|Symbol|Description|
+|---|---|
+|`-`|A hyphen indicates a parameter. For example, `-Identity`.|
+|`< >`|Angle brackets indicate the possible values for a parameter. For example, `-Location <ServerName>` or -Enabled \<$true \| $false\>.|
+|`[ ]`|Square brackets indicate optional parameters and their values. For example, `[-WhatIf]` or `[-ResultSize <Unlimited>]`. <br/> Parameter-value pairs that aren't enclosed in square brackets are required. For example, `-Password <SecureString>`. <br/> If the parameter name itself is enclosed in square brackets, that indicates the parameter is a _positional_ parameter (you can use the parameter value without specifying the parameter), and positional parameters can be required or optional. <br/> For example, `Get-Mailbox [[-Identity] <MailboxIdParameter>]` means the _Identity_ parameter is positional (because it's enclosed in square brackets) and optional (because the whole parameter-value pair is enclosed in square brackets), so you can use `Get-Mailbox -Identity <MailboxIdParameter>` or `Get-Mailbox <MailboxIdParameter>`. Similarly, `Set-Mailbox [-Identity] <MailboxIdParameter>` means the _Identity_ parameter is positional (because it's enclosed in square brackets) and required (because the whole parameter-value pair is not enclosed in square brackets), so you can use `Set-Mailbox -Identity <MailboxIdParameter>` or `Set-Mailbox <MailboxIdParameter>`.|
+|`|`|Pipe symbols in parameter values indicate a choice between values. For example, -Enabled \<$true \| $false\> indicates the _Enabled_ parameter can have the value `$true` or `$false`.|
+|
 
 These command conventions help you understand how a command is constructed. With the exception of the hyphen that indicates a parameter, you don't use these symbols as they're described in the table when you run cmdlets in Exchange PowerShell.
 
@@ -50,37 +49,25 @@ Many cmdlets have only one parameter set, which means that all available paramet
 This cmdlet has two separate parameter sets. Based on the entries, you can use these parameters together in the same command:
 
 - _DsnCode_
-
 - _Internal_
-
 - _Language_
-
 - _Text_
-
 - _Confirm_
-
 - _DomainController_
-
 - _WhatIf_
 
 And you can use these parameters together in the same command:
 
 - _Language_
-
 - _QuotaMessageType_
-
 - _Text_
-
 - _Confirm_
-
 - _DomainController_
-
 - _WhatIf_
 
 But you can't use these parameters together in the same command:
 
 - _DsnCode_ and _QuotaMessageType_.
-
 - _Internal_ and _QuotaMessageType_.
 
 The `<COMMON PARAMETERS>` entry indicates the cmdlet supports the basic Windows PowerShell parameters that are available on virtually any cmdlet (for example, _Debug_). You can use common parameters with parameters from any parameter set. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/p/?LinkID=113216).
@@ -95,11 +82,11 @@ In Exchange PowerShell, you use single quotation marks ( ' ) or double quotation
 
 If you don't enclose the value `Contoso Receive Connector` in quotes, Exchange PowerShell tries to treat each word as a new argument, and the command will fail. In this example, you'll receive an error that looks like this:
 
- `A positional parameter cannot be found that accepts argument 'Receive'`
+> A positional parameter cannot be found that accepts argument 'Receive'
 
 If the value contains variables, you need choose carefully between single quotes and double quotes. For example, suppose you have a variable named `$Server` that has the value `Mailbox01`.
 
-- **Double quotation marks**: Variables are substituted with their values. The input **"$Server Example"** results in the output `Mailbox01 Example`.
+- **Double quotation marks**: Variables are substituted with their values. For example, if the $Server variable has the value Mailbox01, the input **"$Server Example"** results in the output `Mailbox01 Example`.
 
 - **Single quotation marks**: Variables are treated literally. The input **'$Server Example'** results in the output `$Server Example`.
 
@@ -107,36 +94,37 @@ For more information about variables, see [about_Variables](https://docs.microso
 
 ## Escape characters in Exchange PowerShell
 
-In any programming language, an escape character is used to identify special characters literally, and not by their normal function in that language. In Exchange PowerShell, when you enclose a text string in double quotation marks, the escape character is the back quotation mark escape character ( \` ).
+In any programming language, an _escape character_ is used to identify special characters literally, and not by their normal function in that language. In Exchange PowerShell, when you enclose a text string in double quotation marks, the escape character is the back quotation mark escape character ( ` ).
 
-For example, if you want the output `The price is $23`, enter the value  **"The price is \`$23"**. The escape character is required because the dollar sign character ( $ ) defines variables in Exchange PowerShell.
+For example, if you want the output `The price is $23`, enter the value  **"The price is \`$23"**. The escape character is required on the dollar sign character ( $ ) because $ defines variables in PowerShell.
 
-If you enclose the string in single quotation marks, the only special character you need to worry about is the single quotation mark character itself, which requires two single quotation marks ( '' ).
+If you enclose the string in single quotation marks, the only special character you need to worry about is the single quotation mark character itself, which requires two single quotation marks to escape ( `''` ).
 
- For example, if you want the output `Don't confuse two single quotation marks with a double quotation mark!`, enter the value  **'Don''t confuse two single quotation marks with a double quotation mark!'**.
+ For example, if you want the output `Don't confuse two single quotation marks with a double quotation mark!`, enter the value **'Don''t confuse two single quotation marks with a double quotation mark!'**.
 
 ## Command operators in Exchange PowerShell
 
 The following table shows the valid operators that you can use in an Exchange command. Some of these symbols were also described in the earlier [Command conventions in Exchange PowerShell](#command-conventions-in-exchange-powershell) section. However, these symbols have different meanings when they're used on the command line as operators. For example, the minus sign that's used to indicate a parameter can also be used in a command as a mathematical operator.
 
-|**Operator**|**Description**|
-|:-----|:-----|
-|**=**|The equal sign is used as an assignment character. The value on the right side of the equal sign is assigned to the variable on the left side of the equal sign. The following characters are also assignment characters: <br/> • **+=**: Add the value on the right side of the equal sign to the current value that's contained in the variable on the left side of the equal sign. <br/> • **-=**: Subtract the value on the right side of the equal sign from the current value that's contained in the variable on the left side of the equal sign. <br/> • **\*=**: Multiply the current value of the variable on the left side of the equal sign by the value that's specified on the right side of the equal sign. <br/> • **/=**: Divide the current value of the variable on the left side of the equal sign by the value that's specified on the right side of the equal sign. <br/> • **%=**: Modify the current value of the variable on the left side of the equal sign by the value that's specified on the right side of the equal sign.|
-|**:**|A colon can be used to separate a parameter's name from the parameter's value. For example, `-Enabled:$True`. Using a colon is optional with all parameter types except switch parameters. For more information about switch parameters, see [about_Parameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_parameters).|
-|**!**|The exclamation point is a logical **NOT** operator. When it is used with the equal ( **=** ) sign, the combined pair means "not equal to."|
-|**[ ]**|Brackets are used to specify the index value of an array position. Index values are offsets that start at zero. For example, `$Red[9]` refers to the tenth index position in the array, `$Red`. <br/> Brackets can also be used to assign a type to a variable (for example, `$A=[XML] "<Test><A>value</A></Test>"`). The following variable types are available: `Array`, `Bool`, `Byte`, `Char`, `Char[]`, `Decimal`, `Double`, `Float`, `Int`, `Int[]`, `Long`, `Long[]`, `RegEx`, `Single`, `ScriptBlock`, `String`, `Type`, and `XML.`|
-|**{ }**|Braces are used to include an expression in a command. For example, Get-Process \| Where {$\_.HandleCount -gt 400}|
-|**\|**|The pipe symbol is used when one cmdlet pipes a result to another cmdlet. For example, Get-Mailbox -Server SRV1 \| Set-Mailbox -ProhibitSendQuota 2GB.|
-|**\>**|The right-angle bracket is used to send the output of a command to a file, and the contents of the file are overwritten. For example, `Get-TransportRulePredicate > "C:\My Documents\Output.txt"`.|
-|**\>\>**|Double right-angle brackets are used to append the output of a command to an existing file. If the file doesn't exist, a new file is created. For example, `Get-TransportRulePredicate >> "C:\My Documents\Output.txt"`.|
-|**"**|Double quotation marks are used to enclose text strings that contains spaces.|
-|**$**|A dollar sign indicates a variable. For example, `$Blue = 10` assigns the value `10` to the variable `$Blue`.|
-|**@**|The @ symbol references an associative array. For more information, see [about_Arrays](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays).|
-|**$( )**|A dollar sign ( `$` ) with parentheses indicates command substitution. You can use command substitution when you want to use the output of one command as an argument in another command. For example, `Get-ChildItem $(Read-Host -Prompt "Enter FileName: ")`.|
-|**..**|Double-periods indicate a value range. For example, if an array contains several indexes, you can return the values of all indexes between the second and fifth indexes by running the command: `$Blue[2..5]`.|
-|**+**|The **+** operator adds two values together. For example, `6 + 6` equals `12`.|
-|**-**|The **-** operator subtracts one value from another value (for example, `12 - 6` equals `6`) or indicates a negative number (for example, `-6 * 6` equals `-36`).|
-|**\***|You can use the wildcard character to match strings (for example, Get-User \| Where-Object {$\_.Department -like 'Sales*'}), multiply numeric values (for example, `6 * 6` equals `36`), or repeat the string value the specified number of times (for example, `"Test" * 3` equals `TestTestTest`).|
-|**/**|The **/** operator divides one value by another. For example, `6 / 6` equals `1`.|
-|**%**|In a numerical evaluation, the **%** operator returns the remainder from a division operator. For example, `6 % 4` equals `2`.  <br/> In a pipeline, the percent character ( `%` ) is shorthand for the **ForEach-Object** cmdlet. For example, Import-Csv c:\MyFile.csv \| ForEach-Object {Set-Mailbox $\_.Identity -Name $\_.Name} is the same as Import-Csv c:\MyFile.csv \| % {Set-Mailbox $\_.Identity -Name $\_.Name}. For more information, see [about_Pipelines](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pipelines).|
-|**?**|The question mark character ( **?** ) is shorthand for the **Where-Object** cmdlet. For example, Get-Alias \| Where-Object {$\_.Definition -eq "Clear-Host"} is the same as Get-Alias \| ? {$\_.Definition -eq "Clear-Host"}|
+|Operator|Description|
+|---|---|
+|`=`|The equal sign is used as an assignment character. The value on the right side of the equal sign is assigned to the variable on the left side of the equal sign. The following characters are also assignment characters: <ul><li>`+=`: Add the value on the right side of the equal sign to the current value that's contained in the variable on the left side of the equal sign.</li><li>`-=`: Subtract the value on the right side of the equal sign from the current value that's contained in the variable on the left side of the equal sign.</li><li>`*=`: Multiply the current value of the variable on the left side of the equal sign by the value that's specified on the right side of the equal sign.</li><li>`/=`: Divide the current value of the variable on the left side of the equal sign by the value that's specified on the right side of the equal sign.</li><li> `%=`: Modify the current value of the variable on the left side of the equal sign by the value that's specified on the right side of the equal sign.</li></ul>|
+|`:`|A colon can be used to separate a parameter's name from the parameter's value. For example, `-Enabled:$True`. Using a colon is optional with all parameter types except switch parameters. For more information about switch parameters, see [about_Parameters](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_parameters).|
+|`!`|The exclamation point is a logical NOT operator. When it is used with the equal ( = ) sign, the combined pair (`!=`) means "not equal to."|
+|`[ ]`|Brackets are used to specify the index value of an array position. Index values are offsets that start at zero. For example, `$Red[9]` refers to the tenth index position in the array, `$Red`. <br/> Brackets can also be used to assign a type to a variable (for example, `$A=[XML] "<Test><A>value</A></Test>"`). The following variable types are available: `Array`, `Bool`, `Byte`, `Char`, `Char[]`, `Decimal`, `Double`, `Float`, `Int`, `Int[]`, `Long`, `Long[]`, `RegEx`, `Single`, `ScriptBlock`, `String`, `Type`, and `XML.`|
+|`{ }`|Braces are used to include an expression in a command. For example, Get-Process \| Where {$\_.HandleCount -gt 400}|
+|`|`|The pipe symbol is used when one cmdlet pipes a result to another cmdlet. For example, Get-Mailbox -Server SRV1 \| Set-Mailbox -ProhibitSendQuota 2GB.|
+|`>`|The right-angle bracket is used to send the output of a command to a file, and the contents of the file are overwritten. For example, `Get-TransportRulePredicate > "C:\My Documents\Output.txt"`.|
+|`>>`|Double right-angle brackets are used to append the output of a command to an existing file. If the file doesn't exist, a new file is created. For example, `Get-TransportRulePredicate >> "C:\My Documents\Output.txt"`.|
+|`"`|Double quotation marks are used to enclose text strings that contains spaces.|
+|`$`|A dollar sign indicates a variable. For example, `$Blue = 10` assigns the value `10` to the variable `$Blue`.|
+|`@`|The @ symbol references an associative array. For more information, see [about_Arrays](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_arrays).|
+|`$( )`|A dollar sign with parentheses indicates command substitution. You can use command substitution when you want to use the output of one command as an argument in another command. For example, `Get-ChildItem $(Read-Host -Prompt "Enter FileName: ")`.|
+|`..`|Double-periods indicate a value range. For example, if an array contains several indexes, you can return the values of all indexes between the second and fifth indexes by running the command: `$Blue[2..5]`.|
+|`+`|The plus sign operator adds two values together. For example, `6 + 6` equals `12`.|
+|`-`|The minus sign operator subtracts one value from another value (for example, `12 - 6` equals `6`) or indicates a negative number (for example, `-6 * 6` equals `-36`).|
+|`*`|You can use an asterisk to: <ul><li>**Match strings**: For example, `Get-User | Where-Object {$_.Department -like 'Sales*'})`</li><li>**Multiply numeric values**: For example, `6 * 6` equals `36`</li><li>**Repeat the string value a specified number of times**: For example, `"Test" * 3` equals `TestTestTest`</li></ul>|
+|`/`|A forward slash divides one value by another. For example, `6 / 6` equals `1`.|
+|`%`|The percent sign has the following uses: <ul><li>In a numerical evaluation, it returns the remainder from a division operator. For example, `6 % 4` equals `2`.</li><li>In a [pipeline](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_pipelines), it's shorthand for the **ForEach-Object** cmdlet. For example, `Import-Csv C:\MyFile.csv | ForEach-Object {Set-Mailbox $_.Identity -Name $_.Name}` is the same as `Import-Csv C:\MyFile.csv | % {Set-Mailbox $_.Identity -Name $_.Name}`.</li></ul>|
+|`?`|The question mark character is shorthand for the **Where-Object** cmdlet. For example, `Get-Alias | Where-Object {$_.Definition -eq "Clear-Host"}` is the same as `Get-Alias | ? {$_.Definition -eq "Clear-Host"}`.|
+|

--- a/exchange/docs-conceptual/exchange-management-shell.md
+++ b/exchange/docs-conceptual/exchange-management-shell.md
@@ -37,19 +37,14 @@ You only get access to the Exchange cmdlets and parameters that are associated w
 A benefit of remote PowerShell is that you can use Windows PowerShell on a local computer to connect to a remote Exchange server, and import the Exchange cmdlets in the Windows PowerShell session so you can administer Exchange. The only requirements for the computer are:
 
 - A supported operating system for Exchange Server.
-
 - A supported version of the .NET Framework.
-
 - A supported version of the Windows Management Framework (WMF), which includes WinRM and Windows PowerShell.
 
 For details, see the following topics:
 
 - [Exchange 2019 system requirements](https://docs.microsoft.com/Exchange/plan-and-deploy/system-requirements?view=exchserver-2019)
-
 - [Exchange 2016 system requirements](https://docs.microsoft.com/Exchange/plan-and-deploy/system-requirements?view=exchserver-2016)
-
 - [Exchange 2013 system requirements](https://docs.microsoft.com/exchange/exchange-2013-system-requirements-exchange-2013-help)
-
 - [Exchange 2010 system requirements](https://docs.microsoft.com/previous-versions/office/exchange-server-2010/aa996719(v=exchg.141))
 
 However, we recommend that you install the Exchange management tools (which includes the Exchange Management Shell) on any computer that you use to extensively manage Exchange Server. Without the Exchange management tools installed, you need to connect to the remote Exchange server manually, and you don't have access to the additional capabilities that the Exchange management tools provide.
@@ -70,8 +65,10 @@ For more information about Edge Transport servers, see [Edge Transport Servers](
 
 The following table provides links to topics that can help you learn about and use the Exchange Management Shell.
 
-|**Topic**|**Description**|
-|:-----|:-----|
+****
+
+|Topic|Description|
+|---|---|
 |[Open the Exchange Management Shell](open-the-exchange-management-shell.md)|Find and open the Exchange Management Shell on an Exchange server or a computer that has the Exchange management tools installed.|
 |[Connect to Exchange servers using remote PowerShell](connect-to-exchange-servers-using-remote-powershell.md)|Use Windows PowerShell on a local computer to connect to an Exchange server.|
 |[Control remote PowerShell access to Exchange servers](control-remote-powershell-access-to-exchange-servers.md)|Learn how to block or allow users' remote PowerShell access to Exchange servers.|
@@ -79,3 +76,4 @@ The following table provides links to topics that can help you learn about and u
 |[Exchange cmdlet syntax](exchange-cmdlet-syntax.md)|Learn about the structure and syntax of cmdlets in Exchange PowerShell.|
 |[Recipient filters in Exchange Management Shell commands](recipient-filters.md)|Learn about recipient filters in the Exchange Management Shell.|
 |[Use Update-ExchangeHelp to update Exchange PowerShell help topics on Exchange servers](use-update-exchangehelp.md)|Learn how to use Update-ExchangeHelp to update help for Exchange cmdlet reference topics on Exchange servers.|
+|

--- a/exchange/docs-conceptual/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online-powershell-v2.md
@@ -40,7 +40,7 @@ The new cmdlets in the EXO V2 module are listed in the following table:
 
 |New cmdlet in the EXO V2 module|Older related cmdlet|
 |---|---|
-|[Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline)|[Connect-EXOPSSession](mfa-connect-to-exchange-online-powershell) <br/> or <br/> [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)|
+|[Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline)|[Connect-EXOPSSession](mfa-connect-to-exchange-online-powershell.md) <br/> or <br/> [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)|
 |[Get-EXOMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exomailbox)|[Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)|
 |[GetRecipient](https://docs.microsoft.com/powershell/module/exchange/get-exorecipient)|[Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)|
 |[Get-EXOCasMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exocasmailbox)|[Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)|
@@ -51,7 +51,7 @@ The new cmdlets in the EXO V2 module are listed in the following table:
 |[Get-EXOMailboxFolderPermission](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxfolderpermission)|[Get-MailboxFolderPermission](https://docs.microsoft.com/powershell/module/exchange/get-mailboxfolderpermission)|
 |[Get-EXOMobileDeviceStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomobiledevicestatistics)|[Get-MobileDeviceStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mobiledevicestatistics)|
 |[Disconnect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/disconnect-exchangeonline)|[Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)|
-|[Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-ippssession)|[Connect-IPPSSession](mfa-connect-to-scc-powershell)|
+|[Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-ippssession)|[Connect-IPPSSession](mfa-connect-to-scc-powershell.md)|
 
 ## Install and maintain the Exchange Online PowerShell V2 module
 

--- a/exchange/docs-conceptual/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online-powershell-v2.md
@@ -40,18 +40,18 @@ The new cmdlets in the EXO V2 module are listed in the following table:
 
 |New cmdlet in the EXO V2 module|Older related cmdlet|
 |---|---|
-|[Connect-ExchangeOnline](../exchange-ps/exchange/Connect-ExchangeOnline.md)|[Connect-EXOPSSession](mfa-connect-to-exchange-online-powershell.md) <br/> or <br/> [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)|
-|[Get-EXOMailbox](../exchange-ps/exchange/Get-EXOMailbox.md)|[Get-Mailbox](../exchange-ps/exchange/Get-Mailbox.md)|
-|[Get-EXORecipient](../exchange-ps/exchange/Get-EXORecipient.md)|[Get-Recipient](../exchange-ps/exchange/Get-Recipient.md)|
-|[Get-EXOCasMailbox](../exchange-ps/exchange/Get-EXOCasMailbox.md)|[Get-CASMailbox](../exchange-ps/exchange/Get-CASMailbox.md)|
-|[Get-EXOMailboxPermission](../exchange-ps/exchange/Get-EXOMailboxPermission.md)|[Get-MailboxPermission](../exchange-ps/exchange/Get-MailboxPermission.md)|
-|[Get-EXORecipientPermission](../exchange-ps/exchange/Get-EXORecipientPermission.md)|[Get-RecipientPermission](../exchange-ps/exchange/Get-RecipientPermission.md)|
-|[Get-EXOMailboxStatistics](../exchange-ps/exchange/Get-EXOMailboxStatistics.md)|[Get-MailboxStatistics](../exchange-ps/exchange/Get-MailboxStatistics.md)|
-|[Get-EXOMailboxFolderStatistics](../exchange-ps/exchange/Get-EXOMailboxFolderStatistics.md)|[Get-MailboxFolderStatistics](../exchange-ps/exchange/Get-MailboxFolderStatistics.md)|
-|[Get-EXOMailboxFolderPermission](../exchange-ps/exchange/Get-EXOMailboxFolderPermission.md)|[Get-MailboxFolderPermission](../exchange-ps/exchange/Get-MailboxFolderPermission.md)|
-|[Get-EXOMobileDeviceStatistics](../exchange-ps/exchange/Get-EXOMobileDeviceStatistics.md)|[Get-MobileDeviceStatistics](../exchange-ps/exchange/Get-MobileDeviceStatistics.md)|
-|[Disconnect-ExchangeOnline](../exchange-ps/exchange/Disconnect-ExchangeOnline.md)|[Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)|
-|[Connect-IPPSSession](../exchange-ps/exchange/Connect-IPPSSession.md)|[Connect-IPPSSession](mfa-connect-to-scc-powershell.md)|
+|[Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline)|[Connect-EXOPSSession](mfa-connect-to-exchange-online-powershell) <br/> or <br/> [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)|
+|[Get-EXOMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exomailbox)|[Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)|
+|[GetRecipient](https://docs.microsoft.com/powershell/module/exchange/get-exorecipient)|[Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)|
+|[Get-EXOCasMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exocasmailbox)|[Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)|
+|[Get-EXOMailboxPermission](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxPermission)|[Get-MailboxPermission](https://docs.microsoft.com/powershell/module/exchange/get-mailboxpermission)|
+|[Get-EXORecipientPermission](https://docs.microsoft.com/powershell/module/exchange/get-exorecipientpermission)|[Get-RecipientPermission](https://docs.microsoft.com/powershell/module/exchange/get-recipientpermission)|
+|[Get-EXOMailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxstatistics)|[Get-MailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mailboxstatistics)|
+|[Get-EXOMailboxFolderStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxfolderstatistics)|[Get-MailboxFolderStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mailboxfolderstatistics)|
+|[Get-EXOMailboxFolderPermission](https://docs.microsoft.com/powershell/module/exchange/get-exomailboxfolderpermission)|[Get-MailboxFolderPermission](https://docs.microsoft.com/powershell/module/exchange/get-mailboxfolderpermission)|
+|[Get-EXOMobileDeviceStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomobiledevicestatistics)|[Get-MobileDeviceStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mobiledevicestatistics)|
+|[Disconnect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/disconnect-exchangeonline)|[Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)|
+|[Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-ippssession)|[Connect-IPPSSession](mfa-connect-to-scc-powershell)|
 
 ## Install and maintain the Exchange Online PowerShell V2 module
 

--- a/exchange/docs-conceptual/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online-powershell-v2.md
@@ -1,5 +1,5 @@
 ---
-title: Exchange Online PowerShell with modern authentication using V2 Module
+title: About the Exchange Online PowerShell V2 module
 ms.author: chrisda
 author: chrisda
 manager: dansimp
@@ -13,34 +13,45 @@ ms.collection: Strat_EX_Admin
 ms.custom:
 ms.assetid:
 search.appverid: MET150
-description: "Learn how to install and use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell with modern authentication."
+description: "Admins can learn about the installation, maintenance, and design of the Exchange Online PowerShell V2 module that they use to connect to all Exchange-related PowerShell environments in Microsoft 365."
 ---
 
-# Use the Exchange Online PowerShell with modern authentication using V2 module
+# About the Exchange Online PowerShell V2 module
 
-The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) enables admins to connect to their Exchange Online environment in Microsoft 365 to retrieve data, create new objects, update existing objects, remove objects as well as configure Exchange Online and its features.
+The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) uses modern authentication and works with multi-factor authentication (MFA) for connecting to all Exchange-related PowerShell environments in Microsoft 365: Exchange Online PowerShell, Security & Compliance PowerShell, and standalone Exchange Online Protection (EOP) PowerShell.
 
-## Report bugs and issues
+For connection instructions using the EXO V2 module, see the following topics:
+
+- [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md)
+
+- [Connect to Security & Compliance Center PowerShell](connect-to-scc-powershell.md)
+
+- [Connect to Exchange Online Protection PowerShell](connect-to-exchange-online-protection-powershell.md)
+
+The rest of this topic explains how the module works, how to install and maintain the module, and the optimized Exchange Online cmdlets that are available in the module.
+
+## Report bugs and issues for the EXO V2 module
 
 When you report an issue, be sure to include the log files in your email message. To generate the log files, replace \<Path to store log file\> with the output folder you want, and run the following command:
 
-```PowerShell
+```powershell
 Connect-ExchangeOnline -EnableErrorReporting -LogDirectoryPath <Path to store log file> -LogLevel All
 ```
 
 ## How the EXO V2 module works
 
-The Exchange Online PowerShell V2 module contains a small set of new cmdlets that are optimized for bulk data retrieval scenarios (think: thousands and thousands of objects). Until you create a session to connect to your Exchange Online organization, you'll only see these new cmdlets in the module. After you connect to your Exchange Online organization, you'll see all of the older remote PowerShell cmdlets.
+The module contains a small set of exclusive Exchange Online PowerShell cmdlets that are optimized for bulk data retrieval scenarios (think: thousands and thousands of objects). When you first open the module, you'll only see these exclusive cmdlets. After you [connect to your Exchange Online organization](connect-to-exchange-online-powershell.md), you'll see all of the familiar cmdlets that are available in Exchange Online PowerShell.
 
-The EXO V2 module use modern authentication for all cmdlets. You can't use Basic authentication in the EXO V2 module; however, you still need to configure the Basic authentication setting in WinRM as described later in this topic.
+The module use modern authentication for all cmdlets. You can't use Basic authentication in the EXO V2 module; however, you still need to enable the Basic authentication setting in WinRM as explained [later in this topic](#prerequisites-for-the-exo-v2-module).
 
-The new cmdlets in the EXO V2 module are meant to replace their older, less efficient equivalents. However, the original cmdlets are still available in the EXO V2 module for backwards compatibility **after** you create a session to connect to your Exchange Online organization.
+The Exchange Online cmdlets in the EXO V2 module are meant to replace their older, less efficient equivalents, but the equivalent cmdlets are still available (after you connect).
 
-The new cmdlets in the EXO V2 module are listed in the following table:
+The Exchange Online PowerShell cmdlets that are only available in the EXO V2 module are listed in the following table:
 
-|New cmdlet in the EXO V2 module|Older related cmdlet|
+****
+
+|EXO V2 module cmdlet|Older related cmdlet|
 |---|---|
-|[Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline)|[Connect-EXOPSSession](mfa-connect-to-exchange-online-powershell.md) <br/> or <br/> [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)|
 |[Get-EXOMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exomailbox)|[Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)|
 |[GetRecipient](https://docs.microsoft.com/powershell/module/exchange/get-exorecipient)|[Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)|
 |[Get-EXOCasMailbox](https://docs.microsoft.com/powershell/module/exchange/get-exocasmailbox)|[Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)|
@@ -52,17 +63,30 @@ The new cmdlets in the EXO V2 module are listed in the following table:
 |[Get-EXOMobileDeviceStatistics](https://docs.microsoft.com/powershell/module/exchange/get-exomobiledevicestatistics)|[Get-MobileDeviceStatistics](https://docs.microsoft.com/powershell/module/exchange/get-mobiledevicestatistics)|
 |[Disconnect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/disconnect-exchangeonline)|[Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)|
 |[Connect-IPPSSession](https://docs.microsoft.com/powershell/module/exchange/connect-ippssession)|[Connect-IPPSSession](mfa-connect-to-scc-powershell.md)|
+|[Get-UserBriefingConfig](https://docs.microsoft.com/powershell/module/exchange/get-userbriefingconfig)|n/a|
+|[Set-UserBriefingConfig](https://docs.microsoft.com/powershell/module/exchange/set-userbriefingconfig.md)|n/a|
+|
 
-## Install and maintain the Exchange Online PowerShell V2 module
+The connection-related cmdlets that are available in the EXO V2 module are listed in the following table:
 
-You can download the EXO V2 module from the PowerShell gallery [here](https://www.powershellgallery.com/packages/ExchangeOnlineManagement/).
+****
 
-> [!NOTE]
-> Currently, the latest version of PowerShell that's supported for the EXO V2 module is PowerShell 5.1. Support for later versions of PowerShell (and by definition, support for Linux or Mac) is a work in progress.
+|EXO V2 module cmdlet|Older related cmdlet|
+|---|---|
+|[Connect-ExchangeOnline]((https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline)|[Connect-EXOPSSession](v1-module-mfa-connect-to-exo-powershell.md) <br/> or <br/> [New-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/new-pssession)|
+|[Connect-IPPSSession]((https://docs.microsoft.com/powershell/module/exchange/connect-ippssession)|[Connect-IPPSSession](v1-module-mfa-connect-to-scc-powershell.md)|
+|[Disconnect-ExchangeOnline]((https://docs.microsoft.com/powershell/module/exchange/disconnect-exchangeonline)|[Remove-PSSession](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/remove-pssession)|
+|
 
-### What do you need to know before you begin?
+## Install and maintain the EXO V2 module
 
-- Estimated time to complete: 5 minutes
+You can download the EXO V2 module from the PowerShell gallery at <https://www.powershellgallery.com/packages/ExchangeOnlineManagement/>.
+
+The procedures in this section explain how to install, update, and uninstall the EXO V2 module.
+
+### Prerequisites for the EXO V2 module
+
+- Windows PowerShell 5.1 is the latest version of PowerShell that's supported by the EXO V2 module. Support for later versions of PowerShell (and by definition, support for Linux or Mac) is a work in progress.
 
 - You can use the following versions of Windows:
 
@@ -74,9 +98,21 @@ You can download the EXO V2 module from the PowerShell gallery [here](https://ww
   - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
   - Windows Server 2008 R2 SP1<sup>*</sup>
 
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then the Windows Management Framework 5.1. For more information, see [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then the Windows Management Framework 5.1. For more information, see [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
-- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+- Windows PowerShell needs to be configured to run scripts, and by default, it isn't. You'll get the following error when you try to connect:
+
+  > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
+
+  To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window (a Windows PowerShell window you open by selecting **Run as administrator**):
+
+  ```powershell
+  Set-ExecutionPolicy RemoteSigned
+  ```
+
+  For more information about execution policies, see [About Execution Policies](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies).
+
+- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to send the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
 
@@ -98,162 +134,138 @@ You can download the EXO V2 module from the PowerShell gallery [here](https://ww
 
   > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
 
-### Install the EXO V2 module
-
-To install the EXO V2 module for the first time, complete the following steps:
-
-1. Install or update the PowerShellGet module as described in [Installing PowerShellGet](https://docs.microsoft.com/powershell/scripting/gallery/installing-psget).
-
-2. Windows PowerShell needs to be configured to run scripts, and by default, it isn't. To require all PowerShell scripts that you download from the internet are signed by a trusted publisher, run the following command in an elevated Windows PowerShell window:
-
-   ```PowerShell
-   Set-ExecutionPolicy RemoteSigned
-   ```
-
-   **Notes**:
-
-   - You need to configure this setting only once on your computer. Read more about execution policies [here](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_execution_policies).
-
-   - If you don't do this step, you'll receive the following error when you try to connect:
-
-     > Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.
-
-3. Close and re-open the elevated Windows PowerShell window to get the changes from the previous steps.
-
-4. Run the following command from an elevated Windows PowerShell window:
-
-   ```PowerShell
-   Install-Module -Name ExchangeOnlineManagement
-   ```
-
-   Enter **Y** to accept the license agreement.
-
-### Update the EXO V2 module
-
-If the EXO V2 module is already installed on your computer, you can run the following commands to see the version that's currently installed and update it to the latest version.
-
-1. To see the version of the EXO V2 module that's currently installed, run the following commands:
-
-   ```PowerShell
-   Import-Module ExchangeOnlineManagement; Get-Module ExchangeOnlineManagement
-   ```
-
-2. Run the following command to update the EXO V2 module to latest version that's available in the PowerShell Gallery:
-
-   ```PowerShell
-   Update-Module -Name ExchangeOnlineManagement
-   ```
-
-   Enter **Y** to accept the license agreement.
-
-   **Note**: If you receive the following error related to the PowerShellGet module, see Step 1 in the previous [Install the EXO V2 module](#install-the-exo-v2-module) section to update the PowerShellGet module to the latest version.
-
-   > The specified module 'ExchangeOnlineManagement' with PowerShellGetFormatVersion '\<version\>' is not supported by the current version of PowerShellGet. Get the latest version of the PowerShellGet module to install this module, 'ExchangeOnlineManagement'.
-
-   If you need to update the PowerShellGet module, be sure to close and re-open the Windows PowerShell window before you attempt to update the ExchangeOnlineManagement module.
-
-3. To confirm that the update was successful, run the following commands:
-
-   ```PowerShell
-   Import-Module ExchangeOnlineManagement; Get-Module ExchangeOnlineManagement
-   ```
-
-### Uninstall the EXO V2 module
-
-To uninstall the module, run the following command:
-
-```PowerShell
-Uninstall-Module -Name ExchangeOnlineManagement
-```
-
 > [!TIP]
 > Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
 
-## Connect to Exchange Online using the EXO V2 module
+### Install the EXO V2 module
 
-> [!NOTE]
-> If your account uses multi-factor authentication (MFA), skip the first step (the **Get-Credential** cmdlet doesn't support MFA enabled accounts).
+To install the EXO V2 module for the first time, complete the following steps **in an elevated Windows PowerShell window**:
 
-1. On your local computer, open a Windows PowerShell window and run the following command:
+1. Install or update the PowerShellGet module as described in [Installing PowerShellGet](https://docs.microsoft.com/powershell/scripting/gallery/installing-psget).
 
-   ```PowerShell
-   $UserCredential = Get-Credential
+2. Close and re-open the window.
+
+3. Now you can use the **Install-Module** cmdlet to install the EXO V2 module from the PowerShell Gallery. Typically, you'll want the latest public version of the module, but you can also install a Preview version if one is available.
+
+   - To install **the latest public version** of the module, run the following command:
+
+     ```powershell
+     Install-Module -Name ExchangeOnlineManagement
+     ```
+
+     Enter **Y** to accept the license agreement.
+
+   - To install **a Preview version** of the module, replace \<PreviewVersion\> with the necessary value, and run the following command:
+
+     ```powershell
+     Install-Module -Name ExchangeOnlineManagement -RequiredVersion <PreviewVersion> -AllowPrerelease
+     ```
+
+     For example, to install the `2.0.3-Preview` version that's required for [app-only authentication for unattended scripts](app-only-auth-powershell-v2.md), run the following command:
+
+     ```powershell
+     Install-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.3-Preview -AllowPrerelease
+     ```
+
+   When you're finished, enter **Y** to accept the license agreement.
+
+For detailed syntax and parameter information, see [Install-Module](https://docs.microsoft.com/powershell/module/powershellget/install-module).
+
+### Update the EXO V2 module
+
+If the module is already installed on your computer, you can run the following commands to see the version that's currently installed and update it to the latest version from the PowerShell Gallery:
+
+1. To see the version of the module that's currently installed, run the following commands:
+
+   ```powershell
+   Import-Module ExchangeOnlineManagement; Get-Module ExchangeOnlineManagement
    ```
 
-   In the **Windows PowerShell Credential Request** dialog box, type your work or school account and password, and then click **OK**.
+2. You can use the **Update-Module** cmdlet **in an elevated Windows PowerShell window** to update the EXO V2 module from the PowerShell Gallery. Typically, you'll want the latest public version of the module, but you can also upgrade to a Preview version if one is available.
 
-2. Run one of the following commands:
+   - To upgrade to **the latest public version** of the module, run the following command:
 
-   - **Accounts without MFA enabled**:
-
-     ```PowerShell
-     Connect-ExchangeOnline -Credential $UserCredential -ShowProgress $true
+     ```powershell
+     Update-Module -Name ExchangeOnlineManagement
      ```
 
-   - **Accounts with MFA enabled**: Replace `<UPN>` with your account in user principal name format (for example, `navin@contoso.com`) and run the following command:
+     Enter **Y** to accept the license agreement.
 
-     ```PowerShell
-     Connect-ExchangeOnline -UserPrincipalName <UPN> -ShowProgress $true
+   - To upgrade to **a Preview version** of the module, replace \<PreviewVersion\> with the necessary value, and run the following command:
+
+     ```powershell
+     Update-Module -Name ExchangeOnlineManagement -RequiredVersion <PreviewVersion> -AllowPrerelease
      ```
 
-For detailed syntax and parameter information, see [Connect-ExchangeOnline](https://docs.microsoft.com/powershell/module/exchange/connect-exchangeonline).
+     For example, to upgrade to the `2.0.3-Preview` version that's required for [app-only authentication for unattended scripts](app-only-auth-powershell-v2.md), run the following command:
+
+     ```powershell
+     Update-Module -Name ExchangeOnlineManagement -RequiredVersion 2.0.3-Preview -AllowPrerelease
+     ```
+
+     When you're finished, enter **Y** to accept the license agreement.
+
+3. To confirm that the update was successful, run the following commands to check the version information of the module that's installed:
+
+   ```powershell
+   Import-Module ExchangeOnlineManagement; Get-Module ExchangeOnlineManagement
+   ```
+
+For detailed syntax and parameter information, see [Update-Module](https://docs.microsoft.com/powershell/module/powershellget/update-module).
+
+**Note**: If you receive the following error:
+
+> The specified module 'ExchangeOnlineManagement' with PowerShellGetFormatVersion '\<version\>' is not supported by the current version of PowerShellGet. Get the latest version of the PowerShellGet module to install this module, 'ExchangeOnlineManagement'.
+
+Update your installation of the PowerShellGet module to the latest version as described in [Installing PowerShellGet](https://docs.microsoft.com/powershell/scripting/gallery/installing-psget). Be sure to close and re-open the elevated Windows PowerShell window before you attempt to update the ExchangeOnlineManagement module again.
+
+### Uninstall the EXO V2 module
+
+To uninstall the module, run the following command **in an elevated Windows PowerShell window**:
+
+```powershell
+Uninstall-Module -Name ExchangeOnlineManagement
+```
+
+For detailed syntax and parameter information, see [Uninstall-Module](https://docs.microsoft.com/powershell/module/powershellget/uninstall-module).
 
 ## Properties and property sets in the EXO V2 module
 
-The output of traditional Exchange Online cmdlets returns all possible object properties, including many properties that are often blank, or aren't even required in many scenarios. Returning a large number of blank and unnecessary properties causes degraded performance (more server computation and added network load). The full complement of properties are rarely required in the cmdlet output.
+Traditional Exchange Online cmdlets return all possible object properties in their output, including many properties that are often blank or aren't interesting in many scenarios. This behavior causes degraded performance (more server computation and added network load). You rarely (if ever) need the full complement of properties in the cmdlet output.
 
-The EXO V2 module cmdlets have categorized output properties. Instead of giving all properties equal importance and returning them in all scenarios, we've categorized specific related properties into *property sets*. Simply put, these property sets are buckets of two or more related properties on the cmdlet.
+The **Get-EXO\*** cmdlets in the module have categorized output properties. Instead of giving all properties equal importance and returning them in all scenarios, we've categorized specific related properties into property sets. Simply put, these property sets are buckets of two or more related properties on the cmdlet.
 
-Property sets are controlled by the following parameters on the EXO V2 module cmdlets:
+In the biggest and most used **Get-EXO\*** cmdlets:
 
-- *PropertySets*: This parameter accepts one or more available property set names separated by commas.
+- [Get-EXOCasMailbox](../exchange-ps/exchange/Get-EXOCasMailbox.md)
+- [Get-EXOMailbox](../exchange-ps/exchange/Get-EXOMailbox.md)
+- [Get-EXOMailboxStatistics](../exchange-ps/exchange/Get-EXOMailboxStatistics.md)
+- [Get-EXORecipient](../exchange-ps/exchange/Get-EXORecipient.md)
 
-  This example returns the properties that are available in the Archive and Custom property sets:
+Property sets are controlled by the following parameters:
 
-  ```PowerShell
-  Get-EXOMailbox -PropertySets Archive,Custom
-  ```
-
+- *PropertySets*: This parameter accepts one or more available property set names separated by commas. The available property sets are described in [Property sets in Exchange Online PowerShell V2 cmdlets](cmdlet-property-sets.md).
 - *Properties*: This parameter accepts one or more property names separated by commas.
 
-  This example returns the specified properties:
+You can use the *PropertySets* and *Properties* parameters together in the same command.
 
-  ```PowerShell
-  Get-EXOMailbox -Properties LitigationHoldEnabled,AuditEnabled
-  ```
-
-  **Note**: Cmdlets that only return a small number of output properties don't have the *PropertySet* or *Properties* parameters.
-
-You can use *PropertySets* and *Properties* in the same command. For example:
-
-```PowerShell
-Get-EXOMailbox -Properties IsMailboxEnabled,SamAccountName -PropertySets Delivery
-```
-
-```PowerShell
-Get-EXOCASMailbox -Properties EwsEnabled, MAPIBlockOutlookNonCachedMode -PropertySets ActiveSync
-```
-
-We've also included a Minimum property set (or *minset*) in the available property sets that includes a bare minimum set of properties for the cmdlet output.
+We've also included a Minimum property set that includes a bare minimum set of required properties for the cmdlet output (for example, identity properties). The properties in the Minimum property sets are also described in [Property sets in Exchange Online PowerShell V2 cmdlets](cmdlet-property-sets.md).
 
 - If you don't use the *PropertySets* or *Properties* parameters, you automatically get the properties in the Minimum property set.
-
 - If you use the *PropertySets* or *Properties* parameters, you get the specified properties **and** the properties in the Minimum property set.
 
 Either way, the cmdlet output will contain far fewer properties, and the time it takes to return those results will be much faster.
 
-This example returns the properties in the Minimum property set for the first ten mailboxes.
+For example, after you [connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md), the following example returns only the properties in the Minimum property set for the first ten mailboxes.
 
-```PowerShell
+```powershell
 Get-EXOMailbox -ResultSize 10
 ```
 
-In contrast, the same **Get-Mailbox** cmdlet would return at least 230 properties for the same ten mailboxes.
-
-For details about the property sets that are available in EXO V2 module cmdlets, see [Property sets in Exchange Online PowerShell V2 cmdlets](cmdlet-property-sets.md) or the individual EXO V2 module cmdlet reference topics.
+In contrast, the output of the same **Get-Mailbox** command would return at least 230 properties for each of the first ten mailboxes.
 
 > [!NOTE]
-> Although you can retrieve all properties for an object by using the _PropertySets_ parameter with the value All, we highly discourage this because it slows down the cmdlet and reduces reliability. Always use the _PropertySets_ and _Properties_ parameters to retrieve the minimum number of properties.
+> Although the _PropertySets_ parameter accepts the value All, we highly discourage using this value to retrieve all properties, because it slows down the command and reduces reliability. Always use the _PropertySets_ and _Properties_ parameters to retrieve the minimum number of properties that are required for your scenario.
 
 For more information about filtering in the EXO V2 module, see [Filters in the Exchange Online V2 module](filters-v2.md).
 

--- a/exchange/docs-conceptual/exchange-online-powershell.md
+++ b/exchange/docs-conceptual/exchange-online-powershell.md
@@ -15,18 +15,18 @@ description: "Learn about using PowerShell in Exchange Online"
 
 # Exchange Online PowerShell
 
-Exchange Online PowerShell is the administrative interface that enables you to manage your Microsoft Exchange Online organization from the command line.  For example, you can use Exchange Online PowerShell to configure mail flow rules (also known as transport rules) and connectors. The following topics provide information about using Exchange Online PowerShell:
+Exchange Online PowerShell is the administrative interface that enables you to manage your Microsoft Exchange Online organization from the command line. For example, you can use Exchange Online PowerShell to configure mail flow rules (also known as transport rules) and connectors. The following topics provide information about using Exchange Online PowerShell:
 
-- To create a remote PowerShell session to your Exchange Online organization, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
+- To create a remote PowerShell session to your Exchange Online organization that supports both modern authentication and multi-factor authentication (MFA), see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
 
-- To prevent or allow connections to connect to your Exchange Online organization using remote PowerShell, see [Enable or disable access to Exchange Online PowerShell](disable-access-to-exchange-online-powershell.md).
+- To prevent or allow PowerShell access to your Exchange Online organization, see [Enable or disable access to Exchange Online PowerShell](disable-access-to-exchange-online-powershell.md).
 
-- The following introductory video shows you how to connect to and use Exchange Online PowerShell.
+- To learn about the structure and layout of the cmdlet reference topics in Exchange Online PowerShell, see [Exchange cmdlet syntax](exchange-cmdlet-syntax.md).
 
-   **Note:** This video applies to Exchange Online and standalone Exchange Online Protection (EOP) organizations. When you connect to your organization, be sure to specify the correct URL (*ConnectionUri* value). The required URL is different for Exchange Online and EOP organizations.
-
-  [Use Remote PowerShell in EOP](https://videoplayercdn.osi.office.net/hub/?csid=ux-cms-en-us-msoffice&uuid=9cb28006-c2cb-45b6-b72e-eeed8767dee7&AutoPlayVideo=false)
-
-- To find the permissions you need to run a specific cmdlet, or one or more parameters on the cmdlet, see [Find the permissions required to run any Exchange cmdlet](find-exchange-cmdlet-permissions.md).
+- To find the permissions that you need to run a specific cmdlet, or one or more parameters on a cmdlet, see [Find the permissions required to run any Exchange cmdlet](find-exchange-cmdlet-permissions.md).
 
 - To learn about recipient filters in Exchange Online PowerShell, see [Recipient filters in Exchange Management Shell and Exchange Online PowerShell commands](recipient-filters.md).
+
+- To learn about authentication in Exchange Online PowerShell for unattended scripts using AzureAD applications and self-signed certificates, see [App-only authentication for unattended scripts in the EXO V2 module](app-only-auth-powershell-v2.md).
+
+- To learn about property sets in EXO V2 module cmdlets, see [Property sets in Exchange Online PowerShell V2 cmdlets](cmdlet-property-sets.md).

--- a/exchange/docs-conceptual/exchange-online-protection-powershell.md
+++ b/exchange/docs-conceptual/exchange-online-protection-powershell.md
@@ -17,16 +17,12 @@ description: "Learn about using PowerShell in Exchange Online Protection"
 Exchange Online Protection PowerShell is the administrative interface that enables you to manage your standalone Exchange Online Protection (EOP) organization from the command line. For example, you can use Exchange Online Protection PowerShell to configure mail flow rules (also known as transport rules) and connectors.
 
 > [!NOTE]
-> Exchange Online Protection PowerShell is only used in *standalone* EOP organizations (for example, your Microsoft 365 subscription includes only standalone EOP without Exchange Online mailboxes to protect your on-premises email environment). If you have a Microsoft subscription that includes Exchnge Online mailboxes (E3, E5, etc.), you don't use Exchange Online Protection PowerShell; the same features are available in [Exchange Online PowerShell](exchange-online-powershell.md).
+> Exchange Online Protection PowerShell is only used in *standalone* EOP organizations. For example, your Microsoft 365 subscription only includes EOP (no Exchange mailboxes), and you use it to protect your on-premises email environment. If you have a Microsoft 365 subscription that includes Exchange Online mailboxes (E3, E5, etc.), you can't use Exchange Online Protection PowerShell; the same features are available in [Exchange Online PowerShell](exchange-online-powershell.md).
 
 The following topics provide information about using Exchange Online Protection PowerShell:
 
-- To create a remote PowerShell session to your standalone Exchange Online Protection organization, see [Connect to Exchange Online Protection PowerShell](connect-to-exchange-online-protection-powershell.md).
+- To create a remote PowerShell session to your standalone Exchange Online Protection organization that supports both modern authentication and multi-factor authentication (MFA), see [Connect to Exchange Online Protection PowerShell](connect-to-exchange-online-protection-powershell.md).
 
-- For a sample script that lets admins who manage multiple tenants (companies) apply configuration settings to their tenants, see [Sample script for applying EOP settings to multiple tenants](https://docs.microsoft.com/microsoft-365/security/office-365-security/sample-script-for-applying-eop-settings-to-multiple-tenants).
+- To learn about the structure and layout of the cmdlet reference topics in Exchange Online Protection PowerShell, see [Exchange cmdlet syntax](exchange-cmdlet-syntax.md).
 
-- The following introductory video shows you how to connect to and use Exchange Online Protection PowerShell.
-
-  **Note:** This video applies to Exchange Online and standalone EOP organizations. When you connect to your organization, be sure to specify the correct URL (the _ConnectionUri_ value). The required URL is different for Exchange Online and standalone EOP organizations.
-
-  [Use Remote PowerShell in EOP](https://videoplayercdn.osi.office.net/hub/?csid=ux-cms-en-us-msoffice&uuid=9cb28006-c2cb-45b6-b72e-eeed8767dee7&AutoPlayVideo=false)
+- For a sample script that lets admins who manage multiple organizations apply configuration settings to all of their organizations, see [Sample script for applying EOP settings to multiple tenants](https://docs.microsoft.com/microsoft-365/security/office-365-security/sample-script-for-applying-eop-settings-to-multiple-tenants).

--- a/exchange/docs-conceptual/filter-properties.md
+++ b/exchange/docs-conceptual/filter-properties.md
@@ -12,43 +12,28 @@ ms.assetid: b02b0005-2fb6-4bc2-8815-305259fa5432
 description: "Learn about the filterable properties for the Filter parameter in Exchange Server and Exchange Online."
 ---
 
-# Filterable properties for the Filter parameter
+# Filterable properties for the Filter parameter on Exchange cmdlets
 
-You use the _Filter_ parameter to create OPATH filters based on the properties of user and group objects in Exchange Server and Exchange Online. The _Filter_ parameter is available on these recipient cmdlets:
+You use the _Filter_ parameter to create OPATH filters based on the properties of user and group objects in the Exchange Management Shell (Exchange Server PowerShell) and in Exchange Online PowerShell. The _Filter_ parameter is available on these recipient cmdlets:
 
 - [Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)
-
 - [Get-Contact](https://docs.microsoft.com/powershell/module/exchange/get-contact)
-
 - [Get-DistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-distributiongroup)
-
 - [Get-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-dynamicdistributiongroup)
-
 - [Get-Group](https://docs.microsoft.com/powershell/module/exchange/get-group)
-
 - [Get-LinkedUser](https://docs.microsoft.com/powershell/module/exchange/get-linkeduser)
-
 - [Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)
-
 - [Get-MailContact](https://docs.microsoft.com/powershell/module/exchange/get-mailcontact)
-
 - [Get-MailPublicFolder](https://docs.microsoft.com/powershell/module/exchange/get-mailpublicfolder)
-
 - [Get-MailUser](https://docs.microsoft.com/powershell/module/exchange/get-mailuser)
-
 - [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)
-
 - [Get-RemoteMailbox](https://docs.microsoft.com/powershell/module/exchange/get-remotemailbox)
-
 - [Get-SecurityPrincipal](https://docs.microsoft.com/powershell/module/exchange/get-securityprincipal)
-
 - [Get-UMMailbox](https://docs.microsoft.com/powershell/module/exchange/get-ummailbox)
-
 - [Get-User](https://docs.microsoft.com/powershell/module/exchange/get-user)
-
 - [Get-UnifiedGroup](https://docs.microsoft.com/powershell/module/exchange/get-unifiedgroup)
 
-For more information, see [Recipient filters in Exchange PowerShell commands](recipient-filters.md).
+For more information about recipients filters in Exchange PowerShell, see [Recipient filters in Exchange PowerShell commands](recipient-filters.md).
 
 > [!NOTE]
 > The _Filter_ parameter is also available on other cmdlets (for example, **Get-MailboxStatistics**, **Get-Queue**, and **Get-Message**). However, the property values that are accepted by the _Filter_ parameter on these cmdlets aren't similar to the user and group properties that are described in this topic.
@@ -73,8 +58,12 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 
 - To look for blank or non-blank property values, use the value `$null` (for example, `'Property -eq $null'` or `'Property -ne $null'`).
 
-|**Property name**|**LDAP display name**|**Available on cmdlets**|**Value**|**Comments**|
-|:-----|:-----|:-----|:-----|:-----|
+- For filtering considerations for connections using the Exchange Online PowerShell v2 module, see [Filters in the EXO V2 module](filters-v2.md).
+
+****
+
+|Property name|LDAP display name|Available on cmdlets|Value|Comments|
+|---|---|---|---|---|
 |_AcceptMessagesOnlyFrom_|_authOrig_|**Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox** <br/> **Get-UnifiedGroup**|String or `$null`|This filter requires the distinguished name of the individual recipient (a mailbox, mail user, or mail contact). For example, `Get-DistributionGroup -Filter "AcceptMessagesOnlyFrom -eq 'CN=Yuudai Uchida,CN=Users,DC=contoso,DC=com'"` or `Get-DistributionGroup -Filter "AcceptMessagesOnlyFrom -eq 'contoso.com/Users/Angela Gruber'"`. <br/> To find the distinguished name of the individual recipient, replace _\<RecipientIdentity\>_ with the name, alias, or email address of the recipient, and run this command: `Get-Recipient -Identity "<RecipientIdentity>" | Format-List Name,DistinguishedName`. <br/> Although this is a multivalued property, the filter will return a match if the property _contains_ the specified value.|
 |_AcceptMessagesOnlyFromDLMembers_|_dLMemSubmitPerms_|**Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox** <br/> **Get-UnifiedGroup**|String or `$null`|This filter requires the distinguished name or canonical distinguished name of the group (a distribution group, mail-enabled security group, or dynamic distribution group). For example, `Get-Mailbox -Filter "AcceptMessagesOnlyFromDLMembers -eq 'CN=Marketing Department,CN=Users,DC=contoso,DC=com'"`. or `Get-Mailbox -Filter "AcceptMessagesOnlyFromDLMembers -eq 'contoso.com/Users/Marketing Department'"`. <br/> To find the distinguished name of the group, replace _\<GroupIdentity\>_ with the name, alias, or email address of the group, and run one of these commands: `Get-DistributionGroup -Identity "<GroupIdentity>" | Format-List Name,DistinguishedName` or `Get-DynamicDistributionGroup -Identity "<GroupIdentity>" | Format-List Name,DistinguishedName`. <br/> Although this is a multivalued property, the filter will return a match if the property _contains_ the specified value.|
 |_ActiveSyncAllowedDeviceIDs_|_msExchMobileAllowedDeviceIds_|**Get-CASMailbox**|String (wildcards accepted) or `$null`|A device ID is a text string that uniquely identifies the device. Use the **Get-MobileDevice** cmdlet to see the devices that have ActiveSync partnerships with a mailbox. To see the device IDs on a mailbox, replace _\<MailboxIdentity\>_ with the name, alias, or email address of the mailbox, and run this command: `Get-MobileDevice -Mailbox <MailboxIdentity> | Format-List`. <br/> After you have the device ID value, you can use it in the filter. For example, `Get-CasMailbox -Filter "(ActiveSyncAllowedDeviceIDs -like '*text1') -or (ActiveSyncAllowedDeviceIDs -eq 'text2'"`.|
@@ -310,7 +299,8 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 |_WhenSoftDeleted_|_msExchWhenSoftDeletedTime_|**Get-LinkedUser** <br/> **Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox** <br/> **Get-User** <br/> **Get-UnifiedGroup**|A date/time value: 64-bit value representing the number of 100-nanosecond intervals since January 1, 1601 (UTC)|This filter requires the _SoftDeleted_ switch in the command for mailboxes. <br/> For example, `Get-Mailbox -SoftDeleted -Filter "WhenSoftDeleted -gt '8/1/2017 2:00:00 PM'"`.|
 |_WindowsEmailAddress_|_mail_|**Get-Contact** <br/> **Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Group** <br/> **Get-LinkedUser** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox** <br/> **Get-User**|String (wildcards accepted) or `$null`|For example, `Get-Mailbox -Filter "WindowsEmailAddress -like '*@fabrikam.com'"`.|
 |_WindowsLiveID_|_msExchWindowsLiveID_|**Get-LinkedUser** <br/> **Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-User**|String (wildcards accepted) or `$null`|For example, `Get-Mailbox -Filter "WindowsEmailAddress -like '*@fabrikam.onmicrosoft.com'"`.|
+|
 
 ## For more information
 
-Exchange 2007 was the first version of Exchange that required OPATH filters instead of LDAP filters. For more information about converting LDAP filters to OPATH filters, see the Microsoft Exchange Team Blog article, [Need help converting your LDAP filters to OPATH?](https://techcommunity.microsoft.com/t5/exchange-team-blog/need-help-converting-your-ldap-filters-to-opath/ba-p/595108).
+Exchange Server 2007 was the first version of Exchange that required OPATH filters instead of LDAP filters. For more information about converting LDAP filters to OPATH filters, see the Microsoft Exchange Team Blog article, [Need help converting your LDAP filters to OPATH?](https://techcommunity.microsoft.com/t5/exchange-team-blog/need-help-converting-your-ldap-filters-to-opath/ba-p/595108).

--- a/exchange/docs-conceptual/filter-properties.md
+++ b/exchange/docs-conceptual/filter-properties.md
@@ -16,37 +16,37 @@ description: "Learn about the filterable properties for the Filter parameter in 
 
 You use the _Filter_ parameter to create OPATH filters based on the properties of user and group objects in Exchange Server and Exchange Online. The _Filter_ parameter is available on these recipient cmdlets:
 
-- [Get-CASMailbox](../exchange-ps/exchange/Get-CASMailbox.md)
+- [Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)
 
-- [Get-Contact](../exchange-ps/exchange/Get-Contact.md)
+- [Get-Contact](https://docs.microsoft.com/powershell/module/exchange/get-contact)
 
-- [Get-DistributionGroup](../exchange-ps/exchange/Get-DistributionGroup.md)
+- [Get-DistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-distributiongroup)
 
-- [Get-DynamicDistributionGroup](../exchange-ps/exchange/Get-DynamicDistributionGroup.md)
+- [Get-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-dynamicdistributiongroup)
 
-- [Get-Group](../exchange-ps/exchange/Get-Group.md)
+- [Get-Group](https://docs.microsoft.com/powershell/module/exchange/get-group)
 
-- [Get-LinkedUser](../exchange-ps/exchange/Get-LinkedUser.md)
+- [Get-LinkedUser](https://docs.microsoft.com/powershell/module/exchange/get-linkeduser)
 
-- [Get-Mailbox](../exchange-ps/exchange/Get-Mailbox.md)
+- [Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)
 
-- [Get-MailContact](../exchange-ps/exchange/Get-MailContact.md)
+- [Get-MailContact](https://docs.microsoft.com/powershell/module/exchange/get-mailcontact)
 
-- [Get-MailPublicFolder](../exchange-ps/exchange/Get-MailPublicFolder.md)
+- [Get-MailPublicFolder](https://docs.microsoft.com/powershell/module/exchange/get-mailpublicfolder)
 
-- [Get-MailUser](../exchange-ps/exchange/Get-MailUser.md)
+- [Get-MailUser](https://docs.microsoft.com/powershell/module/exchange/get-mailuser)
 
-- [Get-Recipient](../exchange-ps/exchange/Get-Recipient.md)
+- [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)
 
-- [Get-RemoteMailbox](../exchange-ps/exchange/Get-RemoteMailbox.md)
+- [Get-RemoteMailbox](https://docs.microsoft.com/powershell/module/exchange/get-remotemailbox)
 
-- [Get-SecurityPrincipal](../exchange-ps/exchange/Get-SecurityPrincipal.md)
+- [Get-SecurityPrincipal](https://docs.microsoft.com/powershell/module/exchange/get-securityprincipal)
 
-- [Get-UMMailbox](../exchange-ps/exchange/Get-UMMailbox.md)
+- [Get-UMMailbox](https://docs.microsoft.com/powershell/module/exchange/get-ummailbox)
 
-- [Get-User](../exchange-ps/exchange/Get-User.md)
+- [Get-User](https://docs.microsoft.com/powershell/module/exchange/get-user)
 
-- [Get-UnifiedGroup](../exchange-ps/exchange/Get-UnifiedGroup.md)
+- [Get-UnifiedGroup](https://docs.microsoft.com/powershell/module/exchange/get-unifiedgroup)
 
 For more information, see [Recipient filters in Exchange PowerShell commands](recipient-filters.md).
 
@@ -63,7 +63,7 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 
   - Properties that are only used in one type of environment: Microsoft 365, on-premises Exchange, or hybrid. The property might exist on recipient objects in all environments, but the value is only meaningful (a value other than blank or `None`) in one type of environment.
 
-  - Properties that are present, but correspond to features that are no longer used in Exchange 2016 or later.
+  - Properties that are present, but correspond to features that are no longer used.
 
 - Not all recipient properties have a corresponding Active Directory property. The LDAP display name value in the table is "n/a" for these properties, which indicates that the property is calculated (likely by Exchange).
 
@@ -184,10 +184,10 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 |_LastName_|_sn_|**Get-Contact** <br/> **Get-LinkedUser** <br/> **Get-Recipient** <br/> **Get-User**|String (wildcards accepted) or `$null`|For example, `Get-User -Filter "LastName -like 'Martin*'"`.|
 |_MailboxContainerGUID_|_msExchMailboxContainerGuid_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox**|String or `$null`|For example, `Get-Mailbox -Filter 'MailboxContainerGUID -ne $null'`.|
 |_MailboxMoveBatchName_|_msExchMailboxMoveBatchName_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|String (wildcards accepted) or `$null`|This property includes the name of the migration batch. For example, `Get-Mailbox -Filter "MailboxMoveBatchName -like '*LocalMove 01*'"`. <br/> You can find the names of migration batches by running the **Get-MigrationBatch** command. Note that migration batches that you create in the Exchange admin center use the naming convention `MigrationService:<MigrationBatchName>`.|
-|_MailboxMoveFlags_|_msExchMailboxMoveFlags_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|For valid values, see the description of the _Flags_ parameter in[Get-MoveRequest](../exchange-ps/exchange/get-moverequest.md).|For example, `Get-Mailbox -Filter "MailboxMoveFlags -ne 'None'"`. <br/> You can specify multiple values separated by commas, and the order doesn't matter. For example, `Get-Recipient -Filter "MailboxMoveFlags -eq 'IntraOrg,Pull'"` returns the same results as `Get-Recipient -Filter "MailboxMoveFlags -eq 'Pull,IntraOrg'"`. <br/> This multivalued property will only return a match if the property *equals* the specified value.|
+|_MailboxMoveFlags_|_msExchMailboxMoveFlags_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|For valid values, see the description of the _Flags_ parameter in [Get-MoveRequest](https://docs.microsoft.com/powershell/module/exchange/get-moverequest).|For example, `Get-Mailbox -Filter "MailboxMoveFlags -ne 'None'"`. <br/> You can specify multiple values separated by commas, and the order doesn't matter. For example, `Get-Recipient -Filter "MailboxMoveFlags -eq 'IntraOrg,Pull'"` returns the same results as `Get-Recipient -Filter "MailboxMoveFlags -eq 'Pull,IntraOrg'"`. <br/> This multivalued property will only return a match if the property *equals* the specified value.|
 |_MailboxMoveRemoteHostName_|_msExchMailboxMoveRemoteHostName_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|String or `$null`|For example, `Get-Mailbox -Filter 'MailboxMoveRemoteHostName -ne $null'`.|
 |_MailboxMoveSourceMDB_|_msExchMailboxMoveSourceMDBLink_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|String or `$null`|This filter requires the distinguished name of the source mailbox database. For example, `Get-Mailbox -Filter "MailboxMoveSourceMDB -eq 'CN=MBX DB02,CN=Databases,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=Contoso Corporation,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=contoso,DC=com'"`. <br/> You can find the distinguished names of mailbox databases by running this command: `Get-MailboxDatabase | Format-List Name,DistinguishedName`.|
-|_MailboxMoveStatus_|_msExchMailboxMoveStatus_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|For valid values, see the description of the _MoveStatus_ parameter in[Get-MoveRequest](../exchange-ps/exchange/get-moverequest.md).|For example, `Get-Mailbox -Filter "MailboxMoveStatus -eq 'Completed'"`.|
+|_MailboxMoveStatus_|_msExchMailboxMoveStatus_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|For valid values, see the description of the _MoveStatus_ parameter in [Get-MoveRequest](https://docs.microsoft.com/powershell/module/exchange/get-moverequest).|For example, `Get-Mailbox -Filter "MailboxMoveStatus -eq 'Completed'"`.|
 |_MailboxMoveTargetMDB_|_msExchMailboxMoveTargetMDBLink_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox**|String or `$null`|This filter requires the distinguished name of the target mailbox database. For example, `Get-Mailbox -Filter "MailboxMoveTargetMDB -eq 'CN=MBX DB02,CN=Databases,CN=Exchange Administrative Group (FYDIBOHF23SPDLT),CN=Administrative Groups,CN=Contoso Corporation,CN=Microsoft Exchange,CN=Services,CN=Configuration,DC=contoso,DC=com'"`. <br/> You can find the distinguished names of mailbox databases by running this command: `Get-MailboxDatabase | Format-List Name,DistinguishedName`.|
 |_MailboxPlan_|_msExchParentPlanLink_|**Get-Mailbox**|String or `$null`|Mailbox plans correspond to Microsoft 365 license types. The availability of a license plans is determined by the selections that you make when you enroll your domain. <br/> For example, `Get-Mailbox -Filter 'MailboxPlan -ne $null'`.|
 |_MailboxRelease_|_msExchMailboxRelease_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox** <br/> **Get-User**|`None`, `E14`, `E15`, or `$null`.|For example, `Get-Recipient -Filter 'MailboxRelease -ne $null'`.|
@@ -233,7 +233,7 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 |_PopEnabled_|n/a|**Get-CASMailbox**|Boolean (`$true` or `$false`)|For example, `Get-CASMailbox -Filter 'POPEnabled -eq $false'`.|
 |_PostalCode_|_postalCode_|**Get-Contact** <br/> **Get-LinkedUser** <br/> **Get-Recipient** <br/> **Get-User**|String (wildcards accepted) or `$null`|For example, `Get-Recipient -Filter "PostalCode -eq 90210"`.|
 |_PostOfficeBox_|_postOfficeBox_|**Get-Contact** <br/> **Get-LinkedUser** <br/> **Get-User**|String (wildcards accepted) or `$null`|For example, `Get-User -Filter "PostOfficeBox -like '*555*'"`.|
-|_PreviousRecipientTypeDetails_|_msExchPreviousRecipientTypeDetails_|**Get-LinkedUser** <br/> **Get-User**|String or `$null`|For valid values, see the description of the _RecipientTypeDetails_ parameter in[Get-Recipient](../exchange-ps/exchange/get-recipient.md). <br/> For example, `Get-User -Filter 'PreviousRecipientTypeDetails -ne $null'`.|
+|_PreviousRecipientTypeDetails_|_msExchPreviousRecipientTypeDetails_|**Get-LinkedUser** <br/> **Get-User**|String or `$null`|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient). <br/> For example, `Get-User -Filter 'PreviousRecipientTypeDetails -ne $null'`.|
 |_PrimarySmtpAddress_|n/a|**Get-CASMailbox** <br/> **Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox** <br/> **Get-UMMailbox** <br/> **Get-UnifiedGroup**|String (wildcards accepted)|Don't use the _PrimarySmtpAddress_ property; use the _EmailAddresses_ property instead. Any filter that uses the _PrimarySmtpAddress_ property will also search values in the _EmailAddresses_ property. For example, if a mailbox has the primary email address dario@contoso.com, and the additional proxy addresses dario2@contoso.com and dario3@contoso.com, all of the following filters will return that mailbox in the result: `"PrimarySmtpAddress -eq 'dario@contoso.com'"`, `"PrimarySmtpAddress -eq 'dario2@contoso.com'"`, or `"PrimarySmtpAddress -eq 'dario3@contoso.com'"`.|
 |_ProhibitSendQuota_|_mDBOverQuotaLimit_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox**|A byte quantified size value (for example, `300MB` or `1.5GB`), or `Unlimited`. Unqualified values are treated as bytes.|You can only use the _Filter_ parameter to look for the value `Unlimited` for this property. For example, `Get-Mailbox -Filter "ProhibitSendQuota -eq 'Unlimited'"` or `Get-Mailbox -Filter "ProhibitSendQuota -ne 'Unlimited'"`. <br/> You can't use the _Filter_ parameter to look for size values of this property. Instead, use this syntax: `Get-Mailbox | where "$_.ProhibitSendQuota -<Operator> '<Size>'"`. For example, `Get-Mailbox | where "$_.ProhibitSendQuota -lt '70GB'"`.|
 |_ProhibitSendReceiveQuota_|_mDBOverHardQuotaLimit_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox**|A byte quantified size value (for example, `300MB` or `1.5GB`), or `Unlimited`. Unqualified values are treated as bytes.|You can only use the _Filter_ parameter to look for the value `Unlimited` for this property. For example, `Get-Mailbox -Filter "ProhibitSendReceiveQuota -eq 'Unlimited'"` or `Get-Mailbox -Filter "ProhibitSendReceiveQuota -ne 'Unlimited'"`. <br/> You can't use the _Filter_ parameter to look for size values of this property. Instead, use this syntax: `Get-Mailbox | where "$_.ProhibitSendReceiveQuota -<Operator> '<Size>'"`. For example, `Get-Mailbox | where "$_.ProhibitSendReceiveQuota -lt '70GB'"`.|
@@ -243,7 +243,7 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 |_RecipientContainer_|_msExchDynamicDLBaseDN_|**Get-DynamicDistributionGroup**|String or `$null`|This filter requires the distinguished name or canonical distinguished name of the organizational unit or container in Active Directory. For example, `Get-DynamicDistributionGroup -Filter "RecipientContainer -eq 'CN=Users,DC=contoso,DC=com'"` or `Get-DynamicDistributionGroup -Filter "RecipientContainer -eq 'contoso.com/Users'"` <br/> To find the distinguished names or canonical distinguished names of organizational units and containers in Active Directory, run this command: `Get-OrganizationalUnit -IncludeContainers | Format-List Name,DistinguishedName,ID`.|
 |_RecipientLimits_|_msExchRecipLimit_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox**|Integer or `Unlimited`|For example, `Get-Mailbox -Filter "RecipientLimits -ne 'Unlimited'"`.|
 |_RecipientType_|n/a|**Get-Contact** <br/> **Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Group** <br/> **Get-LinkedUser** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox** <br/> **Get-SecurityPrincipal** <br/> **Get-User** <br/> **Get-UnifiedGroup**|`DynamicDistributionGroup`, `MailContact`, `MailNonUniversalGroup`, `MailUniversalDistributionGroup`, `MailUniversalSecurityGroup`, `MailUser`, `PublicFolder` or `UserMailbox`|For example, `Get-Recipient -Filter "RecipientType -eq 'MailContact'"`.|
-|_RecipientTypeDetails_|n/a|**Get-Contact** <br/> **Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Group** <br/> **Get-LinkedUser** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox** <br/> **Get-SecurityPrincipal** <br/> **Get-User** <br/> **Get-UnifiedGroup**|String|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](../exchange-ps/exchange/Get-Recipient.md). <br/> For example, `Get-Recipient -Filter "RecipientTypeDetails -eq 'SharedMailbox'"`.|
+|_RecipientTypeDetails_|n/a|**Get-Contact** <br/> **Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Group** <br/> **Get-LinkedUser** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-Recipient** <br/> **Get-RemoteMailbox** <br/> **Get-SecurityPrincipal** <br/> **Get-User** <br/> **Get-UnifiedGroup**|String|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient). <br/> For example, `Get-Recipient -Filter "RecipientTypeDetails -eq 'SharedMailbox'"`.|
 |_RecoverableItemsQuota_|_msExchDumpsterQuota_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox**|A byte quantified size value (for example, `300MB` or `1.5GB`), or `Unlimited`. Unqualified values are treated as bytes.|You can only use the _Filter_ parameter to look for the value `Unlimited` for this property. For example, `Get-Mailbox -Filter "RecoverableItemsQuota -eq 'Unlimited'"` or `Get-Mailbox -Filter "RecoverableItemsQuota -ne 'Unlimited'"`. <br/> You can't use the _Filter_ parameter to look for size values of this property. Instead, use this syntax: `Get-Mailbox | where "$_.RecoverableItemsQuota -<Operator> '<Size>'`. For example, `Get-Mailbox | where "$_.RecoverableItemsQuota -gt '35GB'"`.|
 |_RecoverableItemsWarningQuota_|_msExchDumpsterWarningQuota_|**Get-Mailbox** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox**|A byte quantified size value (for example, `300MB` or `1.5GB`), or `Unlimited`. Unqualified values are treated as bytes.|You can only use the _Filter_ parameter to look for the value `Unlimited` for this property. For example, `Get-Mailbox -Filter "RecoverableItemsWarningQuota -eq 'Unlimited'"` or `Get-Mailbox -Filter "RecoverableItemsWarningQuota -ne 'Unlimited'"`. <br/> You can't use the _Filter_ parameter to look for size values of this property. Instead, use this syntax: `Get-Mailbox | where "$_.RecoverableItemsWarningQuota -<Operator> '<Size>'`". For example, `Get-Mailbox | where "$_.RecoverableItemsWarningQuota -gt '25GB'"`.|
 |_RejectMessagesFrom_|_unauthOrig_|**Get-DistributionGroup** <br/> **Get-DynamicDistributionGroup** <br/> **Get-Mailbox** <br/> **Get-MailContact** <br/> **Get-MailPublicFolder** <br/> **Get-MailUser** <br/> **Get-RemoteMailbox** <br/> **Get-UnifiedGroup**|String or `$null`|This filter requires the distinguished name of the individual recipient (a mailbox, mail user, or mail contact). For example, `Get-DistributionGroup -Filter "RejectMessagesFrom -eq 'CN=Yuudai Uchida,CN=Users,DC=contoso,DC=com'"` or `Get-DistributionGroup -Filter "RejectMessagesFrom -eq 'contoso.com/Users/Angela Gruber'"`. <br/> To find the distinguished name of the individual recipient, replace _\<RecipientIdentity\>_ with the name, alias, or email address of the recipient, and run this command: `Get-Recipient -Identity "<RecipientIdentity>" | Format-List Name,DistinguishedName`. <br/> Although this is a multivalued property, the filter will return a match if the property _contains_ the specified value.|
@@ -314,5 +314,3 @@ The properties that have been _confirmed_ to work with the _Filter_ parameter in
 ## For more information
 
 Exchange 2007 was the first version of Exchange that required OPATH filters instead of LDAP filters. For more information about converting LDAP filters to OPATH filters, see the Microsoft Exchange Team Blog article, [Need help converting your LDAP filters to OPATH?](https://techcommunity.microsoft.com/t5/exchange-team-blog/need-help-converting-your-ldap-filters-to-opath/ba-p/595108).
-
-For more information about the syntax that can be used within OPATH filters, see [Exchange cmdlet syntax](exchange-cmdlet-syntax.md).

--- a/exchange/docs-conceptual/filters-v2.md
+++ b/exchange/docs-conceptual/filters-v2.md
@@ -1,5 +1,5 @@
 ---
-title: Filters in the V2 module
+title: Filters in the EXO V2 module
 ms.author: chrisda
 author: chrisda
 manager: dansimp
@@ -16,9 +16,9 @@ search.appverid: MET150
 description: "Learn about how to use filtering for cmdlets in the Exchange Online V2 module."
 ---
 
-# Filters in the Exchange Online V2 module
+# Filters in the EXO V2 module
 
-The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) contains a few new cmdlets that are optimized for high speed, high volume operations, and (after you connect to your organization) gives you access to the hundreds of existing cmdlets in the service. For more information, see [Use the Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md).
+The Exchange Online PowerShell V2 module (abbreviated as the EXO V2 module) contains a few exclusive cmdlets that are optimized for high speed, high volume operations, and (after you connect to your organization) gives you access to the hundreds of existing cmdlets in the service. For more information, see [About the Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md).
 
 In order to get the most out of the EXO V2 module, you need to follow the guidance in this topic.
 
@@ -26,15 +26,16 @@ In order to get the most out of the EXO V2 module, you need to follow the guidan
 
 Server-side filtering uses the available _Filter_ or _RecipientFilter_ parameters on a cmdlet. Client-side filtering uses the [Where-Object](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/where-object) cmdlet (also known as **where** or **?**).
 
-Generally, you get much better performance with server-side filtering. However, for the EXO V2 module, you actually get better performance when using client-side filtering. We're working on improving the performance of server-side filtering in module.
+Generally, you get much better performance in PowerShell cmdlets with server-side filtering. However, for the EXO V2 module, you actually get better performance when you use client-side filtering. We're working on improving the performance of server-side filtering in the module.
 
 ## Supported and unsupported attributes
 
 Although the EXO V2 module supports the majority of filterable attributes, the following attributes are currently not supported for filtering:
 
-||||
+****
+
+|Cmdlet|Attribute|LDAP Display Name|
 |---|---|---|
-|**Cmdlet**|**Attribute**|**LDAP Display Name**|
 |[Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)|MemberOfGroup <br/><br/> ExternalDirectoryObjectId|memberOf <br/><br/> msExchExternalDirectoryObjectId|
 |[Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)|DeletedItemFlags <br/><br/> ExternalDirectoryObjectId <br/><br/> LanguagesRaw <br/><br/> MasterAccountSid <br/><br/> MemberOfGroup <br/><br/> RequireAllSendersAreAuthenticated <br/><br/> SCLDeleteThresholdInt <br/><br/> SCLJunkThresholdInt <br/><br/> SCLQuarantineThresholdInt <br/><br/> SCLRejectThresholdInt|deletedItemFlags <br/><br/> msExchExternalDirectoryObjectId <br/><br/> msExchUserCulture <br/><br/> msExchMasterAccountSid <br/><br/> memberOf <br/><br/> msExchRequireAuthToSendTo <br/><br/> msExchMessageHygieneSCLDeleteThreshold <br/><br/> msExchMessageHygieneSCLJunkThreshold <br/><br/> msExchMessageHygieneSCLQuarantineThreshold <br/><br/> msExchMessageHygieneSCLRejectThreshold|
 |[Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)|CountryCode <br/><br/> ExternalDirectoryObjectId <br/><br/> MasterAccountSid <br/><br/> MemberOfGroup <br/><br/> Members|countryCode <br/><br/> msExchExternalDirectoryObjectId <br/><br/> msExchMasterAccountSid <br/><br/> memberOf <br/><br/> member|
@@ -44,21 +45,26 @@ Although the EXO V2 module supports the majority of filterable attributes, the f
 
 The following operators are fully supported for all string formats in the EXO V2 module:
 
-- -eq
-- -and
-- -ne
-- -or
-- -not
-- -lt
-- -gt
-- -like
-- -notlike
+- [Logical operators](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_logical_operators):
 
-The -like and -notlike operators are limited in using wildcards (*). Specifically, you can only use wildcards at the beginning of a string value, at the end of a string value, or both.
+  - `-and`
+  - `-not`
+  - `-or`
+
+- [Comparison operators](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators)
+
+  - `-eq`
+  - `-ne`
+  - `-lt`
+  - `-gt`
+  - `-like`
+  - `-notlike`
+
+The `-like` and `-notlike` operators are limited in using wildcards (*). Specifically, you can only use wildcards at the beginning of a string value, at the end of a string value, or both.
 
 For example, the following text search is not supported:
 
-`"UPN  -like 'A*B*C'`
+`"UPN -like 'A*B*C'`
 
 However, the following searches are supported:
 

--- a/exchange/docs-conceptual/find-exchange-cmdlet-permissions.md
+++ b/exchange/docs-conceptual/find-exchange-cmdlet-permissions.md
@@ -9,7 +9,7 @@ ms.topic: article
 ms.service: exchange-online
 localization_priority: Normal
 ms.assetid: 5bcc46d3-8a07-4e9f-b1b0-e4cb0b0afc12
-description: "Admins can learn how to use PowerShell to find the permissions required to run any Exchange or Exchange Online cmdlet."
+description: "Admins can learn how to use PowerShell to find the permissions required to run any cmdlet in Exchange Server PowerShell or Exchange Online PowerShell."
 ---
 
 # Find the permissions required to run any Exchange cmdlet
@@ -22,7 +22,7 @@ You can use PowerShell to find the permissions required to run any Exchange or E
 
 - You can only use PowerShell to perform this procedure.
 
-- Basically, you need to be an administrator to complete this procedure. Specifically, you need access to the **Get-ManagementRole** and **Get-ManagementRoleAssignment** cmdlets. By default, access to these cmdlets is granted by the View-Only Configuration or Role Management roles, which are assigned to the View-Only Organization Management and Organization Management role groups.
+- Basically, you need to be an administrator to complete this procedure. Specifically, you need access to the **Get-ManagementRole** and **Get-ManagementRoleAssignment** cmdlets. By default, access to these cmdlets is granted by the **View-Only Configuration** or **Role Management** roles, which are typically assigned to the **View-Only Organization Management** and **Organization Management** role groups.
 
 - The procedures in this topic don't work in Security & Compliance Center PowerShell. For more information about permissions in the Security & Compliance Center, see [Permissions in the Security & Compliance Center](https://docs.microsoft.com/microsoft-365/security/office-365-security/permissions-in-the-security-and-compliance-center).
 
@@ -35,19 +35,19 @@ You can use PowerShell to find the permissions required to run any Exchange or E
 
 1. Open the PowerShell environment where you want to run the cmdlet.
 
-   - To learn how to use Windows PowerShell to connect to Exchange Online, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
+   - **Exchange Online**: [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
 
-   - To learn how to open the Exchange Management Shell in your on-premises Exchange organization, see [Open the Exchange Management Shell](open-the-exchange-management-shell.md).
+   - **Exchange Server**: [Open the Exchange Management Shell](open-the-exchange-management-shell.md) or [Connect to Exchange servers using remote PowerShell](connect-to-exchange-servers-using-remote-powershell.md).
 
 2. Run the following command to identify the cmdlet and, optionally, one or more parameters on the cmdlet. Be sure to replace `<Cmdlet>` and optionally, `<Parameter1>,<Parameter2>,...` with the actual cmdlet and parameter names you are interested in. If you specify multiple parameters separated by commas, only the roles that include **all** of the parameters are returned.
 
-   ```PowerShell
+   ```powershell
    $Perms = Get-ManagementRole -Cmdlet <Cmdlet> [-CmdletParameters <Parameter1>,<Parameter2>,...]
    ```
 
 3. Run the following command:
 
-   ```PowerShell
+   ```powershell
    $Perms | foreach {Get-ManagementRoleAssignment -Role $_.Name -Delegating $false | Format-Table -Auto Role,RoleAssigneeType,RoleAssigneeName}
    ```
 
@@ -75,7 +75,7 @@ What if there are no results?
 
   Run the following command to find the role that contains the cmdlet or parameters. Be sure to replace `<Cmdlet>` and optionally, `<Parameter1>,<Parameter2>,...` with the actual cmdlet and parameter names you are interested in. Note that you can use wildcard characters (*) in the cmdlet and parameter names (for example, `*-Mailbox*`).
 
-  ```PowerShell
+  ```powershell
   Get-ManagementRoleEntry -Identity *\<Cmdlet>  [-Parameters <Parameter1>,<Parameter2>,... ]
   ```
 
@@ -83,7 +83,7 @@ What if there are no results?
 
   - If the command returns one or more entries for **Name**, **Role**, and **Parameters**, the cmdlet (or parameters on the cmdlet) is available in your environment, but the required role isn't assigned to anyone. To see all roles that aren't assigned to anyone, run the following command:
 
-    ```PowerShell
+    ```powershell
     $na = Get-ManagementRole ; $na | foreach {If ((Get-ManagementRoleAssignment -Role $_.Name -Delegating $false) -eq $null) {$_.Name}}
     ```
 
@@ -93,42 +93,42 @@ What if there are no results?
 
   To include scope information in Step 2, substitute the following command:
 
-  ```PowerShell
+  ```powershell
   $Perms | foreach {Get-ManagementRoleAssignment -Role $_.Name -Delegating $false | Format-List Role,RoleAssigneeType,RoleAssigneeName,*Scope*}
   ```
 
 - To see all roles assigned to a specific user, run the following command:
 
-  ```PowerShell
+  ```powershell
   Get-ManagementRoleAssignment -RoleAssignee <UserIdentity> -Delegating $false | Format-Table -Auto Role,RoleAssigneeName,RoleAssigneeType
   ```
 
   For example:
 
-  ```PowerShell
+  ```powershell
   Get-ManagementRoleAssignment -RoleAssignee julia@contoso.com -Delegating $false | Format-Table -Auto Role,RoleAssigneeName,RoleAssigneeType
   ```
 
 - To see all users who are assigned a specific role, run the following command:
 
-  ```PowerShell
+  ```powershell
   Get-ManagementRoleAssignment -Role "<Role name>" -GetEffectiveUsers -Delegating $false | Where-Object {$_.EffectiveUserName -ne "All Group Members"} | Format-Table -Auto EffectiveUserName,Role,RoleAssigneeName,AssignmentMethod
   ```
 
   For example:
 
-  ```PowerShell
+  ```powershell
   Get-ManagementRoleAssignment -Role "Mailbox Import Export"  -GetEffectiveUsers -Delegating $false | Where-Object {$_.EffectiveUserName -ne "All Group Members"} | Format-Table -Auto EffectiveUserName,Role,RoleAssigneeName,AssignmentMethod
   ```
 
 - To see the members of a specific role group, run the following command:
 
-  ```PowerShell
+  ```powershell
   Get-RoleGroupMember "<Role group name>"
   ```
 
   For example:
 
-  ```PowerShell
+  ```powershell
   Get-RoleGroupMember "Organization Management"
   ```

--- a/exchange/docs-conceptual/recipient-filters.md
+++ b/exchange/docs-conceptual/recipient-filters.md
@@ -14,56 +14,43 @@ description: "Learn about creating different kinds of recipient filters in the E
 
 # Recipient filters in Exchange PowerShell commands
 
-You can use several Exchange Management Shell and Exchange Online PowerShell commands to filter a set of recipients. You can create the following types of filters in an Exchange command:
+The cmdlets in the Exchange Management Shell and Exchange Online PowerShell support a variety of filters in recipient related cmdlets:
 
 - Precanned filters
-
 - Custom filters using the _RecipientFilter_ parameter
-
 - Custom filters using the _Filter_ parameter
-
 - Custom filters using the _ContentFilter_ parameter
 
-Older versions of Exchange used LDAP filtering syntax to create custom address lists, global address lists (GALs), email address policies, and distribution groups. In Exchange Server 2007 and later versions, OPATH filtering syntax replaced LDAP filtering syntax.
+Older versions of Exchange used LDAP filtering syntax to create custom address lists, global address lists (GALs), email address policies, and distribution groups. OPATH filtering syntax replaced LDAP filtering syntax starting in Exchange Server 2007.
 
 ## Precanned filters
 
 A precanned filter is a commonly used Exchange filter that you can use to meet a variety of recipient-filtering criteria for creating dynamic distribution groups, email address policies, address lists, or GALs. With precanned filters, you can use either the Exchange PowerShell or the Exchange admin center (EAC). Using precanned filters, you can do the following:
 
 - Determine the scope of recipients.
-
 - Add conditional filtering based on properties such as company, department, and state or region.
-
 - Add custom attributes for recipients. For more information, see [Custom Attributes](https://docs.microsoft.com/Exchange/recipients/mailbox-custom-attributes).
 
 The following parameters are considered precanned filters:
 
 - _IncludedRecipients_
-
 - _ConditionalCompany_
-
 - _ConditionalDepartment_
-
 - _ConditionalStateOrProvince_
-
 - _ConditionalCustomAttribute1_ to _ConditionalCustomAttribute15_.
 
 Precanned filters are available for the following cmdlets:
 
 - [New-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/new-dynamicdistributiongroup)
-
 - [Set-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/set-dynamicdistributiongroup)
 
 - [New-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/new-emailaddresspolicy)
-
 - [Set-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/set-emailaddresspolicy)
 
 - [New-AddressList](https://docs.microsoft.com/powershell/module/exchange/new-addresslist)
-
 - [Set-AddressList](https://docs.microsoft.com/powershell/module/exchange/set-addresslist)
 
 - [New-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/new-globaladdresslist)
-
 - [Set-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/set-globaladdresslist)
 
 ### Precanned filter example
@@ -72,8 +59,8 @@ This example describes using precanned filters in the Exchange Management Shell 
 
 - From which organizational unit (OU) do you want to include recipients? (This question corresponds to the _RecipientContainer_ parameter.)
 
-> [!NOTE]
-> Selecting the OU for this purpose applies only when creating dynamic distribution groups, and not when creating email address policies, address lists, or GALs.
+  > [!NOTE]
+  > Selecting the OU for this purpose applies only when creating dynamic distribution groups, and not when creating email address policies, address lists, or GALs.
 
 - What type of recipients do you want to include? (This question corresponds to the _IncludedRecipients_ parameter.)
 
@@ -81,13 +68,13 @@ This example describes using precanned filters in the Exchange Management Shell 
 
 This example creates the dynamic distribution group Contoso Finance for user mailboxes in the OU Contoso.com/Users and specifies the condition to include only recipients who have the **Department** attribute defined as Finance and the **Company** attribute defined as Contoso.
 
-```PowerShell
+```powershell
 New-DynamicDistributionGroup -Name "Contoso Finance" -OrganizationalUnit Contoso.com/Users -RecipientContainer Contoso.com/Users -IncludedRecipients MailboxUsers -ConditionalDepartment "Finance" -ConditionalCompany "Contoso"
 ```
 
 This example displays the properties of this new dynamic distribution group.
 
-```PowerShell
+```powershell
 Get-DynamicDistributionGroup -Identity "Contoso Finance" | Format-List Recipient*,Included*
 ```
 
@@ -98,19 +85,15 @@ If precanned filters don't meet your needs for creating or modifying dynamic dis
 The recipient filter parameter is available for the following cmdlets:
 
 - [New-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/new-dynamicdistributiongroup)
-
 - [Set-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/set-dynamicdistributiongroup)
 
 - [New-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/new-emailaddresspolicy)
-
 - [Set-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/set-emailaddresspolicy)
 
 - [New-AddressList](https://docs.microsoft.com/powershell/module/exchange/new-addresslist)
-
 - [Set-AddressList](https://docs.microsoft.com/powershell/module/exchange/set-addresslist)
 
 - [New-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/new-globaladdresslist)
-
 - [Set-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/set-globaladdresslist)
 
 For more information about the filterable properties you can use with the _RecipientFilter_ parameter, see [Filterable properties for the RecipientFilter parameter](recipientfilter-properties.md).
@@ -121,7 +104,7 @@ The following example uses the _RecipientFilter_ parameter to create a dynamic d
 
 This example uses custom filters to create a dynamic distribution group for user mailboxes that have the **Company** attribute defined as Contoso and the **Office** attribute defined as North Building.
 
-```PowerShell
+```powershell
 New-DynamicDistributionGroup -Name AllContosoNorth -OrganizationalUnit contoso.com/Users -RecipientFilter "((RecipientType -eq 'UserMailbox') -and (Company -eq 'Contoso') -and (Office -eq 'North Building'))"
 ```
 
@@ -133,40 +116,26 @@ Using the _Filter_ parameter to modify command results is known as server-side f
 
 To find the filterable properties for cmdlets that have the _Filter_ parameter, you can run the **Get** command against an object and format the output by pipelining the **Format-List** parameter. Most of the returned values will be available for use in the _Filter_ parameter. The following example returns a detailed list for the mailbox Ayla.
 
-```PowerShell
+```powershell
 Get-Mailbox -Identity Ayla | Format-List
 ```
 
 The _Filter_ parameter is available for the following recipient cmdlets:
 
 - [Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)
-
 - [Get-Contact](https://docs.microsoft.com/powershell/module/exchange/get-contact)
-
 - [Get-DistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-distributiongroup)
-
 - [Get-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-dynamicdistributiongroup)
-
 - [Get-Group](https://docs.microsoft.com/powershell/module/exchange/get-group)
-
 - [Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)
-
 - [Get-MailContact](https://docs.microsoft.com/powershell/module/exchange/get-mailcontact)
-
 - [Get-MailPublicFolder](https://docs.microsoft.com/powershell/module/exchange/get-mailpublicfolder)
-
 - [Get-MailUser](https://docs.microsoft.com/powershell/module/exchange/get-mailuser)
-
 - [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)
-
 - [Get-RemoteMailbox](https://docs.microsoft.com/powershell/module/exchange/get-remotemailbox)
-
 - [Get-SecurityPrincipal](https://docs.microsoft.com/powershell/module/exchange/get-securityprincipal)
-
 - [Get-UMMailbox](https://docs.microsoft.com/powershell/module/exchange/get-ummailbox)
-
 - [Get-User](https://docs.microsoft.com/powershell/module/exchange/get-user)
-
 - [Get-UnifiedGroup](https://docs.microsoft.com/powershell/module/exchange/get-unifiedgroup)
 
 For more information about the filterable properties you can use with the _Filter_ parameter, see [Filterable properties for the Filter parameter](filter-properties.md).
@@ -175,7 +144,7 @@ For more information about the filterable properties you can use with the _Filte
 
 This example uses the _Filter_ parameter to return information about users whose title contains the word "manager".
 
-```PowerShell
+```powershell
 Get-User -Filter "Title -like 'Manager*'"
 ```
 
@@ -187,7 +156,7 @@ You can use the _ContentFilter_ parameter to select specific message content to 
 
 This example creates an export request that searches Ayla's mailbox for messages where the body contains the phrase "company prospectus". If that phrase is found, the command exports all messages with that phrase to a .pst file.
 
-```PowerShell
+```powershell
 New-MailboxExportRequest -Mailbox Ayla -ContentFilter "Body -like 'company prospectus*'"
 ```
 
@@ -210,9 +179,8 @@ When creating your own custom OPath filters, consider the following items:
 - You need to enclose the whole OPath filter in double quotation marks " or " single quotation marks ' '. Although any OPath filter object is technically a string and not a script block, you can still use braces { }, but only if the filter doesn't contain variables that require expansion. The characters that you can use to enclose the whole OPath filter depend on types of values that you're searching for and the characters you used (or didn't use) to enclose those values:
 
   - **Text values**: Depends on how you enclosed the text to search for:
-  
-    - **Text enclosed in single quotation marks**: Enclose the whole OPath filter in double quotation marks or braces.
 
+    - **Text enclosed in single quotation marks**: Enclose the whole OPath filter in double quotation marks or braces.
     - **Text enclosed in double quotation marks**: Enclose the whole OPath filter in braces.
 
   - **Variables**: Enclose the whole OPath filter in double quotation marks (for example, `"Name -eq '$User'"`).
@@ -220,17 +188,17 @@ When creating your own custom OPath filters, consider the following items:
   - **Integer values**: Depends on how you enclosed (or didn't enclose) the integer to search for:
 
     - **Integer not enclosed**: Enclose the whole OPath filter in double quotation marks, single quotation marks, or braces (for example `"CountryCode -eq 840"`).
-
     - **Integer enclosed in single quotation marks**: Enclose the whole OPath filter in double quotation marks or braces `"CountryCode -eq '840'"`.
-
     - **Integer enclosed in double quotation marks**: Enclose the whole OPath filter in braces (for example `{CountryCode -eq "840"}`).
 
   - **System values**: Enclose the whole OPath filter in single quotation marks or braces (for example `'HiddenFromAddressListsEnabled -eq $true'`). If you escape the dollar sign system value, you can also enclose the whole OPath filter in double quotation marks (for example, ``"HiddenFromAddressListsEnabled -eq `$true"``).
 
   The compatibility of search criteria and the valid characters that you can use to enclose the whole OPath filter are summarized in the following table:
 
-  |**Search value**|**OPath filter enclosed <br/> in double quotation marks**|**OPath filter enclosed <br/> in single quotation marks**|**OPath filter enclosed <br/> in braces**|
-  |:-----|:-----:|:-----:|:-----:|
+  ****
+
+  |Search value|OPath filter <br/> enclosed in <br/> double quotation marks|OPath filter <br/> enclosed in <br/> single quotation marks|OPath filter enclosed in <br/> braces|
+  |---|:---:|:---:|:---:|
   |`'Text'`|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
   |`"Text"`|||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
   |`'$Variable'`|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|||
@@ -239,40 +207,36 @@ When creating your own custom OPath filters, consider the following items:
   |`"500"`|||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
   |`$true`||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
   |`` `$true``|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |
 
-- Include the hyphen before all operators. The most common operators include:
+- Include the hyphen before all logical or comparison operators. The most common operators include:
 
-  - **-and**
-
-  - **-or**
-
-  - **-not**
-
-  - **-eq** (equals)
-
-  - **-ne** (not equal)
-
-  - **-lt** (less than)
-
-  - **-gt** (greater than)
-
-  - **-like** (string comparison)
-
-  - **-notlike** (string comparison)
+  - `-and`
+  - `-or`
+  - `-not`
+  - `-eq` (equals)
+  - `-ne` (not equal)
+  - `-lt` (less than)
+  - `-gt` (greater than)
+  - `-like` (string comparison)
+  - `-notlike` (string comparison)
 
 - Many filterable properties accept wildcard characters. If you use a wildcard character, use the **-like** operator instead of the **-eq** operator. The **-like** operator is used to find pattern matches in rich types (for example, strings) whereas the **-eq** operator is used to find an exact match.
 
 - For more information about operators you can use, see:
 
   - [about_Logical_Operators](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_logical_operators)
-
   - [about_Comparison_Operators](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_comparison_operators)
 
 ## Recipient filter documentation
 
 The following table contains links to topics that will help you learn more about the filterable properties that you can use with Exchange recipient commands.
 
-|**Topic**|**Description**|
-|:-----|:-----|
-|[Filterable properties for the RecipientFilter parameter](recipientfilter-properties.md)|Learn more about the filterable properties that are available for the _RecipientFilter_ parameter.|
-|[Filterable properties for the Filter parameter](filter-properties.md) |Learn more about the filterable properties that are available for the _Filter_ parameter.|
+****
+
+|Topic|Description|
+|---|---|
+|[Filterable properties for the RecipientFilter parameter on Exchange cmdlets](recipientfilter-properties.md)|Learn more about the filterable properties that are available for the _RecipientFilter_ parameter.|
+|[Filterable properties for the Filter parameter on Exchange cmdlets](filter-properties.md) |Learn more about the filterable properties that are available for the _Filter_ parameter.|
+|[Filters in the EXO V2 module](filters-v2.md)|Learn about the considerations for filters when you connect to Exchange Online PowerShell using the Exchange Online PowerShell V2 module.|
+|

--- a/exchange/docs-conceptual/recipient-filters.md
+++ b/exchange/docs-conceptual/recipient-filters.md
@@ -50,21 +50,21 @@ The following parameters are considered precanned filters:
 
 Precanned filters are available for the following cmdlets:
 
-- [New-DynamicDistributionGroup](../exchange-ps/exchange/new-dynamicdistributiongroup.md)
+- [New-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/new-dynamicdistributiongroup)
 
-- [Set-DynamicDistributionGroup](../exchange-ps/exchange/set-dynamicdistributiongroup.md)
+- [Set-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/set-dynamicdistributiongroup)
 
-- [New-EmailAddressPolicy](../exchange-ps/exchange/new-emailaddresspolicy.md)
+- [New-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/new-emailaddresspolicy)
 
-- [Set-EmailAddressPolicy](../exchange-ps/exchange/set-emailaddresspolicy.md)
+- [Set-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/set-emailaddresspolicy)
 
-- [New-AddressList](../exchange-ps/exchange/new-addresslist.md)
+- [New-AddressList](https://docs.microsoft.com/powershell/module/exchange/new-addresslist)
 
-- [Set-AddressList](../exchange-ps/exchange/set-addresslist.md)
+- [Set-AddressList](https://docs.microsoft.com/powershell/module/exchange/set-addresslist)
 
-- [New-GlobalAddressList](../exchange-ps/exchange/new-globaladdresslist.md)
+- [New-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/new-globaladdresslist)
 
-- [Set-GlobalAddressList](../exchange-ps/exchange/set-globaladdresslist.md)
+- [Set-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/set-globaladdresslist)
 
 ### Precanned filter example
 
@@ -97,21 +97,21 @@ If precanned filters don't meet your needs for creating or modifying dynamic dis
 
 The recipient filter parameter is available for the following cmdlets:
 
-- [New-DynamicDistributionGroup](../exchange-ps/exchange/new-dynamicdistributiongroup.md)
+- [New-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/new-dynamicdistributiongroup)
 
-- [Set-DynamicDistributionGroup](../exchange-ps/exchange/set-dynamicdistributiongroup.md)
+- [Set-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/set-dynamicdistributiongroup)
 
-- [New-EmailAddressPolicy](../exchange-ps/exchange/new-emailaddresspolicy.md)
+- [New-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/new-emailaddresspolicy)
 
-- [Set-EmailAddressPolicy](../exchange-ps/exchange/set-emailaddresspolicy.md)
+- [Set-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/set-emailaddresspolicy)
 
-- [New-AddressList](../exchange-ps/exchange/new-addresslist.md)
+- [New-AddressList](https://docs.microsoft.com/powershell/module/exchange/new-addresslist)
 
-- [Set-AddressList](../exchange-ps/exchange/set-addresslist.md)
+- [Set-AddressList](https://docs.microsoft.com/powershell/module/exchange/set-addresslist)
 
-- [New-GlobalAddressList](../exchange-ps/exchange/new-globaladdresslist.md)
+- [New-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/new-globaladdresslist)
 
-- [Set-GlobalAddressList](../exchange-ps/exchange/set-globaladdresslist.md)
+- [Set-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/set-globaladdresslist)
 
 For more information about the filterable properties you can use with the _RecipientFilter_ parameter, see [Filterable properties for the RecipientFilter parameter](recipientfilter-properties.md).
 
@@ -139,35 +139,35 @@ Get-Mailbox -Identity Ayla | Format-List
 
 The _Filter_ parameter is available for the following recipient cmdlets:
 
-- [Get-CASMailbox](../exchange-ps/exchange/get-casmailbox.md)
+- [Get-CASMailbox](https://docs.microsoft.com/powershell/module/exchange/get-casmailbox)
 
-- [Get-Contact](../exchange-ps/exchange/get-contact.md)
+- [Get-Contact](https://docs.microsoft.com/powershell/module/exchange/get-contact)
 
-- [Get-DistributionGroup](../exchange-ps/exchange/get-distributiongroup.md)
+- [Get-DistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-distributiongroup)
 
-- [Get-DynamicDistributionGroup](../exchange-ps/exchange/get-dynamicdistributiongroup.md)
+- [Get-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/get-dynamicdistributiongroup)
 
-- [Get-Group](../exchange-ps/exchange/get-group.md)
+- [Get-Group](https://docs.microsoft.com/powershell/module/exchange/get-group)
 
-- [Get-Mailbox](../exchange-ps/exchange/get-mailbox.md)
+- [Get-Mailbox](https://docs.microsoft.com/powershell/module/exchange/get-mailbox)
 
-- [Get-MailContact](../exchange-ps/exchange/get-mailcontact.md)
+- [Get-MailContact](https://docs.microsoft.com/powershell/module/exchange/get-mailcontact)
 
-- [Get-MailPublicFolder](../exchange-ps/exchange/get-mailpublicfolder.md)
+- [Get-MailPublicFolder](https://docs.microsoft.com/powershell/module/exchange/get-mailpublicfolder)
 
-- [Get-MailUser](../exchange-ps/exchange/get-mailuser.md)
+- [Get-MailUser](https://docs.microsoft.com/powershell/module/exchange/get-mailuser)
 
-- [Get-Recipient](../exchange-ps/exchange/get-recipient.md)
+- [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient)
 
-- [Get-RemoteMailbox](../exchange-ps/exchange/get-remotemailbox.md)
+- [Get-RemoteMailbox](https://docs.microsoft.com/powershell/module/exchange/get-remotemailbox)
 
-- [Get-SecurityPrincipal](../exchange-ps/exchange/get-securityprincipal.md)
+- [Get-SecurityPrincipal](https://docs.microsoft.com/powershell/module/exchange/get-securityprincipal)
 
-- [Get-UMMailbox](../exchange-ps/exchange/get-ummailbox.md)
+- [Get-UMMailbox](https://docs.microsoft.com/powershell/module/exchange/get-ummailbox)
 
-- [Get-User](../exchange-ps/exchange/get-user.md)
+- [Get-User](https://docs.microsoft.com/powershell/module/exchange/get-user)
 
-- [Get-UnifiedGroup](../exchange-ps/exchange/Get-UnifiedGroup.md)
+- [Get-UnifiedGroup](https://docs.microsoft.com/powershell/module/exchange/get-unifiedgroup)
 
 For more information about the filterable properties you can use with the _Filter_ parameter, see [Filterable properties for the Filter parameter](filter-properties.md).
 
@@ -181,7 +181,7 @@ Get-User -Filter "Title -like 'Manager*'"
 
 ## Custom filters using the ContentFilter parameter
 
-You can use the _ContentFilter_ parameter to select specific message content to export when using the [New-MailboxExportRequest](../exchange-ps/exchange/new-mailboxexportrequest.md) cmdlet. If the command finds a message that contains the match to the content filter, it exports the message to a .pst file.
+You can use the _ContentFilter_ parameter to select specific message content to export when using the [New-MailboxExportRequest](https://docs.microsoft.com/powershell/module/exchange/new-mailboxexportrequest) cmdlet. If the command finds a message that contains the match to the content filter, it exports the message to a .pst file.
 
 ### ContentFilter parameter example
 

--- a/exchange/docs-conceptual/recipientfilter-properties.md
+++ b/exchange/docs-conceptual/recipientfilter-properties.md
@@ -12,16 +12,13 @@ ms.assetid: cf78aca5-6699-485c-9b15-e0adba252176
 description: "Learn about the recipient properties that you can use with the RecipientFilter parameter in Exchange Server and Exchange Online cmdlets."
 ---
 
-# Filterable properties for the RecipientFilter parameter
+# Filterable properties for the RecipientFilter parameter on Exchange cmdlets
 
 You use the _RecipientFilter_ parameter to create OPATH filters based on the properties of recipient objects in Exchange Server 2016 or later, and Exchange Online. The _RecipientFilter_ parameter is available in the following cmdlets:
 
 - [New-AddressList](https://docs.microsoft.com/powershell/module/exchange/new-addresslist) and [Set-AddressList](https://docs.microsoft.com/powershell/module/exchange/set-addresslist)
-
 - [New-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/new-dynamicdistributiongroup) and [Set-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/set-dynamicdistributiongroup)
-
 - [New-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/new-emailaddresspolicy) and [Set-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/set-emailaddresspolicy)
-
 - [New-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/new-globaladdresslist) and [Set-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/set-globaladdresslist)
 
 ## Filterable recipient properties
@@ -33,7 +30,6 @@ The recipient properties that have been *confirmed* to work with the _RecipientF
 - The list might include:
 
   - Properties that are only used in one type of environment: Microsoft 365, on-premises Exchange, or hybrid. The property might exist on recipient objects in all environments, but the value is only meaningful (a value other than blank or `None`) in one type of environment.
-
   - Properties that are present, but correspond to features that are no longer used in Exchange.
 
 - You can't use properties from other Active Directory schema extensions with the _RecipientFilter_ parameter.
@@ -50,10 +46,12 @@ The recipient properties that have been *confirmed* to work with the _RecipientF
 
 - To look for blank or non-blank property values, use the value `$null` (for example, `'Property -eq $null'` or `'Property -ne $null'`).
 
+- For filtering considerations for connections using the Exchange Online PowerShell v2 module, see [Filters in the EXO V2 module](filters-v2.md).
+
 ****
 
-|**Property name**|**LDAP display name**|**Value**|**Comments**|
-|:-----|:-----|:-----|:-----|
+|Property name|LDAP display name|Value|Comments|
+|---|---|---|---|
 |_AcceptMessagesOnlyFrom_|_authOrig_|Dynamic distribution groups: String (wildcards accepted). <br/> Others: Blank or non-blank.||
 |_AcceptMessagesOnlyFromDLMembers_|_dLMemSubmitPerms_|Dynamic distribution groups: String (wildcards accepted). <br/> Others: Blank or non-blank.||
 |_ActiveSyncAllowedDeviceIDs_|_msExchMobileAllowedDeviceIds_|String (wildcards accepted).||
@@ -309,9 +307,8 @@ The recipient properties that have been *confirmed* to work with the _RecipientF
 |_WhenSoftDeleted_|_msExchWhenSoftDeletedTime_|Dynamic distribution groups: A date/time value using the time zone and regional settings of the Exchange server. <br/> Others: Blank or non-blank.||
 |_WindowsEmailAddress_|_mail_|String (wildcards accepted).||
 |_WindowsLiveID_|_msExchWindowsLiveID_|String (wildcards accepted).||
+|
 
 ## For more information
 
-Exchange 2007 was the first version of Exchange that required OPATH filters instead of LDAP filters. For more information about converting LDAP filters to OPATH filters, see the Microsoft Exchange Team Blog article, [Need help converting your LDAP filters to OPATH?](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Need-help-converting-your-LDAP-filters-to-OPATH/ba-p/595108).
-
-For more information about the syntax that can be used within OPATH filters, see [Exchange cmdlet syntax](exchange-cmdlet-syntax.md).
+Exchange Server 2007 was the first version of Exchange that required OPATH filters instead of LDAP filters. For more information about converting LDAP filters to OPATH filters, see the Microsoft Exchange Team Blog article, [Need help converting your LDAP filters to OPATH?](https://techcommunity.microsoft.com/t5/Exchange-Team-Blog/Need-help-converting-your-LDAP-filters-to-OPATH/ba-p/595108).

--- a/exchange/docs-conceptual/recipientfilter-properties.md
+++ b/exchange/docs-conceptual/recipientfilter-properties.md
@@ -16,13 +16,13 @@ description: "Learn about the recipient properties that you can use with the Rec
 
 You use the _RecipientFilter_ parameter to create OPATH filters based on the properties of recipient objects in Exchange Server 2016 or later, and Exchange Online. The _RecipientFilter_ parameter is available in the following cmdlets:
 
-- [New-AddressList](../exchange-ps/exchange/new-addresslist.md) and [Set-AddressList](../exchange-ps/exchange/set-addresslist.md)
+- [New-AddressList](https://docs.microsoft.com/powershell/module/exchange/new-addresslist) and [Set-AddressList](https://docs.microsoft.com/powershell/module/exchange/set-addresslist)
 
-- [New-DynamicDistributionGroup](../exchange-ps/exchange/new-dynamicdistributiongroup.md) and [Set-DynamicDistributionGroup](../exchange-ps/exchange/set-dynamicdistributiongroup.md)
+- [New-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/new-dynamicdistributiongroup) and [Set-DynamicDistributionGroup](https://docs.microsoft.com/powershell/module/exchange/set-dynamicdistributiongroup)
 
-- [New-EmailAddressPolicy](../exchange-ps/exchange/new-emailaddresspolicy.md) and [Set-EmailAddressPolicy](../exchange-ps/exchange/set-emailaddresspolicy.md)
+- [New-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/new-emailaddresspolicy) and [Set-EmailAddressPolicy](https://docs.microsoft.com/powershell/module/exchange/set-emailaddresspolicy)
 
-- [New-GlobalAddressList](../exchange-ps/exchange/new-globaladdresslist.md) and [Set-GlobalAddressList](../exchange-ps/exchange/set-globaladdresslist.md)
+- [New-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/new-globaladdresslist) and [Set-GlobalAddressList](https://docs.microsoft.com/powershell/module/exchange/set-globaladdresslist)
 
 ## Filterable recipient properties
 
@@ -166,10 +166,10 @@ The recipient properties that have been *confirmed* to work with the _RecipientF
 |_LitigationHoldOwner_|_msExchLitigationHoldOwner_|String (wildcards accepted).||
 |_LocaleID_|_localeID_|Integer|For valid values, [Microsoft Locale ID Values](https://docs.microsoft.com/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a).|
 |_MailboxMoveBatchName_|_msExchMailboxMoveBatchName_|String (wildcards accepted).||
-|_MailboxMoveFlags_|_msExchMailboxMoveFlags_|For valid values, see the description of the _Flags_ parameter in[Get-MoveRequest](../exchange-ps/exchange/get-moverequest.md).||
+|_MailboxMoveFlags_|_msExchMailboxMoveFlags_|For valid values, see the description of the _Flags_ parameter in [Get-MoveRequest](https://docs.microsoft.com/powershell/module/exchange/get-moverequest).||
 |_MailboxMoveRemoteHostName_|_msExchMailboxMoveRemoteHostName_|String (wildcards accepted).||
 |_MailboxMoveSourceMDB_|_msExchMailboxMoveSourceMDBLink_|String (wildcards accepted in dynamic distribution groups).||
-|_MailboxMoveStatus_|_msExchMailboxMoveStatus_|For valid values, see the description of the _MoveStatus_ parameter in[Get-MoveRequest](../exchange-ps/exchange/get-moverequest.md).||
+|_MailboxMoveStatus_|_msExchMailboxMoveStatus_|For valid values, see the description of the _MoveStatus_ parameter in [Get-MoveRequest](https://docs.microsoft.com/powershell/module/exchange/get-moverequest).||
 |_MailboxMoveTargetMDB_|_msExchMailboxMoveTargetMDBLink_|String (wildcards accepted in dynamic distribution groups).||
 |_MailboxPlan_|_msExchParentPlanLink_|String (wildcards accepted).|Mailbox plans correspond to Microsoft 365 license types. The availability of a license plans is determined by the selections that you make when you enroll your domain.|
 |_MailboxRelease_|_msExchMailboxRelease_|String (wildcards accepted).||
@@ -220,7 +220,7 @@ The recipient properties that have been *confirmed* to work with the _RecipientF
 |_PopEnabled_|n/a|Boolean (`$true` or `$false`)||
 |_PostalCode_|_postalCode_|String (wildcards accepted).||
 |_PostOfficeBox_|_postOfficeBox_|String (wildcards accepted).||
-|_PreviousRecipientTypeDetails_|_msExchPreviousRecipientTypeDetails_|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](../exchange-ps/exchange/get-recipient.md).||
+|_PreviousRecipientTypeDetails_|_msExchPreviousRecipientTypeDetails_|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient).||
 |_PrimaryGroupId_|_primaryGroupId_|Integer|For domain users, the value of this property is typically 513, which corresponds to the Domain Users group.|
 |_PrimarySmtpAddress_|n/a|String (wildcards accepted).|Don't use the _PrimarySmtpAddress_ property; use the _EmailAddresses_ property instead. Any filter that uses the _PrimarySmtpAddress_ property will also search values in the _EmailAddresses_ property. For example, if a mailbox has the primary email address dario@contoso.com, and the additional proxy addresses dario2@contoso.com and dario3@contoso.com, all of the following filters will return that mailbox in the result: `"PrimarySmtpAddress -eq 'dario@contoso.com'"`, `"PrimarySmtpAddress -eq 'dario2@contoso.com'"`, or `"PrimarySmtpAddress -eq 'dario3@contoso.com'"`.|
 |_ProhibitSendQuota_|_mDBOverQuotaLimit_|Dynamic distribution groups: A byte quantified size value (for example, `50MB` or `1.5GB`). Unqualified values are treated as bytes. <br/> Others: Blank or non-blank.||
@@ -236,8 +236,8 @@ The recipient properties that have been *confirmed* to work with the _RecipientF
 |_RecipientDisplayType_|_msExchRecipientDisplayType_|`MailboxUser` (0), `DistributionGroup` (1), `PublicFolder` (2), `DynamicDistributionGroup` (3), `Organization` (4), `PrivateDistributionList` (5), `RemoteMailUser` (6). `ConferenceRoomMailbox` (7), or `EquipmentMailbox` (8).||
 |_RecipientFilter_|_msExchQueryFilter_|String (wildcards accepted).||
 |_RecipientLimits_|_msExchRecipLimit_|`Unlimited` or an integer.|This property specifies the maximum number of recipients that are allowed in messages sent by the mailbox.|
-|_RecipientType_|n/a|For valid values, see the description of the _RecipientType_ parameter in [Get-Recipient](../exchange-ps/exchange/get-recipient.md).||
-|_RecipientTypeDetails_|n/a|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](../exchange-ps/exchange/get-recipient.md).||
+|_RecipientType_|n/a|For valid values, see the description of the _RecipientType_ parameter in [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient).||
+|_RecipientTypeDetails_|n/a|For valid values, see the description of the _RecipientTypeDetails_ parameter in [Get-Recipient](https://docs.microsoft.com/powershell/module/exchange/get-recipient).||
 |_RecoverableItemsQuota_|_msExchDumpsterQuota_|Dynamic distribution groups: A byte quantified size value (for example, `50MB` or `1.5GB`). Unqualified values are treated as bytes. <br/> Others: Blank or non-blank.||
 |_RecoverableItemsWarningQuota_|_msExchDumpsterWarningQuota_|Dynamic distribution groups: A byte quantified size value (for example, `50MB` or `1.5GB`). Unqualified values are treated as bytes. <br/> Others: Blank or non-blank.||
 |_RejectMessagesFrom_|_unauthOrig_|Dynamic distribution groups: String (wildcards accepted). <br/> Others: Blank or non-blank.||

--- a/exchange/docs-conceptual/scc-powershell.md
+++ b/exchange/docs-conceptual/scc-powershell.md
@@ -15,8 +15,12 @@ description: "Learn about using Security & Compliance Center PowerShell."
 
 # Security & Compliance Center PowerShell
 
-Security & Compliance Center PowerShell is the administrative interface that enables you to manage your Security & Compliance Center settings from the command line. For example, you can use Security & Compliance Center PowerShell to perform Compliance Searches and configure access to the Security & Compliance Center. The following topics provide information about using Security & Compliance Center PowerShell:
+Security & Compliance Center PowerShell is the administrative interface that enables you to manage the features that are available in the Security & Compliance Center from the command line. For example, you can use Security & Compliance Center PowerShell to perform Compliance Searches and configure access to the Security & Compliance Center. The following topics provide information about using Security & Compliance Center PowerShell:
 
-- To create a remote PowerShell session to the Security & Compliance Center, see [Connect to Security & Compliance Center PowerShell](connect-to-scc-powershell.md). Note that the connection instructions are different from Exchange Online or Exchange Online Protection (the _ConnectionUri_ value is different).
+- To create a remote PowerShell session that supports both modern authentication and multi-factor authentication (MFA), see [Connect to Security & Compliance Center PowerShell](connect-to-scc-powershell.md). Note that the connection instructions are different from Exchange Online PowerShell or standalone Exchange Online Protection (EOP) PowerShell (the _ConnectionUri_ value is different).
 
-- A cmdlet is a lightweight command that is imported into your local Windows PowerShell session. Note that some cmdlets are available only in the Security & Compliance Center. Other cmdlets have the same names and functionality as those in Exchange Online, but they are also available in the Security & Compliance Center.
+- To learn about the structure and layout of the cmdlet reference topics in Security & Compliance Center PowerShell, see [Exchange cmdlet syntax](exchange-cmdlet-syntax.md).
+
+Many of the cmdlets that are available in Security & Compliance Center PowerShell correspond to features that are only available in the Security & Compliance Center, so the related cmdlets are exclusive to Security & Compliance Center PowerShell. But, some cmdlets that are available in Security & Compliance Center PowerShell have the same names and functionality as those in Exchange Online PowerShell (for example, [Get-User](../exchange-ps/exchange/Get-User.md)).
+
+Also, some features that are available in the Security & Compliance Center (for example, [anti-spam and anti-malware](https://docs.microsoft.com/microsoft-365/security/office-365-security/anti-spam-and-anti-malware-protection?view=o365-worldwide) cmdlets are only available in [Exchange Online PowerShell](exchange-online-powershell.md)). Check the **Applies to** value in the cmdlet reference topic to verify where the cmdlet actually resides.

--- a/exchange/docs-conceptual/toc.yml
+++ b/exchange/docs-conceptual/toc.yml
@@ -1,66 +1,75 @@
 - name: Home
   href: index.yml
   items:
-  - name: Exchange Server PowerShell
-    href: exchange-management-shell.md
-    items:
-    - name: Open the Exchange Management Shell
-      href: open-the-exchange-management-shell.md
-    - name: Connect to Exchange servers using remote PowerShell
-      href: connect-to-exchange-servers-using-remote-powershell.md
-    - name: Control remote PowerShell access to Exchange servers
-      href: control-remote-powershell-access-to-exchange-servers.md
-    - name: Find the permissions required to run any Exchange cmdlet
-      href: find-exchange-cmdlet-permissions.md
-    - name: Exchange cmdlet syntax
-      href: exchange-cmdlet-syntax.md
-    - name: Use Update-ExchangeHelp to update Exchange PowerShell help topics on Exchange servers
-      href: use-update-exchangehelp.md
-    - name: Recipient filters in Exchange Management Shell commands
-      href: recipient-filters.md
+    - name: Exchange Server PowerShell
+      href: exchange-management-shell.md
       items:
-      - name: Filterable properties for the Filter parameter
-        href: filter-properties.md
-      - name: Filterable properties for the RecipientFilter parameter
-        href: recipientfilter-properties.md   
-  - name: Exchange Online PowerShell
-    href: exchange-online-powershell.md
-    items:
-    - name: Connect to Exchange Online PowerShell - Basic auth
-      href: connect-to-exchange-online-powershell.md
+        - name: Open the Exchange Management Shell
+          href: open-the-exchange-management-shell.md
+        - name: Connect to Exchange servers using remote PowerShell
+          href: connect-to-exchange-servers-using-remote-powershell.md
+        - name: Control remote PowerShell access to Exchange servers
+          href: control-remote-powershell-access-to-exchange-servers.md
+        - name: Find the permissions required to run any Exchange cmdlet
+          href: find-exchange-cmdlet-permissions.md
+        - name: Exchange cmdlet syntax
+          href: exchange-cmdlet-syntax.md
+        - name: Use Update-ExchangeHelp to update Exchange PowerShell help topics on Exchange servers
+          href: use-update-exchangehelp.md
+        - name: Recipient filters in Exchange Management Shell commands
+          href: recipient-filters.md
+          items:
+            - name: Filterable properties for the Filter parameter
+              href: filter-properties.md
+            - name: Filterable properties for the RecipientFilter parameter
+              href: recipientfilter-properties.md
+    - name: Exchange Online PowerShell
+      href: exchange-online-powershell.md
       items:
-      - name: Connect to Exchange Online PowerShell using multi-factor authentication
-        href: mfa-connect-to-exchange-online-powershell.md
-    - name: Find the permissions required to run any Exchange cmdlet
-      href: find-exchange-cmdlet-permissions.md
-    - name: Enable or disable access to Exchange Online PowerShell
-      href: disable-access-to-exchange-online-powershell.md
-    - name: Recipient filters in Exchange PowerShell commands
-      href: recipient-filters.md
+        - name: About the Exchange Online PowerShell V2 module
+          href: exchange-online-powershell-v2.md
+        - name: Connect to Exchange Online PowerShell - modern auth and MFA
+          href: connect-to-exchange-online-powershell.md
+        - name: Enable or disable access to Exchange Online PowerShell
+          href: disable-access-to-exchange-online-powershell.md
+        - name: Exchange cmdlet syntax
+          href: exchange-cmdlet-syntax.md
+        - name: Find the permissions required to run any Exchange cmdlet
+          href: find-exchange-cmdlet-permissions.md
+        - name: Recipient filters in Exchange PowerShell commands
+          href: recipient-filters.md
+          items:
+            - name: Filterable properties for the Filter parameter
+              href: filter-properties.md
+            - name: Filterable properties for the RecipientFilter parameter
+              href: recipientfilter-properties.md
+            - name: Filters in EXO V2 module cmdlets
+              href: filters-v2.md
+        - name: App-only authentication for unattended scripts
+          href: app-only-auth-powershell-v2.md
+        - name: Property sets in EXO V2 module cmdlets
+          href: cmdlet-property-sets.md
+        - name: V1 module - Connect to Exchange Online PowerShell
+          href: v1-module-mfa-connect-to-exo-powershell.md
+        - name: Basic auth - Connect to Exchange Online PowerShell
+          href: basic-auth-connect-to-exo-powershell.md
+    - name: Security & Compliance Center PowerShell
+      href: scc-powershell.md
       items:
-      - name: Filterable properties for the Filter parameter
-        href: filter-properties.md
-      - name: Filterable properties for the RecipientFilter parameter
-        href: recipientfilter-properties.md
-  - name: Exchange Online PowerShell V2 - modern auth
-    href: exchange-online-powershell-v2.md
-    items:
-    - name: Property sets in V2 cmdlets
-      href: cmdlet-property-sets.md
-    - name: Filters in the V2 module
-      href: filters-v2.md
-    - name: App-only authentication for unattended scripts
-      href: app-only-auth-powershell-v2.md
-  - name: Security & Compliance Center PowerShell
-    href: scc-powershell.md
-    items:
-    - name: Connect to Security & Compliance Center PowerShell
-      href: connect-to-scc-powershell.md
+        - name: Connect to Security & Compliance Center PowerShell - modern auth and MFA
+          href: connect-to-scc-powershell.md
+        - name: Exchange cmdlet syntax
+          href: exchange-cmdlet-syntax.md
+        - name: V1 module - Connect to Security & Compliance Center PowerShell
+          href: v1-module-mfa-connect-to-scc-powershell.md
+        - name: Basic auth - Connect to Exchange Online Protection PowerShell
+          href: basic-auth-connect-to-scc-powershell.md
+    - name: Exchange Online Protection PowerShell
+      href: exchange-online-protection-powershell.md
       items:
-      - name: Connect to Security & Compliance Center PowerShell using multi-factor authentication
-        href: mfa-connect-to-scc-powershell.md
-  - name: Exchange Online Protection PowerShell
-    href: exchange-online-protection-powershell.md
-    items:
-    - name: Connect to Exchange Online Protection PowerShell
-      href: connect-to-exchange-online-protection-powershell.md
+        - name: Connect to Exchange Online Protection PowerShell - modern auth and MFA
+          href: connect-to-exchange-online-protection-powershell.md
+        - name: Exchange cmdlet syntax
+          href: exchange-cmdlet-syntax.md
+        - name: Basic auth - Connect to Exchange Online Protection PowerShell
+          href: basic-auth-connect-to-eop-powershell.md

--- a/exchange/docs-conceptual/use-update-exchangehelp.md
+++ b/exchange/docs-conceptual/use-update-exchangehelp.md
@@ -39,7 +39,7 @@ This method requires that the Exchange server has direct access to the internet.
 
 Run the following command in the Exchange Management Shell:
 
-```PowerShell
+```powershell
 Update-ExchangeHelp -Verbose
 ```
 
@@ -139,13 +139,13 @@ If you want to identify only the update packages that apply to you, follow these
 
    To find the version details on a single Exchange server, run the following command:
 
-   ```PowerShell
+   ```powershell
    Get-Command Exsetup.exe | ForEach {$_.FileVersionInfo}
    ```
 
    To find the version details for all Exchange servers in your organization, run the following command:
 
-   ```PowerShell
+   ```powershell
    Get-ExchangeServer | Sort-Object Name | ForEach {Invoke-Command -ComputerName $_.Name -ScriptBlock {Get-Command ExSetup.exe | ForEach{$_.FileVersionInfo}}} | Format-Table -Auto
    ```
 

--- a/exchange/docs-conceptual/v1-module-mfa-connect-to-exo-powershell.md
+++ b/exchange/docs-conceptual/v1-module-mfa-connect-to-exo-powershell.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect to Exchange Online PowerShell using multi-factor authentication"
+title: "V1 module - Connect to Exchange Online PowerShell using MFA"
 ms.author: chrisda
 author: chrisda
 manager: dansimp
@@ -8,17 +8,18 @@ ms.audience: Admin
 ms.topic: article
 ms.service: exchange-online
 localization_priority: Normal
-ms.assetid: 04dae4ce-34a7-49c5-bf75-11e72452e04a
+ms.assetid:
 search.appverid: MET150
-description: "Learn how to connect to Exchange Online PowerShell by using multi-factor authentication (MFA)."
+ROBOTS: NOINDEX
+description: "Admins can learn how to use the older Exchange Online Remote PowerShell Module to connect to Security & Compliance Center PowerShell for multi-factor authentication (MFA) or federated authentication."
 ---
 
-# Connect to Exchange Online PowerShell using multi-factor authentication
+# V1 module - Connect to Exchange Online PowerShell using MFA
 
 > [!NOTE]
-> We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell using MFA. For instructions, see [Use the Exchange Online PowerShell V2 module](exchange-online-powershell-v2.md).
+> The older Exchange Online Remote PowerShell Module that's described in this topic will eventually be retired. The Exchange Online PowerShell V2 module (EXO V2 module) supports MFA, so we suggest using it instead. For instructions, see [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md).
 
-If you want to use multi-factor authentication (MFA) to connect to Exchange Online PowerShell, you can't use the instructions at [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md) to use remote PowerShell to connect to Exchange Online. MFA requires you to install the Exchange Online Remote PowerShell Module, and use the **Connect-EXOPSSession** cmdlet to connect.
+If you want to use multi-factor authentication (MFA) to connect to Exchange Online PowerShell, you can't use the instructions at [Basic auth - Connect to Exchange Online PowerShell](basic-auth-connect-to-exo-powershell.md) to use remote PowerShell to connect to Exchange Online. MFA requires you to install the Exchange Online Remote PowerShell Module, and use the **Connect-EXOPSSession** cmdlet to connect.
 
 ## What do you need to know before you begin?
 
@@ -27,22 +28,16 @@ If you want to use multi-factor authentication (MFA) to connect to Exchange Onli
 - You can use the following versions of Windows:
 
   - Windows 10
-
   - Windows 8.1
-
   - Windows Server 2019
-
   - Windows Server 2016
-
   - Windows Server 2012 or Windows Server 2012 R2
-
   - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
-
   - Windows Server 2008 R2 SP1<sup>*</sup>
 
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
-- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to send the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
 
@@ -85,7 +80,7 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 - Windows Remote Management (WinRM) on your computer needs to allow Basic authentication (it's enabled by default). To verify that Basic authentication is enabled, run this command **in a Command Prompt**:
 
-- When you use the Exchange Online Remote PowerShell Module, your session will end after one hour, which can be problematic for long-running scripts or processes. To avoid this issue, use [Trusted IPs](https://docs.microsoft.com/azure/active-directory/authentication/howto-mfa-mfasettings#trusted-ips) to bypass MFA for connections from your intranet. Trusted IPs allow you to connect to Exchange Online PowerShell from your intranet using the old instructions at [Connect to Exchange Online PowerShell](connect-to-exchange-online-powershell.md). Also, if you have servers in a datacenter, be sure to add their public IP addresses to Trusted IPs as described [here](https://docs.microsoft.com/azure/active-directory/authentication/howto-mfa-mfasettings#enable-the-trusted-ips-feature-by-using-service-settings).
+- When you use the Exchange Online Remote PowerShell Module, your session will end after one hour, which can be problematic for long-running scripts or processes. To avoid this issue, use [Trusted IPs](https://docs.microsoft.com/azure/active-directory/authentication/howto-mfa-mfasettings#trusted-ips) to bypass MFA for connections from your intranet. Trusted IPs allow you to connect to Exchange Online PowerShell from your intranet using the old instructions at [Basic auth - Connect to Exchange Online PowerShell](basic-auth-connect-to-exo-powershell.md). Also, if you have servers in a datacenter, be sure to add their public IP addresses to Trusted IPs as described [here](https://docs.microsoft.com/azure/active-directory/authentication/howto-mfa-mfasettings#enable-the-trusted-ips-feature-by-using-service-settings).
 
 > [!TIP]
 > Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542) or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
@@ -96,7 +91,7 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 2. The command that you need to run uses the following syntax:
 
-   ```PowerShell
+   ```powershell
    Connect-EXOPSSession [-UserPrincipalName -ConnectionUri <ConnectionUri> -AzureADAuthorizationEndPointUri <AzureADUri> -DelegatedOrganization <String>]
    ```
 
@@ -104,28 +99,31 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
    - The _\<ConnectionUri\>_ and _\<AzureADUri\>_ values depend on the nature of your Microsoft 365 organization as described in the following table:
 
-     |**Microsoft 365 offering**|**_ConnectionUri_ parameter value**|**_AzureADAuthorizationEndPointUri_ parameter value**|
-     |:-----|:-----|:-----|
+     ****
+
+     |Microsoft 365 offering|_ConnectionUri_ parameter value|_AzureADAuthorizationEndPointUri_ parameter value|
+     |---|---|---|
      |Microsoft 365|Not used|Not used|
      |Office 365 Germany|`https://outlook.office.de/PowerShell-LiveID`|`https://login.microsoftonline.de/common`|
      |Microsoft 365 GCC High|`https://outlook.office365.us/powershell-liveid`|`https://login.microsoftonline.us/common`|
      |Microsoft 365 DoD|`https://webmail.apps.mil/powershell-liveid`|`https://login.microsoftonline.us/common`|
+     |
 
    This example connects to Exchange Online in Microsoft 365 using the account chris@contoso.com.
 
-   ```PowerShell
+   ```powershell
    Connect-EXOPSSession -UserPrincipalName chris@contoso.com
    ```
 
    This example connects to Exchange Online Germany using the account lukas@fabrikam.com.
 
-   ```PowerShell
+   ```powershell
    Connect-EXOPSSession -UserPrincipalName lukas@fabrikam.com -ConnectionUri https://outlook.office.de/PowerShell-LiveID -AzureADAuthorizationEndPointUri https://login.microsoftonline.de/common
    ```
 
    This example connects to Exchange Online to manage another tenant.
 
-   ```PowerShell
+   ```powershell
    Connect-EXOPSSession -UserPrincipalName chris@contoso.com -DelegatedOrganization fabrikam.onmicrosoft.com
    ```
 
@@ -142,7 +140,7 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 > [!NOTE]
 > Be sure to disconnect the remote PowerShell session when you're finished. If you close the Exchange Online Remote PowerShell Module window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect all currently open PowerShell sessions in the current window, run the following command:
 
-```PowerShell
+```powershell
 Get-PSSession | Remove-PSSession
 ```
 

--- a/exchange/docs-conceptual/v1-module-mfa-connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/v1-module-mfa-connect-to-scc-powershell.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect to Security & Compliance Center PowerShell using multi-factor authentication"
+title: "V1 module - Connect to Security & Compliance Center PowerShell using MFA"
 ms.author: chrisda
 author: chrisda
 manager: dansimp
@@ -8,20 +8,24 @@ ms.audience: Admin
 ms.topic: article
 ms.service: o365-security-and-compliance
 localization_priority: Normal
-ms.assetid: 8e11c808-e734-4874-ac94-e5251ea85c19
+ms.assetid:
 search.appverid: MET150
-description: "Learn how to connect to Security & Compliance Center PowerShell by using multi-factor authentication (MFA) or federated authentication."
+ROBOTS: NOINDEX
+description: "Admins can learn how to use the older Exchange Online Remote PowerShell Module to connect to Security & Compliance Center PowerShell for multi-factor authentication (MFA) or federated authentication."
 ---
 
-# Connect to Security & Compliance Center PowerShell using multi-factor authentication
-
-If your account uses multi-factor authentication (MFA) or federated authentication, you can't use the instructions at [Connect to Security & Compliance Center PowerShell](connect-to-scc-powershell.md) to use remote PowerShell to connect to the Security & Compliance Center. Instead, you need to install the Exchange Online Remote PowerShell Module, and use the **Connect-IPPSSession** cmdlet to connect to Security & Compliance Center PowerShell.
+# V1 module - Connect to Security & Compliance Center PowerShell using MFA
 
 > [!NOTE]
-> 
-> - Delegated Access Permission (DAP) partners can't use the procedures in this topic to connect to their customer tenant organizations in Security & Compliance Center PowerShell. MFA and the Exchange Online Remote PowerShell Module don't work with delegated authentication.
-> 
-> - The Exchange Online Remote PowerShell Module is not supported in PowerShell Core (macOS, Linux, or Windows Nano Server). As a workaround, you can install the module on a computer that's running a supported version of Windows (physical or virtual), and use remote desktop software to connect.
+> The older Exchange Online Remote PowerShell Module that's described in this topic will eventually be retired. The Exchange Online PowerShell V2 module (EXO V2 module) supports MFA, so we suggest using it instead. For instructions, see [Connect to Security & Compliance Center PowerShell](connect-to-scc-powershell.md).
+
+If your account uses multi-factor authentication (MFA) or federated authentication, you can't use the instructions at [Basic auth - Connect to Security & Compliance Center PowerShell](basic-auth-connect-to-scc-powershell.md) to use remote PowerShell to connect to the Security & Compliance Center. Instead, you need to install the Exchange Online Remote PowerShell Module, and use the **Connect-IPPSSession** cmdlet to connect to Security & Compliance Center PowerShell.
+
+**Notes**:
+
+- Delegated Access Permission (DAP) partners can't use the procedures in this topic to connect to their customer tenant organizations in Security & Compliance Center PowerShell. MFA and the Exchange Online Remote PowerShell Module don't work with delegated authentication.
+
+- The Exchange Online Remote PowerShell Module is not supported in PowerShell Core (macOS, Linux, or Windows Nano Server). As a workaround, you can install the module on a computer that's running a supported version of Windows (physical or virtual), and use remote desktop software to connect.
 
 ## What do you need to know before you begin?
 
@@ -30,22 +34,16 @@ If your account uses multi-factor authentication (MFA) or federated authenticati
 - You can use the following versions of Windows:
 
   - Windows 10
-
   - Windows 8.1
-
   - Windows Server 2019
-
   - Windows Server 2016
-
   - Windows Server 2012 or Windows Server 2012 R2
-
   - Windows 7 Service Pack 1 (SP1)<sup>*</sup>
-
   - Windows Server 2008 R2 SP1<sup>*</sup>
 
-  <sup>\*</sup> This version of windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
+  <sup>\*</sup> This version of Windows has reached end of support, and is now only supported when running in Azure virtual machines. To use this version of Windows, you need to install the Microsoft .NET Framework 4.5 or later and then an updated version of the Windows Management Framework: 3.0, 4.0, or 5.1 (only one). For more information, see [Install the .NET Framework](https://docs.microsoft.com/dotnet/framework/install/on-windows-7), [Windows Management Framework 3.0](https://www.microsoft.com/download/details.aspx?id=34595), [Windows Management Framework 4.0](https://www.microsoft.com/download/details.aspx?id=40855), and [Windows Management Framework 5.1](https://aka.ms/wmf5download).
 
-- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to transport the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
+- WinRM needs to allow Basic authentication (it's enabled by default). We don't send the username and password combination, but the Basic authentication header is required to send the session's OAuth token, since the client-side WinRM implementation has no support for OAuth.
 
   **Note**: You must temporarily enable WinRM to run the following commands. You can enable it by running the command: `winrm quickconfig`.
 
@@ -95,7 +93,7 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 2. The command that you need to run uses the following syntax:
 
-   ```PowerShell
+   ```powershell
    Connect-IPPSSession -UserPrincipalName <UPN> [-ConnectionUri <ConnectionUri> -AzureADAuthorizationEndPointUri <AzureADUri>]
    ```
 
@@ -103,22 +101,25 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
    - The _\<ConnectionUri\>_ and _\<AzureADUri\>_ values depend on the location of your Microsoft 365 organization as described in the following table:
 
-   |**Microsoft 365 offering**|**_ConnectionUri_ parameter value**|**_AzureADAuthorizationEndPointUri_ parameter value**|
-   |---|---|---|
-   |Microsoft 365|Not used |Not used|
-   |Office 365 Germany|`https://ps.compliance.protection.outlook.de/PowerShell-LiveID`|`https://login.microsoftonline.de/common`|
-   |Microsoft 365 GCC High|`https://ps.compliance.protection.office365.us/powershell-liveid/`|`https://login.microsoftonline.us/common`|
-   |Microsoft 365 DoD|`https://l5.ps.compliance.protection.office365.us/powershell-liveid/`|`https://login.microsoftonline.us/common`|
+     ****
+
+     |Microsoft 365 offering|_ConnectionUri_ parameter value|_AzureADAuthorizationEndPointUri_ parameter value|
+     |---|---|---|
+     |Microsoft 365|Not used |Not used|
+     |Office 365 Germany|`https://ps.compliance.protection.outlook.de/PowerShell-LiveID`|`https://login.microsoftonline.de/common`|
+     |Microsoft 365 GCC High|`https://ps.compliance.protection.office365.us/powershell-liveid/`|`https://login.microsoftonline.us/common`|
+     |Microsoft 365 DoD|`https://l5.ps.compliance.protection.office365.us/powershell-liveid/`|`https://login.microsoftonline.us/common`|
+     |
 
    This example connects to Security & Compliance Center PowerShell in Microsoft 365 using the account chris@contoso.com.
 
-   ```PowerShell
+   ```powershell
    Connect-IPPSSession -UserPrincipalName chris@contoso.com
    ```
 
    This example connects to Security & Compliance Center PowerShell in Office 365 Germany using the account lukas@fabrikam.com.
 
-   ```PowerShell
+   ```powershell
    Connect-IPPSSession -UserPrincipalName lukas@fabrikam.com -ConnectionUri https://ps.compliance.protection.outlook.de/PowerShell-LiveID -AzureADAuthorizationEndPointUri https://login.microsoftonline.de/common
    ```
 
@@ -134,13 +135,13 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 5. **(Optional)**: If you want to connect to an Exchange Online PowerShell module session in the same window, you need to run
 
-   ```PowerShell
+   ```powershell
    $EXOSession=New-ExoPSSession -UserPrincipalName <UPN> [-ConnectionUri <ConnectionUri> -AzureADAuthorizationEndPointUri <AzureADUri>]
    ```
 
    and then import the Exchange Online session into the current one using an specific prefix
 
-   ```PowerShell
+   ```powershell
    Import-PSSession $EXOSession -Prefix EXO
    ```
 

--- a/exchange/exchange-ps/exchange/Add-RecipientPermission.md
+++ b/exchange/exchange-ps/exchange/Add-RecipientPermission.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Add-RecipientPermission cmdlet to add SendAs permission to users in a cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Add-UnifiedGroupLinks.md
+++ b/exchange/exchange-ps/exchange/Add-UnifiedGroupLinks.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Add-UnifiedGroupLinks cmdlet to add members, owners and subscribers to Microsoft 365 Groups in your cloud-based organization. To remove members, owners and subscribers, use the Remove-UnifiedGroupLinks cmdlet. To modify other properties of Microsoft 365 Groups, use the Set-UnifiedGroup cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Connect-ExchangeOnline.md
+++ b/exchange/exchange-ps/exchange/Connect-ExchangeOnline.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Connect-ExchangeOnline
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Connect-ExchangeOnline cmdlet in the Exchange Online PowerShell V2 module to connect to an Exchange Online organization.
 

--- a/exchange/exchange-ps/exchange/Connect-IPPSSession.md
+++ b/exchange/exchange-ps/exchange/Connect-IPPSSession.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Connect-IPPSSession
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Connect-IPPSSession cmdlet in the Exchange Online PowerShell V2 module to connect to Security & Compliance Center PowerShell or standalone Exchange Online Protection PowerShell.
 

--- a/exchange/exchange-ps/exchange/Delete-QuarantineMessage.md
+++ b/exchange/exchange-ps/exchange/Delete-QuarantineMessage.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Delete-QuarantineMessage cmdlet to delete quarantine messages from your cloud-based organization
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disable-AntiPhishRule.md
+++ b/exchange/exchange-ps/exchange/Disable-AntiPhishRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Disable-AntiPhishRule cmdlet to disable antiphish rules in your cloud-based organization..
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disable-HostedContentFilterRule.md
+++ b/exchange/exchange-ps/exchange/Disable-HostedContentFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Disable-HostedContentFilterRule cmdlet to disable spam filter rules (content filter rules) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disable-HostedOutboundSpamFilterRule.md
+++ b/exchange/exchange-ps/exchange/Disable-HostedOutboundSpamFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Disable-HostedOutboundSpamFilterRule cmdlet to disable outbound spam filter rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disable-JournalArchiving.md
+++ b/exchange/exchange-ps/exchange/Disable-JournalArchiving.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Disable-JournalArchiving cmdlet to disable journal archiving for specific users. Microsoft 365 journal archiving uses mailboxes in Exchange Online to record or journal messages for mailboxes in on-premises organizations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disable-SafeAttachmentRule.md
+++ b/exchange/exchange-ps/exchange/Disable-SafeAttachmentRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Disable-SafeAttachmentRule cmdlet to disable enabled Safe Attachments rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disable-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/Disable-SafeLinksRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Disable-SafeLinksRule cmdlet to disable enabled Safe Links rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Disconnect-ExchangeOnline.md
+++ b/exchange/exchange-ps/exchange/Disconnect-ExchangeOnline.md
@@ -15,7 +15,7 @@ monikerRange: "exchonline-ps"
 # Disconnect-ExchangeOnline
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Disconnect-ExchangeOnline cmdlet in the Exchange Online PowerShell V2 module to disconnect from an Exchange Online organization.
 

--- a/exchange/exchange-ps/exchange/Enable-AntiPhishRule.md
+++ b/exchange/exchange-ps/exchange/Enable-AntiPhishRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Enable-AntiPhishRule cmdlet to enable antiphish rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Enable-HostedContentFilterRule.md
+++ b/exchange/exchange-ps/exchange/Enable-HostedContentFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Enable-HostedContentFilterRule cmdlet to enable spam filter rules (content filter rules) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Enable-HostedOutboundSpamFilterRule.md
+++ b/exchange/exchange-ps/exchange/Enable-HostedOutboundSpamFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Enable-HostedOutboundSpamFilterRule cmdlet to enable outbound spam filter rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Enable-OrganizationCustomization.md
+++ b/exchange/exchange-ps/exchange/Enable-OrganizationCustomization.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 You may be prompted to run the EnableOrganizationCustomization cmdlet before you create or modify objects in your Exchange Online organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Enable-SafeAttachmentRule.md
+++ b/exchange/exchange-ps/exchange/Enable-SafeAttachmentRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Enable-SafeAttachmentRule cmdlet to enable disabled Safe Attachments rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Enable-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/Enable-SafeLinksRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Enable-SafeLinksRule cmdlet to enable disabled Safe Links rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Export-QuarantineMessage.md
+++ b/exchange/exchange-ps/exchange/Export-QuarantineMessage.md
@@ -19,7 +19,7 @@ Use the Export-QuarantineMessage cmdlet to export quarantined messages and files
 
 For files that are protected by Office 365 Advanced Threat Protection in SharePoint Online, OneDrive for Business and Microsoft Teams, the files are exported in Base64 format.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ATPTotalTrafficReport.md
+++ b/exchange/exchange-ps/exchange/Get-ATPTotalTrafficReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-ATPTotalTrafficReport to view details about message traffic in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AccessToCustomerDataRequest.md
+++ b/exchange/exchange-ps/exchange/Get-AccessToCustomerDataRequest.md
@@ -19,7 +19,7 @@ Use the Get-AccessToCustomerDataRequest cmdlet to view Microsoft 365 customer lo
 
 Note: Customer lockbox is included in the Microsoft 365 E5 plan. If you don't have a Microsoft 365 E5 plan, you can buy a separate customer lockbox subscription with any Microsoft 365 Enterprise plan.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AdministrativeUnit.md
+++ b/exchange/exchange-ps/exchange/Get-AdministrativeUnit.md
@@ -19,7 +19,7 @@ Use the Get-AdministrativeUnit cmdlet to view administrative units, which are Az
 
 Note: Administrative units are only available in Azure Active Directory Premium. You create and manage administrative units in Azure AD PowerShell.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AdvancedThreatProtectionDocumentDetail.md
+++ b/exchange/exchange-ps/exchange/Get-AdvancedThreatProtectionDocumentDetail.md
@@ -15,7 +15,7 @@ monikerRange: "exchonline-ps || eop-ps"
 ## SYNOPSIS
 This cmdlet is available only in the cloud-based service. Use the Get-AdvancedThreatProtectionDocumentDetailReport cmdlet to view the results of Office 365 Advanced Threat Protection (ATP) actions for files in SharePoint Online, OneDrive for Business and Microsoft Teams in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AdvancedThreatProtectionDocumentReport.md
+++ b/exchange/exchange-ps/exchange/Get-AdvancedThreatProtectionDocumentReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-AdvancedThreatProtectionDocumentReport cmdlet to view the results of Office 365 Advanced Threat Protection (ATP) actions for files in SharePoint Online, OneDrive for Business and Microsoft Teams in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AdvancedThreatProtectionTrafficReport.md
+++ b/exchange/exchange-ps/exchange/Get-AdvancedThreatProtectionTrafficReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-AdvancedThreatProtectionTrafficReport cmdlet to view the results of Safe Attachments and Safe Links actions in your cloud-based organization for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-AntiPhishPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-AntiPhishPolicy cmdlet to view antiphish policies in your cloud-based organization. This cmdlet returns results only in Exchange Online PowerShell.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AntiPhishRule.md
+++ b/exchange/exchange-ps/exchange/Get-AntiPhishRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-AntiPhishRule cmdlet to view antiphish rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ApplicationAccessPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-ApplicationAccessPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-ApplicationAccessPolicy cmdlet to view the list of application access policies.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-AtpPolicyForO365.md
+++ b/exchange/exchange-ps/exchange/Get-AtpPolicyForO365.md
@@ -23,7 +23,7 @@ Use the Get-AtpPolicyForO365 cmdlet to view the Advanced Threat Protection (ATP)
 
 - ATP to protect files in SharePoint Online, OneDrive for Business and Microsoft Teams.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/Get-CASMailbox.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-CASMailbox cmdlet to view the Client Access settings that are configured on mailboxes.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOCASMailbox cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOCASMailbox cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CASMailboxPlan.md
+++ b/exchange/exchange-ps/exchange/Get-CASMailboxPlan.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-CASMailboxPlan cmdlet to view Client Access services (CAS) mailbox plans in cloud-based organizations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CalendarDiagnosticObjects.md
+++ b/exchange/exchange-ps/exchange/Get-CalendarDiagnosticObjects.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-CalendarDiagnosticObjects cmdlet to collect a range of calendar logs. The calendar diagnostic logs track important calendar-related event data for each mailbox, and can be used to troubleshoot calendar issues that occur in mailboxes. The logs track all calendar items and meeting messages.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-Clutter.md
+++ b/exchange/exchange-ps/exchange/Get-Clutter.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-Clutter cmdlet to view Clutter settings for mailboxes in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ComplianceTag.md
+++ b/exchange/exchange-ps/exchange/Get-ComplianceTag.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Get-ComplianceTag cmdlet to view labels in the Security & Compliance Center. Labels apply retention settings to content.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ComplianceTagStorage.md
+++ b/exchange/exchange-ps/exchange/Get-ComplianceTagStorage.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Get-ComplianceTagStorage cmdlet to confirm that you've created the label policy by using the Enable-ComplianceTagStorage cmdlet. Labels apply retention settings to content.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CompromisedUserAggregateReport.md
+++ b/exchange/exchange-ps/exchange/Get-CompromisedUserAggregateReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-CompromisedUserAggregateReport cmdlet to return general data about compromised users for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CompromisedUserDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-CompromisedUserDetailReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-CompromisedUserDetailReport cmdlet to return detailed information about compromised users for the last 30 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ConnectionByClientTypeDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-ConnectionByClientTypeDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-ConnectionByClientTypeDetailReport cmdlet to view details about the different types of clients that connected to mailboxes in your organization. The client types indicate different protocols, for example, Outlook on the web, MAPI, POP3, IMAP4, Exchange ActiveSync, and Exchange Web Services.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ConnectionByClientTypeReport.md
+++ b/exchange/exchange-ps/exchange/Get-ConnectionByClientTypeReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-ConnectionByClientTypeReport cmdlet to view a summary of the different types of clients that connected to all mailboxes in your organization. The client types indicate different protocols, for example, Outlook on the web, MAPI, POP3, IMAP4, Exchange ActiveSync, and Exchange Web Services.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsAVConferenceTimeReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsAVConferenceTimeReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsAVConferenceTimeReport cmdlet to view statistics about the time in minutes that was used during audio and video conferences that were held by Skype for Business Online users in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsActiveUserReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsActiveUserReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsActiveUserReport cmdlet to view statistics about Skype for Business Online users in your cloud-based organization. The cmdlet shows the total number of unique users that signed in and took part in at least one peer-to-peer session or conference during the specified time period.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsClientDeviceDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsClientDeviceDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsClientDeviceDetailReport cmdlet to view statistics about the number of peer-to-peer sessions and conferences by users and devices that connected to Skype for Business Online in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsClientDeviceReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsClientDeviceReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsClientDeviceReport cmdlet to view statistics about the client devices that connected to Skype for Business Online in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsConferenceReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsConferenceReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsConferenceReport cmdlet to view statistics about the conferences that were held by Skype for Business Online users in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsP2PAVTimeReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsP2PAVTimeReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsP2PAVTimeReport cmdlet to view statistics about the audio and video time in minutes that was used during peer-to-peer (P2P) sessions that were held by Skype for Business Online users in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsP2PSessionReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsP2PSessionReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsP2PSessionReport cmdlet to view statistics about the peer-to-peer (P2P) sessions held by Skype for Business Online users in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsPSTNConferenceTimeReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsPSTNConferenceTimeReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsPSTNConferenceTimeReport cmdlet to show the number of minutes that Skype for Business Online users spent in dial-in or dial-out conferences.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsPSTNUsageDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsPSTNUsageDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsPSTNUsageDetailReport cmdlet to view public switched telephone network (PSTN) usage details for Skype for Business Online users.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsUserActivitiesReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsUserActivitiesReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsUserActivitiesReport cmdlet to view number and type of activities that a use participated in while connected to Skype for Business Online in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-CsUsersBlockedReport.md
+++ b/exchange/exchange-ps/exchange/Get-CsUsersBlockedReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-CsUsersBlockedReport cmdlet to view Skype for Business Online users who have been blocked due to fraudulent call activities.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DataClassificationConfig.md
+++ b/exchange/exchange-ps/exchange/Get-DataClassificationConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-DataClassificationConfig cmdlet to view the data classification configuration for your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DataEncryptionPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-DataEncryptionPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-DataEncryptionPolicy cmdlet to view data encryption policies in Exchange Online.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DataRetentionReport.md
+++ b/exchange/exchange-ps/exchange/Get-DataRetentionReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Get-DataRetentionReport cmdlet to view information about data retention in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DkimSigningConfig.md
+++ b/exchange/exchange-ps/exchange/Get-DkimSigningConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-DkimSigningConfig cmdlet to view the DomainKeys Identified Mail (DKIM) signing policy settings for domains in a cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DlpDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-DlpDetailReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-DlpDetailReport cmdlet to list details about Data Loss Prevention (DLP) rule matches for Exchange Online, SharePoint Online, and OneDrive for Business in your cloud-based organization for the last 30 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DlpDetectionsReport.md
+++ b/exchange/exchange-ps/exchange/Get-DlpDetectionsReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-DlpDetectionsReport cmdlet to list a summary of Data Loss Prevention (DLP) rule matches for Exchange Online, SharePoint Online and OneDrive for Business in your cloud-based organization for the last 30 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DlpSensitiveInformationTypeRulePackage.md
+++ b/exchange/exchange-ps/exchange/Get-DlpSensitiveInformationTypeRulePackage.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Get-DlpSensitiveInformationTypeConfig cmdlet to view data loss prevention (DLP) sensitive information type rule packages in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-DlpSiDetectionsReport.md
+++ b/exchange/exchange-ps/exchange/Get-DlpSiDetectionsReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Get-DlpSiDetectionsReport cmdlet to view information about data loss prevention (DLP) sensitive information type detections in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-EXOCasMailbox.md
+++ b/exchange/exchange-ps/exchange/Get-EXOCasMailbox.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOCasMailbox
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXOCasMailbox cmdlet to view the Client Access settings that are configured on mailboxes.
 

--- a/exchange/exchange-ps/exchange/Get-EXOMailbox.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMailbox.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOMailbox
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXOMailbox cmdlet to view mailbox objects and attributes, populate property pages, or supply mailbox information to other tasks.
 

--- a/exchange/exchange-ps/exchange/Get-EXOMailboxFolderPermission.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMailboxFolderPermission.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOMailboxFolderPermission
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-ExOMailboxFolderPermission cmdlet to view folder-level permissions in mailboxes.
 

--- a/exchange/exchange-ps/exchange/Get-EXOMailboxFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMailboxFolderStatistics.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOMailboxFolderStatistics
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXOMailboxFolderStatistics cmdlet to retrieve information about the folders in a specified mailbox, including the number and size of items in the folder, the folder name and ID, and other information.
 

--- a/exchange/exchange-ps/exchange/Get-EXOMailboxPermission.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMailboxPermission.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOMailboxPermission
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXOMailboxPermission cmdlet to retrieve permissions on a mailbox.
 

--- a/exchange/exchange-ps/exchange/Get-EXOMailboxStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMailboxStatistics.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOMailboxStatistics
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXOMailboxStatistics cmdlet to return information about a mailbox, such as the size of the mailbox, the number of messages it contains, and the last time it was accessed.
 

--- a/exchange/exchange-ps/exchange/Get-EXOMobileDeviceStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMobileDeviceStatistics.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXOMobileDeviceStatistics
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXOMobileDeviceStatistics cmdlet to retrieve the list of mobile devices configured to synchronize with a specified user's mailbox and return a list of statistics about the mobile devices.
 

--- a/exchange/exchange-ps/exchange/Get-EXORecipient.md
+++ b/exchange/exchange-ps/exchange/Get-EXORecipient.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXORecipient
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-ExORecipient cmdlet to view existing recipient objects in your organization. This cmdlet returns all mail-enabled objects (for example, mailboxes, mail users, mail contacts, and distribution groups).
 

--- a/exchange/exchange-ps/exchange/Get-EXORecipientPermission.md
+++ b/exchange/exchange-ps/exchange/Get-EXORecipientPermission.md
@@ -14,7 +14,7 @@ monikerRange: "exchonline-ps"
 # Get-EXORecipientPermission
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-EXORecipientPermission cmdlet to view information about SendAs permissions that are configured for users in a cloud-based organization.
 

--- a/exchange/exchange-ps/exchange/Get-EligibleDistributionGroupForMigration.md
+++ b/exchange/exchange-ps/exchange/Get-EligibleDistributionGroupForMigration.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-EligibleDistributionGroupForMigration cmdlet to identify distribution groups that can be upgraded to Microsoft 365 Groups. You can't upgrade mail-enabled security groups to Microsoft 365 Groups.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-FocusedInbox.md
+++ b/exchange/exchange-ps/exchange/Get-FocusedInbox.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-FocusedInbox cmdlet to view the Focused Inbox configuration for mailboxes in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-GroupActivityReport.md
+++ b/exchange/exchange-ps/exchange/Get-GroupActivityReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-GroupActivityReport cmdlet to view the number of distribution groups that were created and deleted in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HistoricalSearch.md
+++ b/exchange/exchange-ps/exchange/Get-HistoricalSearch.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HistoricalSearch cmdlet to view information about historical searches that have been performed within the last ten days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HostedConnectionFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-HostedConnectionFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HostedConnectionFilterPolicy cmdlet to view the settings of connection filter policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-HostedContentFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HostedContentFilterPolicy cmdlet to view the settings of spam filter policies (content filter policies) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HostedContentFilterRule.md
+++ b/exchange/exchange-ps/exchange/Get-HostedContentFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HostedContentFilterRule cmdlet to view spam filter rules (content filter rules) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HostedOutboundSpamFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-HostedOutboundSpamFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HostedOutboundSpamFilterPolicy cmdlet to view outbound spam filter policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HostedOutboundSpamFilterRule.md
+++ b/exchange/exchange-ps/exchange/Get-HostedOutboundSpamFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HostedOutboundSpamFilterRule cmdlet to view outbound spam filter rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HybridMailflow.md
+++ b/exchange/exchange-ps/exchange/Get-HybridMailflow.md
@@ -19,7 +19,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HybridMailflow cmdlet to view the message transport settings for a hybrid deployment.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-HybridMailflowDatacenterIPs.md
+++ b/exchange/exchange-ps/exchange/Get-HybridMailflowDatacenterIPs.md
@@ -19,7 +19,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-HybridMailflowDatacenterIPs cmdlet to retrieve the IP addresses of the Microsoft Exchange Online Protection (EOP) service data centers.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/Get-InboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-InboundConnector cmdlet to view the settings for an Inbound connector in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-LicenseVsUsageSummaryReport.md
+++ b/exchange/exchange-ps/exchange/Get-LicenseVsUsageSummaryReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-LicenseVsUsageSummaryReport cmdlet to retrieve a report that identifies the number of active users for installed software licenses (workloads).
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-LinkedUser.md
+++ b/exchange/exchange-ps/exchange/Get-LinkedUser.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-LinkedUser cmdlet to view existing linked user accounts.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailDetailATPReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailDetailATPReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailDetailATPReport cmdlet to list details about Exchange Online Protection and Advanced Threat protection (ATP) detections in your cloud-based organization for the last 10 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailDetailDlpPolicyReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailDetailDlpPolicyReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailDetailDlpPolicyReport cmdlet to view the details of messages that matched the conditions defined by any data loss prevention (DLP) policies. This cmdlet works on messages that were sent within the last seven days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailDetailMalwareReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailDetailMalwareReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailDetailMalwareReport cmdlet to view the details of messages that contained malware for the last 10 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailDetailSpamReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailDetailSpamReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailDetailSpamReport cmdlet to view the details of spam messages for the last 10 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailDetailTransportRuleReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailDetailTransportRuleReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailDetailTransportRuleReport cmdlet to view the details of messages that matched the conditions defined by any transport rules for the last 10 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailFilterListReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailFilterListReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailFilterListReport cmdlet to obtain values for various parameters that can be supplied to other reporting cmdlets.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailTrafficATPReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailTrafficATPReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailTrafficATPReport cmdlet to view the results of Exchange Online Protection and Advanced Threat Protection (ATP) detections in your cloud-based organization for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailTrafficPolicyReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailTrafficPolicyReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailTrafficPolicyReport cmdlet to view statistics about messages that were affected by data loss prevention (DLP) policies and transport rules for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailTrafficReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailTrafficReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailTrafficReport cmdlet to view details about message traffic in your organization for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailTrafficSummaryReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailTrafficSummaryReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailTrafficSummaryReport cmdlet to view summary information about message traffic in your organization for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailTrafficTopReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailTrafficTopReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailTrafficTopReport cmdlet to view a report of the highest volume senders, recipients, malware recipients and spam recipients in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Get-Mailbox.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-Mailbox cmdlet to view mailbox objects and attributes, populate property pages, or supply mailbox information to other tasks.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailbox cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailbox cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxActivityReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxActivityReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-MailboxActivityReport cmdlet to view the number of mailboxes created and deleted in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxFolderPermission.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxFolderPermission.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-MailboxFolderPermission cmdlet to view folder-level permissions in mailboxes.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxFolderPermission cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxFolderPermission cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-MailboxFolderStatistics cmdlet to retrieve information about the folders in a specified mailbox, including the number and size of items in the folder, the folder name and ID, and other information.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxFolderStatistics cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxFolderStatistics cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxLocation.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxLocation.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-MailboxLocation cmdlet to view mailbox location information in Exchange Online.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxPermission.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxPermission.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-MailboxPermission cmdlet to retrieve permissions on a mailbox.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxPermission cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxPermission cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxPlan.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxPlan.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailboxPlan cmdlet to view information about mailbox plans in the cloud-based service.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxStatistics.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-MailboxStatistics cmdlet to return information about a mailbox, such as the size of the mailbox, the number of messages it contains, and the last time it was accessed. In addition, you can get the move history or a move report of a completed move request.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxStatistics cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMailboxStatistics cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxUsageDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxUsageDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-MailboxUsageDetailReport cmdlet to view usage details about mailboxes in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailboxUsageReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxUsageReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-MailboxUsageReport cmdlet to view the number of mailboxes in your organization that are within 25% of the maximum mailbox size, and the number of mailboxes that are over the maximum size for your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MailflowStatusReport.md
+++ b/exchange/exchange-ps/exchange/Get-MailflowStatusReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MailflowStatusReport cmdlet to return the message counts for a specific date range organized by the final disposition of the message for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MessageTrace.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTrace.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MessageTrace cmdlet to trace messages as they pass through the cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MessageTraceDetail.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTraceDetail.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MessageTraceDetail cmdlet to view the message trace event details for a specific message. Note that these detailed results are returned less quickly than the Get-MessageTrace results.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MobileDeviceStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-MobileDeviceStatistics.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-MobileDeviceStatistics cmdlet to retrieve the list of mobile devices configured to synchronize with a specified user's mailbox and return a list of statistics about the mobile devices.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMobileDeviceStatistics cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXOMobileDeviceStatistics cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-MxRecordReport.md
+++ b/exchange/exchange-ps/exchange/Get-MxRecordReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-MxRecordReport cmdlet to view information about the mail exchanger (MX) records that are configured for a specified domain.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-O365ClientBrowserDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-O365ClientBrowserDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-O365ClientBrowserDetailReport cmdlet to get a detailed report of client browser use.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-O365ClientBrowserReport.md
+++ b/exchange/exchange-ps/exchange/Get-O365ClientBrowserReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-O365ClientBrowserReport cmdlet to get a summary report of client browser use.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-O365ClientOSDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-O365ClientOSDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-O365ClientOSDetailReport cmdlet to get a detailed report of client operating system use.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-O365ClientOSReport.md
+++ b/exchange/exchange-ps/exchange/Get-O365ClientOSReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-O365ClientOSReport cmdlet to get a summary report of client operating system use.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-OMEConfiguration.md
+++ b/exchange/exchange-ps/exchange/Get-OMEConfiguration.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-OMEConfiguration cmdlet to view Microsoft 365 Message Encryption (OME) configurations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-OMEMessageStatus.md
+++ b/exchange/exchange-ps/exchange/Get-OMEMessageStatus.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-OMEMessageStatus cmdlet to view the Microsoft 365 Message Encryption (OME) revocation status for a specific message.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-OnPremisesOrganization.md
+++ b/exchange/exchange-ps/exchange/Get-OnPremisesOrganization.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-OnPremisesOrganization cmdlet to retrieve settings for the OnPremisesOrganization object that has been created for a hybrid deployment.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-OnlineMeetingConfiguration.md
+++ b/exchange/exchange-ps/exchange/Get-OnlineMeetingConfiguration.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-OnlineMeetingConfiguration cmdlet to view status and usage information about Skype Meetings and Skype for Business Online for mailboxes. Skype Meetings automatically includes Skype for Business Online conference join information in Exchange Online meeting invitations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-OutboundConnector.md
+++ b/exchange/exchange-ps/exchange/Get-OutboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-OutboundConnector cmdlet to view the configuration information for an Outbound connector in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-OutboundConnectorReport.md
+++ b/exchange/exchange-ps/exchange/Get-OutboundConnectorReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-OutboundConnectorReport cmdlet to view the Outbound connectors that are used to deliver mail to specific domains.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-PerimeterConfig.md
+++ b/exchange/exchange-ps/exchange/Get-PerimeterConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-PerimeterConfig cmdlet to view the list of gateway server and internal mail server IP addresses that have been added to the cloud-based safelists.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-PhishFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-PhishFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-PhishFilterPolicy cmdlet to view the spoof intelligence policy and detected spoofed sending activities in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-Place.md
+++ b/exchange/exchange-ps/exchange/Get-Place.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-Place cmdlet to view the additional metadata that was configured on room mailboxes by using the Set-Place cmdlet. The additional metadata provides a better search and room suggestion experience.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-QuarantineMessage.md
+++ b/exchange/exchange-ps/exchange/Get-QuarantineMessage.md
@@ -19,7 +19,7 @@ Use the Get-QuarantineMessage cmdlet to view quarantined messages and files in y
 
 **Note**: Quarantined files are files protected by Office 365 Advanced Threat Protection in SharePoint Online, OneDrive for Business and Microsoft Teams.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-QuarantineMessageHeader.md
+++ b/exchange/exchange-ps/exchange/Get-QuarantineMessageHeader.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-QuarantineMessageHeader cmdlet to view the message header of a quarantined message. The command will fail if the specified message is not in quarantine.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-RMSTrustedPublishingDomain.md
+++ b/exchange/exchange-ps/exchange/Get-RMSTrustedPublishingDomain.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-RMSTrustedPublishingDomain cmdlet to view the settings of an existing trusted publishing domain (TPD) in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-Recipient.md
+++ b/exchange/exchange-ps/exchange/Get-Recipient.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-Recipient cmdlet to view existing recipient objects in your organization. This cmdlet returns all mail-enabled objects (for example, mailboxes, mail users, mail contacts, and distribution groups).
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXORecipient cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXORecipient cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 In cloud environments, to return Microsoft 365 Groups, you need to use the RecipientTypeDetails parameter with the value GroupMailbox.
 

--- a/exchange/exchange-ps/exchange/Get-RecipientPermission.md
+++ b/exchange/exchange-ps/exchange/Get-RecipientPermission.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-RecipientPermission cmdlet to view information about SendAs permissions that are configured for users in a cloud-based organization.
 
-**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXORecipientPermission cmdlet instead of this cmdlet. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: In Exchange Online PowerShell, we recommend that you use the Get-EXORecipientPermission cmdlet instead of this cmdlet. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-RecipientStatisticsReport.md
+++ b/exchange/exchange-ps/exchange/Get-RecipientStatisticsReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-RecipientStatisticsReport cmdlet to view the recipient statistics report.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ReportExecutionInstance.md
+++ b/exchange/exchange-ps/exchange/Get-ReportExecutionInstance.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-ReportExecutionInstance cmdlet to review the report execution instance in Exchange Online.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-RetentionEvent.md
+++ b/exchange/exchange-ps/exchange/Get-RetentionEvent.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Get-RetentionEvent cmdlet to view retention events in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SCInsights.md
+++ b/exchange/exchange-ps/exchange/Get-SCInsights.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SCInsights cmdlet to view Microsoft 365 insights information.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SPOActiveUserReport.md
+++ b/exchange/exchange-ps/exchange/Get-SPOActiveUserReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-SpoActiveUserReport cmdlet to view statistics about Microsoft SharePoint Online users in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SPOSkyDriveProDeployedReport.md
+++ b/exchange/exchange-ps/exchange/Get-SPOSkyDriveProDeployedReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-SPOSkyDriveProDeployedReport cmdlet to view the number of My Site sites in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SPOSkyDriveProStorageReport.md
+++ b/exchange/exchange-ps/exchange/Get-SPOSkyDriveProStorageReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-SPOSkyDriveProStorageReport cmdlet to view statistics about the space taken up (in MB) by My Sites in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SPOTeamSiteDeployedReport.md
+++ b/exchange/exchange-ps/exchange/Get-SPOTeamSiteDeployedReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-SPOTeamSiteDeployedReport cmdlet to view statistics about the number of team sites in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SPOTeamSiteStorageReport.md
+++ b/exchange/exchange-ps/exchange/Get-SPOTeamSiteStorageReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-SPOTeamSiteStorageReport cmdlet to view statistics about the space taken up (in MB) by team sites in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SPOTenantStorageMetricReport.md
+++ b/exchange/exchange-ps/exchange/Get-SPOTenantStorageMetricReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-SPOTenantStorageMetricReport cmdlet to view statistics about the space taken up (in MB) by all sites in for your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SafeAttachmentPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-SafeAttachmentPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SafeAttachmentPolicy cmdlet to view Safe Attachments policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SafeAttachmentRule.md
+++ b/exchange/exchange-ps/exchange/Get-SafeAttachmentRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SafeAttachmentRule cmdlet to view Safe Attachments rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SafeLinksAggregateReport.md
+++ b/exchange/exchange-ps/exchange/Get-SafeLinksAggregateReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SafeLinksAggregateReport cmdlet to return to return general data about Safe Links for the last 90 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SafeLinksDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-SafeLinksDetailReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SafeLinksAggregateReport cmdlet to return to return detailed information about Safe Links.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SafeLinksPolicy.md
+++ b/exchange/exchange-ps/exchange/Get-SafeLinksPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SafeLinksPolicy cmdlet to view Safe Links policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/Get-SafeLinksRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SafeLinksRule cmdlet to view Safe Links rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-ServiceDeliveryReport.md
+++ b/exchange/exchange-ps/exchange/Get-ServiceDeliveryReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-ServiceDeliveryReport cmdlet to view information about the message delivery path for a specified recipient.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SpoofMailReport.md
+++ b/exchange/exchange-ps/exchange/Get-SpoofMailReport.md
@@ -19,7 +19,7 @@ Use the Get-SpoofMailReport cmdlet to view information about insider spoofing in
 
 This cmdlet is only available in Microsoft 365 Enterprise E5, or with Advanced Threat Protection licenses.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-StaleMailboxDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-StaleMailboxDetailReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-StaleMailboxDetailReport cmdlet to view mailboxes that haven't been accessed for at least 30 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-StaleMailboxReport.md
+++ b/exchange/exchange-ps/exchange/Get-StaleMailboxReport.md
@@ -19,7 +19,7 @@ This cmdlet was deprecated in January, 2018. For information about the available
 
 Use the Get-StaleMailboxReport cmdlet to view the number of mailboxes that haven't been accessed for at least 30 days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SupervisoryReviewActivity.md
+++ b/exchange/exchange-ps/exchange/Get-SupervisoryReviewActivity.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-SupervisoryReviewActivity cmdlet to view all activities performed by a reviewer for a specific supervision policy. This information may be useful if reviewer activities are required in regulatory compliance audits or in litigation.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-SupervisoryReviewPolicyReport.md
+++ b/exchange/exchange-ps/exchange/Get-SupervisoryReviewPolicyReport.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Get-SupervisoryReviewPolicyReport cmdlet to view supervisory review policy events in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-TenantAllowBlockListItems.md
+++ b/exchange/exchange-ps/exchange/Get-TenantAllowBlockListItems.md
@@ -20,7 +20,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-TenantAllowBlockListItems cmdlet to view entries in the Tenant Allow/Block List in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-TenantAnalyticsConfig.md
+++ b/exchange/exchange-ps/exchange/Get-TenantAnalyticsConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 This cmdlet has been deprecated and no longer used.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Get-UnifiedGroup.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-UnifiedGroup cmdlet to view Microsoft 365 Groups in your cloud-based organization. To view members, owners and subscribers for Microsoft 365 Groups, use the Get-UnifiedGroupLinks cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-UnifiedGroupLinks.md
+++ b/exchange/exchange-ps/exchange/Get-UnifiedGroupLinks.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-UnifiedGroupLinks cmdlet to view membership and ownership information for Microsoft 365 Groups in your cloud-based organization. To view other properties for Microsoft 365 Groups, use the Get-UnifiedGroup cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-UrlTrace.md
+++ b/exchange/exchange-ps/exchange/Get-UrlTrace.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-UrlTrace cmdlet to view the results of Safe Links actions in your cloud-based organization. Currently, the date range can't be more than seven days.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-UserAnalyticsConfig.md
+++ b/exchange/exchange-ps/exchange/Get-UserAnalyticsConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Get-TenantAnalyticsConfig cmdlet to view the MyAnalytics privacy settings for cloud-based users.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Get-UserBriefingConfig.md
+++ b/exchange/exchange-ps/exchange/Get-UserBriefingConfig.md
@@ -13,7 +13,7 @@ monikerRange: "exchonline-ps"
 # Get-UserBriefingConfig
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Get-UserBriefingConfig cmdlet to get the current state of the Briefing email flag for the specified user. For more details about configuring the Briefing email, see [Configure Briefing email](https://docs.microsoft.com/Briefing/be-admin).
 

--- a/exchange/exchange-ps/exchange/Import-ContactList.md
+++ b/exchange/exchange-ps/exchange/Import-ContactList.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Import-ContactList cmdlet and a .csv file to import a user's mail contacts to a cloud-based mailbox. Users can use an email client to export their contacts to a .csv file that is formatted for Microsoft Office Outlook.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Import-RMSTrustedPublishingDomain.md
+++ b/exchange/exchange-ps/exchange/Import-RMSTrustedPublishingDomain.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Import-RMSTrustedPublishingDomain cmdlet to import a trusted publishing domain (TPD) from an on-premises server running Active Directory Rights Management Services (AD RMS) or from RMS Online into your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/New-AntiPhishPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-AntiPhishPolicy cmdlet to create antiphish policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-AntiPhishRule.md
+++ b/exchange/exchange-ps/exchange/New-AntiPhishRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-AntiPhishRule cmdlet to create antiphish rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-ApplicationAccessPolicy.md
+++ b/exchange/exchange-ps/exchange/New-ApplicationAccessPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-ApplicationAccessPolicy cmdlet to restrict or deny access for an application that is using Outlook REST APIs or Microsoft Graph APIs to a specific set of mailboxes. These policies are complimentary to the permission scopes that are declared by the application.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-AuthenticationPolicy.md
+++ b/exchange/exchange-ps/exchange/New-AuthenticationPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the New-AuthenticationPolicy cmdlet to create authentication policies in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-AvailabilityConfig.md
+++ b/exchange/exchange-ps/exchange/New-AvailabilityConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-AvailabilityConfig cmdlet to create an availability configuration. An availability configuration specifies an existing account that's used to exchange free/busy information between organizations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-DataEncryptionPolicy.md
+++ b/exchange/exchange-ps/exchange/New-DataEncryptionPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-DataEncryptionPolicy cmdlet to create data encryption policies in Exchange Online.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-DkimSigningConfig.md
+++ b/exchange/exchange-ps/exchange/New-DkimSigningConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-DkimSigningConfig cmdlet to create the DomainKeys Identified Mail (DKIM) signing policy settings for domains in a cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/New-HostedContentFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-HostedContentFilterPolicy cmdlet to create spam filter policies (content filter policies) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-HostedContentFilterRule.md
+++ b/exchange/exchange-ps/exchange/New-HostedContentFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-HostedContentFilterRule cmdlet to create spam filter rules (content filter rules) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-HostedOutboundSpamFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/New-HostedOutboundSpamFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-HostedOutboundSpamFilterPolicy cmdlet to create outbound spam filter policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-HostedOutboundSpamFilterRule.md
+++ b/exchange/exchange-ps/exchange/New-HostedOutboundSpamFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-HostedOutboundSpamFilterRule cmdlet to create outbound spam filter rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/New-InboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-InboundConnector cmdlet to create a new Inbound connector in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-OMEConfiguration.md
+++ b/exchange/exchange-ps/exchange/New-OMEConfiguration.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-OMEConfiguration cmdlet to create a Microsoft 365 Message Encryption (OME) configuration.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-OnPremisesOrganization.md
+++ b/exchange/exchange-ps/exchange/New-OnPremisesOrganization.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-OnPremisesOrganization cmdlet to create an OnPremisesOrganization object in a Microsoft 365 organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-OutboundConnector.md
+++ b/exchange/exchange-ps/exchange/New-OutboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-OutboundConnector cmdlet to create a new Outbound connector in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-SafeAttachmentPolicy.md
+++ b/exchange/exchange-ps/exchange/New-SafeAttachmentPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-SafeAttachmentPolicy cmdlet to create Safe Attachments policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-SafeAttachmentRule.md
+++ b/exchange/exchange-ps/exchange/New-SafeAttachmentRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-SafeAttachmentRule cmdlet to create Safe Attachments rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-SafeLinksPolicy.md
+++ b/exchange/exchange-ps/exchange/New-SafeLinksPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-SafeLinksPolicy cmdlet to create Safe Links policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/New-SafeLinksRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-SafeLinksRule cmdlet to create Safe Links rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-TenantAllowBlockListItems.md
+++ b/exchange/exchange-ps/exchange/New-TenantAllowBlockListItems.md
@@ -20,7 +20,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-TenantAllowBlockListItems cmdlet to add entries to the Tenant Allow/Block List in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/New-UnifiedGroup.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the New-UnifiedGroup cmdlet to create Microsoft 365 Groups in your cloud-based organization. To add members, owners, and subscribers to Microsoft 365 Groups, use the Add-UnifiedGroupLinks cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Preview-QuarantineMessage.md
+++ b/exchange/exchange-ps/exchange/Preview-QuarantineMessage.md
@@ -19,7 +19,7 @@ Use the Preview-QuarantineMessage cmdlet to preview the contents of quarantined 
 
 **Note**: This cmdlet isn't available for files that are protected by Office 365 Advanced Threat Protection in SharePoint Online, OneDrive for Business, and Microsoft Teams.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Release-QuarantineMessage.md
+++ b/exchange/exchange-ps/exchange/Release-QuarantineMessage.md
@@ -19,7 +19,7 @@ Use the Release-QuarantineMessage cmdlet to release messages from quarantine in 
 
 For files that are protected by Office 365 Advanced Threat Protection in SharePoint Online, OneDrive for Business and Microsoft Teams, you can unblock the files in the respective team sites and document libraries by using the Release-QuarantineMessage cmdlet so users can access, share, and download the files.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-AntiPhishPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-AntiPhishPolicy cmdlet to remove antiphish policies from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-AntiPhishRule.md
+++ b/exchange/exchange-ps/exchange/Remove-AntiPhishRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-AntiPhishRule cmdlet to remove antiphish rules from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-ApplicationAccessPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-ApplicationAccessPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-ApplicationAccessPolicy cmdlet to remove application access policies. These changes may take up to 30 minutes to go live.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-AuthenticationPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-AuthenticationPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Remove-AuthenticationPolicy cmdlet to remove authentication policies from your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-AvailabilityConfig.md
+++ b/exchange/exchange-ps/exchange/Remove-AvailabilityConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-AvailabilityConfig cmdlet to remove an availability configuration. An availability configuration specifies an existing account that's used to exchange free/busy information between organizations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-HostedContentFilterPolicy.md
@@ -19,7 +19,7 @@ Use the Remove-HostedContentFilterPolicy cmdlet to remove spam filter policies (
 
 When a policy is removed and there are rules associated with it, the rules are not removed when the policy is removed. This is by design. If you want to remove the associated rules, you need to do this separately via the Remove-HostedContentFilterRule cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-HostedContentFilterRule.md
+++ b/exchange/exchange-ps/exchange/Remove-HostedContentFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-HostedContentFilterRule cmdlet to remove spam filter rules (content filter rules) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-HostedOutboundSpamFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-HostedOutboundSpamFilterPolicy.md
@@ -19,7 +19,7 @@ Use the Remove-HostedOutboundSpamFilterPolicy cmdlet to remove outbound spam fil
 
 When a policy is removed and there are rules associated with it, the rules are not removed when the policy is removed. This is by design. If you want to remove the associated rules, you need to do this separately via the Remove-HostedOutboundSpamFilterRule cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-HostedOutboundSpamFilterRule.md
+++ b/exchange/exchange-ps/exchange/Remove-HostedOutboundSpamFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-HostedOutboundSpamFilterRule cmdlet to remove outbound spam filter rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/Remove-InboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-InboundConnector cmdlet to delete an Inbound connector from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-OMEConfiguration.md
+++ b/exchange/exchange-ps/exchange/Remove-OMEConfiguration.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-OMEConfiguration cmdlet to remove custom Microsoft 365 Message Encryption (OME) configurations. You can't use this cmdlet to remove the default OME configuration.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-OnPremisesOrganization.md
+++ b/exchange/exchange-ps/exchange/Remove-OnPremisesOrganization.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-OnPremisesOrganization cmdlet to remove an OnPremisesOrganization object in a Microsoft 365 tenant.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-OutboundConnector.md
+++ b/exchange/exchange-ps/exchange/Remove-OutboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-OutboundConnector cmdlet to delete an Outbound connector from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-RMSTrustedPublishingDomain.md
+++ b/exchange/exchange-ps/exchange/Remove-RMSTrustedPublishingDomain.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-RMSTrustedPublishingDomain cmdlet to remove an existing trusted publishing domain (TPD) from your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-RecipientPermission.md
+++ b/exchange/exchange-ps/exchange/Remove-RecipientPermission.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-RecipientPermission cmdlet to remove SendAs permission from users in a cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-SafeAttachmentPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-SafeAttachmentPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-SafeAttachmentPolicy cmdlet to remove Safe Attachments policies from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-SafeAttachmentRule.md
+++ b/exchange/exchange-ps/exchange/Remove-SafeAttachmentRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-SafeAttachmentRule cmdlet to remove Safe Attachments rules from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-SafeLinksPolicy.md
+++ b/exchange/exchange-ps/exchange/Remove-SafeLinksPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-SafeLinksPolicy cmdlet to remove Safe Links policies from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/Remove-SafeLinksRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-SafeLinksRule cmdlet to remove Safe Links rules from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-TenantAllowBlockListItems.md
+++ b/exchange/exchange-ps/exchange/Remove-TenantAllowBlockListItems.md
@@ -20,7 +20,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-TenantAllowBlockListItems cmdlet to remove entries from the Tenant Allow/Block List in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Remove-UnifiedGroup.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-UnifiedGroup cmdlet to remove Microsoft 365 Groups from your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Remove-UnifiedGroupLinks.md
+++ b/exchange/exchange-ps/exchange/Remove-UnifiedGroupLinks.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Remove-UnifiedGroupLinks cmdlet to remove members, owners and subscribers from Microsoft 365 Groups in your cloud-based organization. To add members, owners and subscribers, use the Add-UnifiedGroupLinks cmdlet. To modify other properties of Microsoft 365 Groups, use the Set-UnifiedGroup cmdlet.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Rotate-DkimSigningConfig.md
+++ b/exchange/exchange-ps/exchange/Rotate-DkimSigningConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Rotate-DkimSigningConfig cmdlet to rotate the public and private DomainKeys Identified Mail (DKIM) signing policy keys for domains in a cloud-based organization. This cmdlet creates new DKIM keys and uses the alternate DKIM selector. Typically, you don't need to use this cmdlet, because Microsoft 365 automatically rotates your DKIM keys.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
+++ b/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Search-UnifiedAuditLog cmdlet to search the unified audit log. This log contains events from Exchange Online, SharePoint Online, OneDrive for Business, Azure Active Directory, Microsoft Teams, Power BI, Sway, and other Microsoft 365 services. You can search for all events in a specified date range, or you can filter the results based on specific criteria, such as the user who performed the action, the action, or the target object.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-AccessToCustomerDataRequest.md
+++ b/exchange/exchange-ps/exchange/Set-AccessToCustomerDataRequest.md
@@ -19,7 +19,7 @@ Use the Set-AccessToCustomerDataRequest cmdlet to approve, deny, or cancel Micro
 
 Note: Customer lockbox is included in the Microsoft 365 E5 plan. If you don't have a Microsoft 365 E5 plan, you can buy a separate customer lockbox subscription with any Microsoft 365 Enterprise plan.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-AntiPhishPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-AntiPhishPolicy cmdlet to modify antiphish policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-AntiPhishRule.md
+++ b/exchange/exchange-ps/exchange/Set-AntiPhishRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-AntiPhishRule cmdlet to modify antiphish rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-ApplicationAccessPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-ApplicationAccessPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-ApplicationAccessPolicy cmdlet to modify the description of an application access policy.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-AtpPolicyForO365.md
+++ b/exchange/exchange-ps/exchange/Set-AtpPolicyForO365.md
@@ -23,7 +23,7 @@ Use the Set-AtpPolicyForO365 cmdlet to modify the Advanced Threat Protection (AT
 
 - ATP to protect files in SharePoint Online, OneDrive for Business and Microsoft Teams.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-AuthenticationPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-AuthenticationPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Set-AuthenticationPolicy cmdlet to modify authentication policies in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-Clutter.md
+++ b/exchange/exchange-ps/exchange/Set-Clutter.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-Clutter cmdlet to configure Clutter settings for mailboxes in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-DataEncryptionPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-DataEncryptionPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-DataEncryptionPolicy cmdlet to modify data encryption policies in Exchange Online.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-FocusedInbox.md
+++ b/exchange/exchange-ps/exchange/Set-FocusedInbox.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-FocusedInbox cmdlet to enable or disable Focused Inbox for mailboxes in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-HostedConnectionFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-HostedConnectionFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-HostedConnectionFilterPolicy cmdlet to modify the settings of connection filter policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-HostedContentFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-HostedContentFilterPolicy cmdlet to modify spam filter policies (content filter policies) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-HostedContentFilterRule.md
+++ b/exchange/exchange-ps/exchange/Set-HostedContentFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-HostedContentFilterRule cmdlet to modify spam filter rules (content filter rules) in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-HostedOutboundSpamFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-HostedOutboundSpamFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-HostedOutboundSpamFilterPolicy cmdlet to modify outbound spam filter policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-HostedOutboundSpamFilterRule.md
+++ b/exchange/exchange-ps/exchange/Set-HostedOutboundSpamFilterRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-HostedOutboundSpamFilterRule cmdlet to modify the settings of outbound spam filter rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-HybridMailflow.md
+++ b/exchange/exchange-ps/exchange/Set-HybridMailflow.md
@@ -19,7 +19,7 @@ Use the Set-HybridMailflow cmdlet to configure the message transport settings fo
 
 The Set-HybridMailflow cmdlet is only used to support hybrid deployments configured with the Hybrid Configuration wizard offered in Microsoft Exchange Server 2010 Service Pack 2 (SP2).
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/Set-InboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-InboundConnector cmdlet to change an existing Inbound connector in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-LinkedUser.md
+++ b/exchange/exchange-ps/exchange/Set-LinkedUser.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-LinkedUser cmdlet to modify the properties of an existing linked user account. The Outlook Live Directory Sync (OLSync) service account is a linked user.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-MailboxPlan.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxPlan.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-MailboxPlan cmdlet to modify the settings of mailbox plans in the cloud-based service.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-MigrationUser.md
+++ b/exchange/exchange-ps/exchange/Set-MigrationUser.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-MigrationUser cmdlet to modify the migration settings of a user in an existing migration batch.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-OMEConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-OMEConfiguration.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-OMEConfiguration cmdlet to configure Microsoft 365 Message Encryption (OME).
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-OMEMessageRevocation.md
+++ b/exchange/exchange-ps/exchange/Set-OMEMessageRevocation.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-OMEMessageRevocation cmdlet to revoke Microsoft 365 Message Encryption (OME) for a message. Revoking encryption prevents the recipient from viewing the message in the Office 365 Message Encryption portal.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-OnPremisesOrganization.md
+++ b/exchange/exchange-ps/exchange/Set-OnPremisesOrganization.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-OnPremisesOrganization cmdlet to modify the parameters of the OnPremisesOrganization object on the Microsoft 365 tenant.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-OutboundConnector.md
+++ b/exchange/exchange-ps/exchange/Set-OutboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-OutboundConnector cmdlet to modify an existing Outbound connector in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-PerimeterConfig.md
+++ b/exchange/exchange-ps/exchange/Set-PerimeterConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-PerimeterConfig cmdlet to modify the list of gateway server IP addresses that have been added to the cloud-based safelists.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-PhishFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-PhishFilterPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-PhishFilterPolicy cmdlet to configure the spoof intelligence policy in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-Place.md
+++ b/exchange/exchange-ps/exchange/Set-Place.md
@@ -19,7 +19,7 @@ Use the Set-Place cmdlet to update room mailboxes with additional metadata, whic
 
 **Note**: In hybrid environments, this cmdlet doesn't work on the following properties on synchronized room mailboxes: City, CountryOrRegion, GeoCoordinates, Phone, PostalCode, State, and Street. To modify these properties on synchronized room mailboxes, use the Set-User or Set-Mailbox cmdlets in on-premises Exchange.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-RMSTemplate.md
+++ b/exchange/exchange-ps/exchange/Set-RMSTemplate.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-RMSTemplate cmdlet to modify the properties of an existing Rights Management Services (RMS) template in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-RMSTrustedPublishingDomain.md
+++ b/exchange/exchange-ps/exchange/Set-RMSTrustedPublishingDomain.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-RMSTrustedPublishingDomain cmdlet to configure a trusted publishing domain (TPD) in your organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-SafeAttachmentPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-SafeAttachmentPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-SafeAttachmentPolicy cmdlet to modify Safe Attachments policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-SafeAttachmentRule.md
+++ b/exchange/exchange-ps/exchange/Set-SafeAttachmentRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-SafeAttachmentRule cmdlet to modify Safe Attachments rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-SafeLinksPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-SafeLinksPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-SafeLinksPolicy cmdlet to modify Safe Links policies in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/Set-SafeLinksRule.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-SafeLinksRule cmdlet to create Safe Links rules in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-TenantAllowBlockListItems.md
+++ b/exchange/exchange-ps/exchange/Set-TenantAllowBlockListItems.md
@@ -20,7 +20,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-TenantAllowBlockListItems cmdlet to modify entries in the Tenant Allow/Block List in the Security & Compliance Center.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-TenantAnalyticsConfig.md
+++ b/exchange/exchange-ps/exchange/Set-TenantAnalyticsConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 **This cmdlet has been deprecated and no longer used.**
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
@@ -19,7 +19,7 @@ Use the Set-UnifiedGroup cmdlet to modify Microsoft 365 Groups in your cloud-bas
 
 **IMPORTANT**: You can't use this cmdlet to remove all Microsoft Online Email Routing Address (MOERA) addresses from the group. There must be at least one MOERA address attached to a group at any given point of time. To learn more about MOERA addresses, see [How the proxyAddresses attribute is populated in Azure AD](https://support.microsoft.com/help/3190357).
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-UserAnalyticsConfig.md
+++ b/exchange/exchange-ps/exchange/Set-UserAnalyticsConfig.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-UserAnalyticsConfig cmdlet to modify the MyAnalytics privacy settings for cloud-based users.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Set-UserBriefingConfig.md
+++ b/exchange/exchange-ps/exchange/Set-UserBriefingConfig.md
@@ -13,7 +13,7 @@ monikerRange: "exchonline-ps"
 # Set-UserBriefingConfig
 
 ## SYNOPSIS
-This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 Use the Set-UserBriefingConfig cmdlet to enable or disable the Briefing for a user. For more details about configuring the Briefing, see [Configure Briefing email](https://docs.microsoft.com/Briefing/be-admin).
 

--- a/exchange/exchange-ps/exchange/Start-HistoricalSearch.md
+++ b/exchange/exchange-ps/exchange/Start-HistoricalSearch.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Start-HistoricalSearch cmdlet to start a new historical search.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Start-MigrationUser.md
+++ b/exchange/exchange-ps/exchange/Start-MigrationUser.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Start-MigrationUser cmdlet to start the migration of a user in an existing migration batch.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Stop-HistoricalSearch.md
+++ b/exchange/exchange-ps/exchange/Stop-HistoricalSearch.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Stop-HistoricalSearch cmdlet to stop an existing historical search that has a status value of NotStarted.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Stop-MigrationUser.md
+++ b/exchange/exchange-ps/exchange/Stop-MigrationUser.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Stop-MigrationUser cmdlet to stop the migration of a user in an existing migration batch.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Test-ApplicationAccessPolicy.md
+++ b/exchange/exchange-ps/exchange/Test-ApplicationAccessPolicy.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Test-ApplicationAccessPolicy cmdlet to test access right of an application to a specific user/mailbox.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Undo-SoftDeletedMailbox.md
+++ b/exchange/exchange-ps/exchange/Undo-SoftDeletedMailbox.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Undo-SoftDeletedMailbox cmdlet to recover a mailbox that has been deleted. Mailboxes can be recovered within 30 days of being deleted.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Undo-SoftDeletedUnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Undo-SoftDeletedUnifiedGroup.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Undo-SoftDeletedUnifiedGroup cmdlet to restore soft-deleted Microsoft 365 Groups in your cloud-based organization.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Upgrade-DistributionGroup.md
+++ b/exchange/exchange-ps/exchange/Upgrade-DistributionGroup.md
@@ -19,7 +19,7 @@ Use the Upgrade-DistributionGroup cmdlet to upgrade distribution groups to Micro
 
 Note: Before you use this cmdlet, verify there are no email address policies that you created with the IncludeUnifiedGroupRecipients parameter; otherwise the command will fail. Remove and recreate the email address policies after you upgrade your distribution groups to Microsoft 365 Groups.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Validate-OutboundConnector.md
+++ b/exchange/exchange-ps/exchange/Validate-OutboundConnector.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Validate-OutboundConnector cmdlet to test the settings of Outbound connectors in Microsoft 365.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/Validate-RetentionRuleQuery.md
+++ b/exchange/exchange-ps/exchange/Validate-RetentionRuleQuery.md
@@ -17,7 +17,7 @@ This cmdlet is available only in Security & Compliance Center PowerShell. For mo
 
 Use the Validate-RetentionRuleQuery cmdlet to validate the Keyword Query Language (KQL) content search filters for retention rules.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/set-CASMailboxPlan.md
+++ b/exchange/exchange-ps/exchange/set-CASMailboxPlan.md
@@ -17,7 +17,7 @@ This cmdlet is available only in the cloud-based service.
 
 Use the Set-CASMailboxPlan cmdlet to modify Client Access services (CAS) mailbox plans in cloud-based organizations.
 
-**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Use the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
+**Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Conect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 


### PR DESCRIPTION
Apparently, must now use full links rather than relative links when referencing cmdlet ref topics in the conceptual area.