### PR TITLE
Adding Teams admin center names for policies

### DIFF
--- a/teams/teams-ps/teams/New-CsGroupPolicyAssignment.md
+++ b/teams/teams-ps/teams/New-CsGroupPolicyAssignment.md
@@ -32,7 +32,7 @@ Group policy assignment allows you to easily manage policies across different su
 Group policy assignments are only propagated to users that are direct members of the group; the assignments are not propagated to members of nested groups.
 
 Group policy assignment is currently limited to the following policy types:
-CallingLineIdentity, OnlineVoiceRoutingPolicy, TeamsAppSetupPolicy, TeamsCallingPolicy, TeamsCallParkPolicy, TeamsChannelsPolicy, TeamsComplianceRecordingPolicy, TenantDialPlan, TeamsEducationAssignmentsAppPolicy, TeamsMeetingBroadcastPolicy, TeamsMeetingPolicy, TeamsMessagingPolicy, TeamsUpdateManagementPolicy.
+CallingLineIdentity (Caller ID policies), OnlineVoiceRoutingPolicy (Voice Routing policies), TeamsAppSetupPolicy (App Setup policies), TeamsCallingPolicy (Calling policies), TeamsCallParkPolicy (Call park policies), TeamsChannelsPolicy, TeamsComplianceRecordingPolicy, TenantDialPlan, TeamsEducationAssignmentsAppPolicy, TeamsMeetingBroadcastPolicy (Live Events policies), TeamsMeetingPolicy (Meeting policies), TeamsMessagingPolicy (Messaging policies), TeamsUpdateManagementPolicy.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/office-docs-powershell/issues/6255

Adding in parenthesis, the more descriptive name given to the policies that are available in the Teams admin center.

Left out the ones that still do not have an option in Teams admin center.