### PR TITLE
Adding global metadata to sharepoint-pnp

### DIFF
--- a/sharepoint/docfx.json
+++ b/sharepoint/docfx.json
@@ -68,6 +68,9 @@
       "ms.service":{
         "sharepoint-ps/sharepoint-online/*.yml":"sharepoint-powershell"
       },
+      "ms.service":{
+        "sharepoint-ps/sharepoint-pnp/*.yml":"sharepoint-powershell"
+      },
       "ms.prod":{
         "sharepoint-ps/sharepoint-server/*.yml":"sharepoint-2016-powershell"
       }

--- a/sharepoint/docfx.json
+++ b/sharepoint/docfx.json
@@ -66,9 +66,7 @@
     },
     "fileMetadata": {
       "ms.service":{
-        "sharepoint-ps/sharepoint-online/*.yml":"sharepoint-powershell"
-      },
-      "ms.service":{
+        "sharepoint-ps/sharepoint-online/*.yml":"sharepoint-powershell",
         "sharepoint-ps/sharepoint-pnp/*.yml":"sharepoint-powershell"
       },
       "ms.prod":{


### PR DESCRIPTION
Added sharepoint-powershell as the ms.service value for the sharepoint-pnp PowerShell. The lack of this metadata is causing build errors.