### PR TITLE
Added Cmdlet reference for Portal Launch Scheduler Commands

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOPortalLaunchWaves.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOPortalLaunchWaves.md
@@ -1,0 +1,93 @@
+---
+external help file: sharepointonline.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:https://docs.microsoft.com/powershell/module/sharepoint-online/get-spoportallaunchwaves
+schema: 2.0.0
+applicable: SharePoint Online
+title: Get-SPOPortalLaunchWaves
+author: fikrudeju
+ms.author: fishibru
+manager: suyog
+---
+
+# Get-SPOPortalLaunchWaves
+
+## SYNOPSIS
+Get the current state of a portal launch on a site.
+
+## SYNTAX
+
+```
+Get-SPOPortalLaunchWaves [-LaunchSiteUrl <String>] [-DisplayFormat <WaveDisplayFormats>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-SPOPortalLaunchWaves cmdlet can be used to determine if a portal launch is scheduled for a site, and if so, its current rollout status. 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-SPOPortalLaunchWaves -LaunchSiteUrl "https://contoso.sharepoint.com/teams/newsite" 
+```
+
+This example checks if a portal launch is scheduled for the site https://contoso.sharepoint.com/teams/newsite. If it is scheduled, then it will return the details of the configuration.
+
+### Example 2
+```powershell
+Get-SPOPortalLaunchWaves
+```
+
+This example checks if a portal launch is scheduled on any site in the tenant (i.e. if . If so, it will return details of each launch configuration. 
+
+## PARAMETERS
+
+### -DisplayFormat
+Specifies whether the waves in the launch setup are displayed in an indented or raw format 
+
+```yaml
+Type: WaveDisplayFormats
+Parameter Sets: (All)
+Aliases:
+Accepted values: Raw, Formatted
+
+Required: False
+Position: Named
+Default value: Formatted
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LaunchSiteUrl
+Specifies the absolute URL for the site being checked for its launch state.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+[New-SPOPortalLaunchWaves](New-SPOPortalLaunchWaves.md)
+
+[Set-SPOPortalLaunchWaves](Set-SPOPortalLaunchWaves.md)
+
+[Remove-SPOPortalLaunchWaves](Remove-SPOPortalLaunchWaves.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/New-SPOPortalLaunchWaves.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/New-SPOPortalLaunchWaves.md
@@ -1,0 +1,249 @@
+---
+external help file: sharepointonline.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:https://docs.microsoft.com/powershell/module/sharepoint-online/new-spoportallaunchwaves
+schema: 2.0.0
+applicable: SharePoint Online
+title: New-SPOPortalLaunchWaves
+author: fikrudeju
+ms.author: fishibru
+manager: suyog
+---
+
+# New-SPOPortalLaunchWaves
+
+## SYNOPSIS
+Schedule a portal launch on a site.
+
+## SYNTAX
+
+```
+New-SPOPortalLaunchWaves -LaunchSiteUrl <String> -RedirectionType <PortalLaunchRedirectionType>
+ -ExpectedNumberOfUsers <PortalLaunchUsersSizeType> [-RedirectUrl <String>] [-FriendlyUrlOfNewSite <String>]
+ [-FriendlyUrlOfOldSite <String>] [-WaveSetupJsonFilepath <String>] [-Waves <String>]
+ -WaveOverrideUsers <String> [-IsTesting <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The New-SPOPortalLaunchWaves cmdlet can be used to schedule a portal launch on a site.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+New-SPOPortalLaunchWaves -LaunchSiteUrl "https://contoso.sharepoint.com/teams/newsite" -RedirectionType Bidirectional -RedirectUrl "https://contoso.sharepoint.com/teams/oldsite" -ExpectedNumberOfUsers 10kTo30kUsers -WaveOverrideUsers "*@microsoft.com" -Waves '
+[{Name:"Wave 1", Groups:["Viewers SG1"], LaunchDateUtc:"2020/10/14"},
+{Name:"Wave 2", Groups:["Viewers SG2"], LaunchDateUtc:"2020/10/15"},
+{Name:"Wave 3", Groups:["Viewers SG3"], LaunchDateUtc:"2020/10/16"}]'
+```
+
+In this scenario, the customer migrates users from an existing SharePoint site (https://contoso.sharepoint.com/teams/oldsite) to a new SharePoint site (https://contoso.sharepoint.com/teams/newsite) in a staged manner.
+
+### Example 2
+```powershell
+New-SPOPortalLaunchWaves -LaunchSiteUrl "https://contoso.sharepoint.com/teams/newsite" -RedirectionType ToTemporaryPage -RedirectUrl "https://www.microsoft.com" -ExpectedNumberOfUsers 10kTo30kUsers -WaveOverrideUsers "*@microsoft.com" -Waves '
+[{Name:"Wave 1", Groups:["Viewers SG1"], LaunchDateUtc:"2020/10/14"},
+{Name:"Wave 2", Groups:["Viewers SG2"], LaunchDateUtc:"2020/10/15"},
+{Name:"Wave 3", Groups:["Viewers SG3"], LaunchDateUtc:"2020/10/16"}]' 
+```
+
+In this scenario, the customer does not have an existing SharePoint site and is directing users to a new SharePoint site (https://contoso.sharepoint.com/teams/newsite) in a staged manner. If a user is in a wave that has not been launched, they will be redirected to a temporary page (any URL).
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpectedNumberOfUsers
+Specifies the expected number of users that the site will be launched to.
+
+```yaml
+Type: PortalLaunchUsersSizeType
+Parameter Sets: (All)
+Aliases:
+Accepted values: LessThan10kUsers, From10kTo30kUsers, From30kTo100KUsers, MoreThan100kUsers
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FriendlyUrlOfNewSite
+Specified a friendly short URL (if any) you already configured to access the launch site
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FriendlyUrlOfOldSite
+Specified a friendly short URL (if any) you already configured to access the old site 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LaunchSiteUrl
+Specifies the absolute URL for the site being checked for its launch state.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedirectUrl
+Specifies the absolute URL for the site that users will be redirected to if their wave is not launched.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedirectionType
+Specifies the redirection type, i.e. Bidirectional or ToTemporaryPage.
+
+```yaml
+Type: PortalLaunchRedirectionType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Bidirectional, ToTemporaryPage
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaveOverrideUsers
+Specifies any users that will be excluded from the wave, i.e. they will have access to the site at any time during the launch assuming they have the correct site permissions.
+Format: user@domain.com, with multiple entries separated by commas 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaveSetupJsonFilepath
+Specifies a file path that contains collection of waves in a JSON format.
+File Content Format: 
+[{Name:"Wave 1", Groups:["<group1>","<group2>",...], LaunchDateUtc:"<YYYY/MM/DD HH:MM>"},
+{Name:"Wave 2", Groups:["<group13>","<group14>",...], LaunchDateUtc:"<YYYY/MM/DD HH:MM>"}]
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Waves
+Specifies which security groups are included in each wave and the launch date in UTC. The number of waves required is dependent on the value indicated for the -ExpectedNumberOfUsers parameter.
+LessThan10kUsers - 1 wave
+10kTo30kUsers - 3 waves
+30kTo100kUsers - 5 waves
+MoreThan100kUsers - 5 waves
+Format: {Name:"Wave 1", Groups:["<group1>","<group2>",...], LaunchDateUtc:"<YYYY/MM/DD HH:MM>"} 
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[Get-SPOPortalLaunchWaves](Get-SPOPortalLaunchWaves.md)
+
+[Set-SPOPortalLaunchWaves](Set-SPOPortalLaunchWaves.md)
+
+[Remove-SPOPortalLaunchWaves](Remove-SPOPortalLaunchWaves.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOPortalLaunchWaves.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOPortalLaunchWaves.md
@@ -1,0 +1,102 @@
+---
+external help file: sharepointonline.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:https://docs.microsoft.com/powershell/module/sharepoint-online/remove-spoportallaunchwaves
+schema: 2.0.0
+applicable: SharePoint Online
+title: Remove-SPOPortalLaunchWaves
+author: fikrudeju
+ms.author: fishibru
+manager: suyog
+---
+
+# Remove-SPOPortalLaunchWaves
+
+## SYNOPSIS
+Delete a portal launch scheduled or in progress for a site.
+
+## SYNTAX
+
+```
+Remove-SPOPortalLaunchWaves -LaunchSiteUrl <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Remove-SPOPortalLaunchWaves cmdlet can be used to delete a portal launch scheduled or in progress for a site.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Remove-SPOPortalLaunchWaves -LaunchSiteUrl "https://contoso.sharepoint.com/teams/newsite"
+```
+
+This example removes a scheduled or in progress launch from https://contoso.sharepoint.com/teams/newsite.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LaunchSiteUrl
+Specifies the absolute URL for the site that you want to delete a scheduled or in progress portal launch.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[Get-SPOPortalLaunchWaves](Get-SPOPortalLaunchWaves.md)
+
+[New-SPOPortalLaunchWaves](New-SPOPortalLaunchWaves.md)
+
+[Set-SPOPortalLaunchWaves](Set-SPOPortalLaunchWaves.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOPortalLaunchWaves.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOPortalLaunchWaves.md
@@ -1,0 +1,126 @@
+---
+external help file: sharepointonline.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:https://docs.microsoft.com/powershell/module/sharepoint-online/set-spoportallaunchwaves
+schema: 2.0.0
+applicable: SharePoint Online
+title: Set-SPOPortalLaunchWaves
+author: fikrudeju
+ms.author: fishibru
+manager: suyog
+---
+
+# Set-SPOPortalLaunchWaves
+
+## SYNOPSIS
+Pause or restart a portal launch in progress.
+
+## SYNTAX
+
+```
+Set-SPOPortalLaunchWaves -LaunchSiteUrl <String> -Status <StatusAction> [-WalkBack <Boolean>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-SPOPortalLaunchWaves allows you to pause or restart the portal launch in progress.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Set-SPOPortalLaunchWaves -Status Pause - LaunchSiteUrl "https://contoso.sharepoint.com/teams/NewSite"
+```
+
+This example pauses a launch on https://contoso.sharepoint.com/teams/newsite, preventing upcoming wave progressions.
+
+### Example 2
+```powershell
+Set-SPOPortalLaunchWaves -Status Restart - LaunchSiteUrl "https://contoso.sharepoint.com/teams/NewSite"
+```
+
+This example restarts a previously-paused launch on https://contoso.sharepoint.com/teams/newsite.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LaunchSiteUrl
+Specifies the absolute URL for the site that you're changing its portal launch status.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Specifies whether you want to start or restart the portal launch in progress.
+
+```yaml
+Type: StatusAction
+Parameter Sets: (All)
+Aliases:
+Accepted values: Pause, Restart
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[Get-SPOPortalLaunchWaves](Get-SPOPortalLaunchWaves.md)
+
+[New-SPOPortalLaunchWaves](New-SPOPortalLaunchWaves.md)
+
+[Remove-SPOPortalLaunchWaves](Remove-SPOPortalLaunchWaves.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/sharepoint-online.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/sharepoint-online.md
@@ -139,6 +139,10 @@ The following cmdlet references are for SharePoint Online.
 
 {{Manually Enter Get-SPOOrgAssetsLibrary Description Here}}
 
+### [Get-SPOPortalLaunchWaves](Get-SPOPortalLaunchWaves.md)
+
+{{Manually Enter Get-SPOPortalLaunchWaves Description Here}}
+
 ### [Get-SPOPublicCdnOrigins](Get-SPOPublicCdnOrigins.md)
 
 {{Manually Enter Get-SPOPublicCdnOrigins Description Here}}
@@ -291,6 +295,11 @@ The following cmdlet references are for SharePoint Online.
 
 {{Manually Enter New-SPOnlineApplicationPrincipalManagementServiceApplicationProxy Description Here}}
 
+
+### [New-SPOPortalLaunchWaves](New-SPOPortalLaunchWaves.md)
+
+{{Manually Enter New-SPOPortalLaunchWaves Description Here}}
+
 ### [New-SPOPublicCdnOrigin](New-SPOPublicCdnOrigin.md)
 
 {{Manually Enter New-SPOPublicCdnOrigin Description Here}}
@@ -338,6 +347,10 @@ The following cmdlet references are for SharePoint Online.
 ### [Remove-SPOOrgAssetsLibrary](Remove-SPOOrgAssetsLibrary.md)
 
 {{Manually Enter Remove-SPOOrgAssetsLibrary Description Here}}
+
+### [Remove-SPOPortalLaunchWaves](Remove-SPOPortalLaunchWaves.md)
+
+{{Manually Enter Remove-SPOPortalLaunchWaves Description Here}}
 
 ### [Remove-SPOPublicCdnOrigin](Remove-SPOPublicCdnOrigin.md)
 
@@ -442,6 +455,10 @@ The following cmdlet references are for SharePoint Online.
 ### [Set-SPOOrgAssetsLibrary](Set-SPOOrgAssetsLibrary.md)
 
 {{Manually Enter Set-SPOOrgAssetsLibrary Description Here}}
+
+### [Set-SPOPortalLaunchWaves](Set-SPOPortalLaunchWaves.md)
+
+{{Manually Enter Set-SPOPortalLaunchWaves Description Here}}
 
 ### [Set-SPOSite](Set-SPOSite.md)
 


### PR DESCRIPTION
The addition is for the following Cmdlets which are used to schedule a portal launch waves
Get-SPOPortalLaunchWaves
New-SPOPortalLaunchWaves
Remove-SPOPortalLaunchWaves
Set-SPOPortalLaunchWaves

Also update the TOC under SharePoint-Online