### PR TITLE
Not all parameter values available in all builds

### DIFF
--- a/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
@@ -240,7 +240,7 @@ The FolderScope parameter specifies the scope of the search by folder type. Vali
 
 - Tasks
 
-The ManagedCustomFolder value returns output for all managed custom folders. The RecoverableItems value returns output for the Recoverable Items folder and the Deletions, DiscoveryHolds, Purges, and Versions subfolders.
+The ManagedCustomFolder value returns output for all managed custom folders. The RecoverableItems value returns output for the Recoverable Items folder and the Deletions, DiscoveryHolds, Purges, and Versions subfolders. Folderscope parameter values LegacyArchiveJournals and NonIpmRoot are only applicable for Exchange 2013 and in addition to this Archives is added in Exchange Server 2016 and later.
 
 ```yaml
 Type: Microsoft.Exchange.Data.Directory.SystemConfiguration.ElcFolderType

--- a/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
@@ -199,48 +199,26 @@ Accept wildcard characters: False
 The FolderScope parameter specifies the scope of the search by folder type. Valid parameter values include:
 
 - All
-
-- Archive
-
+- Archive: Exchange 2016 or later.
 - Calendar
-
 - Contacts
-
 - ConversationHistory
-
 - DeletedItems
-
 - Drafts
-
 - Inbox
-
 - JunkEmail
-
 - Journal
-
-- LegacyArchiveJournals
-
-- ManagedCustomFolder
-
-- NonIpmRoot
-
+- LegacyArchiveJournals: Exchange 2013 only.
+- ManagedCustomFolder: Returns output for all managed custom folders.
+- NonIpmRoot: Exchange 2013 only.
 - Notes
-
 - Outbox
-
 - Personal
-
-- RecoverableItems
-
+- RecoverableItems: Returns output for the Recoverable Items folder and the Deletions, DiscoveryHolds, Purges, and Versions subfolders.
 - RssSubscriptions
-
 - SentItems
-
 - SyncIssues
-
 - Tasks
-
-The ManagedCustomFolder value returns output for all managed custom folders. The RecoverableItems value returns output for the Recoverable Items folder and the Deletions, DiscoveryHolds, Purges, and Versions subfolders. Folderscope parameter values LegacyArchiveJournals and NonIpmRoot are only applicable for Exchange 2013 and in addition to this Archives is added in Exchange Server 2016 and later.
 
 ```yaml
 Type: Microsoft.Exchange.Data.Directory.SystemConfiguration.ElcFolderType

--- a/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-MailboxFolderStatistics.md
@@ -208,9 +208,9 @@ The FolderScope parameter specifies the scope of the search by folder type. Vali
 - Inbox
 - JunkEmail
 - Journal
-- LegacyArchiveJournals: Exchange 2013 only.
+- LegacyArchiveJournals: Exchange 2013 or later.
 - ManagedCustomFolder: Returns output for all managed custom folders.
-- NonIpmRoot: Exchange 2013 only.
+- NonIpmRoot: Exchange 2013 or later.
 - Notes
 - Outbox
 - Personal


### PR DESCRIPTION
The ManagedCustomFolder value returns output for all managed custom folders. The RecoverableItems value returns output for the Recoverable Items folder and the Deletions, DiscoveryHolds, Purges, and Versions subfolders. Folderscope parameter values LegacyArchiveJournals and NonIpmRoot are only applicable for Exchange 2013 and in addition to this Archives is added in Exchange Server 2016 and later.