### PR TITLE
Update Set-SettingOverride.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-SettingOverride.md
+++ b/exchange/exchange-ps/exchange/Set-SettingOverride.md
@@ -45,7 +45,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Set-SettingOverride -Identity "Change OAB Generation" -Server Mailbox01 -Component TimeBasedAssistants -Section OABGeneratorAssistant -Parameters @("WorkCycle=03:00:00")
+Set-SettingOverride -Identity "Change OAB Generation" -Server Mailbox01 -Parameters @("WorkCycle=03:00:00")
 ```
 
 This example modifies the setting override named Change OAB Generation on the server named Mailbox01 by changing the OAB generation interval to 3 hours.


### PR DESCRIPTION
Update Example as parameters "-Component" and "-Section" are not accepted by the Set-SettingOverride cmdlet and cause the example syntax to fail
Remove "-Component TimeBasedAssistants -Section OABGeneratorAssistant " from the Example