### PR TITLE
Fix incorrect IncludeHasTeam parameter name in example

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPUnifiedGroup.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPUnifiedGroup.md
@@ -59,7 +59,7 @@ Retrieves a specific Office 365 Group based on its object instance
 
 ### ------------------EXAMPLE 6------------------
 ```powershell
-Get-PnPUnifiedGroup -IncludeIfHasTeam
+Get-PnPUnifiedGroup -IncludeHasTeam
 ```
 
 Retrieves all the Office 365 Groups and checks for each of them if it has a Microsoft Team provisioned for it


### PR DESCRIPTION
The parameter name was incorrectly shown as IncludeIfHasTeam in the example, fixed to prevent misunderstanding.