### PR TITLE
Update app-only-auth-powershell-v2.md

### DIFF
--- a/exchange/docs-conceptual/app-only-auth-powershell-v2.md
+++ b/exchange/docs-conceptual/app-only-auth-powershell-v2.md
@@ -149,7 +149,7 @@ Create a self-signed x.509 certificate using one of the following methods:
 
 ```powershell
 # Create certificate
-$mycert = New-SelfSignedCertificate -DnsName "example.com" -CertStoreLocation "cert:\LocalMachine\My" -NotAfter (Get-Date).AddYears(1)
+$mycert = New-SelfSignedCertificate -DnsName "example.com" -CertStoreLocation "cert:\LocalMachine\My" -NotAfter (Get-Date).AddYears(1) -KeySpec KeyExchange
 
 # Export certificate to .pfx file
 $mycert | Export-PfxCertificate -FilePath mycert.pfx -Password $(ConvertTo-SecureString -String "1234" -Force -AsPlainText)


### PR DESCRIPTION
Add '-KeySpec KeyExchange' parameter to New-SelfSignedCertificate Cmdlet.

The current syntax of New-SelfSignedCertificate Cmdlet will generate CNG certificate which is not supported. As an one of workarounds to prevent this behavior, we need to add the KeySpec parameter.