### PR TITLE
Added OutlookGifPickerDisabled parameter to Set-OrganizationConfig.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-OrganizationConfig.md
+++ b/exchange/exchange-ps/exchange/Set-OrganizationConfig.md
@@ -83,6 +83,7 @@ Set-OrganizationConfig
  [-MobileAppEducationEnabled <Boolean>]
  [-OAuth2ClientProfileEnabled <Boolean>]
  [-OnlineMeetingsByDefaultEnabled <Boolean>]
+ [-OutlookGifPickerDisabled <Boolean>]
  [-OutlookMobileGCCRestrictionsEnabled <Boolean>]
  [-OutlookMobileHelpShiftEnabled <Boolean>]
  [-OutlookMobileSingleAccountEnabled <Boolean>]
@@ -2047,6 +2048,15 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -OutlookGifPickerDisabled
+This parameter is available only in the cloud-based service.
+
+The OutlookGifPickerDisabled parameter disables the GIF Search (powered by Bing) feature built into the Outlook on the web Compose page.
+
+- $true: GIF Search in Outlook on the web is enabled.
+
+- $False: GIF Search in Outlook on the web is disabled. This is the default value.
 
 ### -OutlookMobileGCCRestrictionsEnabled
 This parameter is available only in the cloud-based service.

--- a/exchange/exchange-ps/exchange/Set-OrganizationConfig.md
+++ b/exchange/exchange-ps/exchange/Set-OrganizationConfig.md
@@ -2052,11 +2052,26 @@ Accept wildcard characters: False
 ### -OutlookGifPickerDisabled
 This parameter is available only in the cloud-based service.
 
-The OutlookGifPickerDisabled parameter disables the GIF Search (powered by Bing) feature built into the Outlook on the web Compose page.
+This feature is currently in Preview, is not availalble everywhere, and is subject to change.
 
-- $true: GIF Search in Outlook on the web is enabled.
+The OutlookGifPickerDisabled parameter disables the GIF Search (powered by Bing) feature that's built into the Compose page in Outlook on the web. Valid values are:
 
-- $False: GIF Search in Outlook on the web is disabled. This is the default value.
+- $true: GIF Search in Outlook on the web is disabled.
+
+- $false: GIF Search in Outlook on the web is enabled. This is the default value.
+
+```yaml
+Type: Boolean
+Parameter Sets: Default
+Aliases:
+Applicable: Exchange Online
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -OutlookMobileGCCRestrictionsEnabled
 This parameter is available only in the cloud-based service.


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/office-docs-powershell/issues/6386.

@chrisda could you confirm this information? Maybe this parameter is not fully available yet because I cannot see the current value with Get-:
![image](https://user-images.githubusercontent.com/33589238/91592634-3631e700-e935-11ea-83f0-05be74873e5b.png)
