### PR TITLE
Replace legacy build pipeline with PowerShell SDP build pipeline for SharePointMigrationTool docs

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -184,17 +184,15 @@
         "Conceptual": "Content",
         "ManagedReference": "Content",
         "RestApi": "Content",
-        "AzurePsModulePage": "Content"
+        "PowershellModule": "Content",
+        "PowershellCmdlet": "Content"
       },
       "build_entry_point": "docs",
       "template_folder": "_themes",
       "version": 0,
-      "customized_template_paths": [
-        "_dependentPackages/azurecli.plugins/azurecli"
-      ],
       "customized_tasks": {
         "docset_prebuild": [
-          "_dependentPackages/CommonPlugins/tools/PowerShellReference.ps1"
+          "_dependentPackages/MAML2Yaml/tools/Run.ps1"
         ]
       },
       "monikerPath": [

--- a/spmt/docfx.json
+++ b/spmt/docfx.json
@@ -21,7 +21,8 @@
         "dest": "spmt/spmt-ps"
       },
       {
-      "files": ["**/*.md"],
+      "files": ["**/*.yml"],
+      "exclude": ["toc.yml"],
       "src": "spmt-ps",
       "version": "spmt-ps",
       "dest": "module"


### PR DESCRIPTION
#6329 