### PR TITLE
Update New-AutoSensitivityLabelRule.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-AutoSensitivityLabelRule.md
+++ b/exchange/exchange-ps/exchange/New-AutoSensitivityLabelRule.md
@@ -183,7 +183,7 @@ Accept wildcard characters: False
 ### -ContentContainsSensitiveInformation
 The ContentContainsSensitiveInformation parameter specifies a condition for the rule that's based on a sensitive information type match in content. The rule is applied to content that contains the specified sensitive information type.
 
-This parameter uses the basic syntax @(@{Name="\<SensitiveInformationType1\>";[minCount="\<Value\>"],@{Name="\<SensitiveInformationType2\>";[minCount="\<Value\>"],...). For example, @(@{Name="U.S. Social Security Number (SSN)"; minCount="2"},@{Name="Credit Card Number"}).
+This parameter uses the basic syntax @(@{Name="\<SensitiveInformationType1\>";[minCount="\<Value\>"],@{Name="\<SensitiveInformationType2\>";[minCount="\<Value\>"],...). For example, @(@{Name="U.S. Social Security Number (SSN)"; minCount="2"},@{Name="Credit Card Number"; minCount="1"; minConfidence="85"}).
 
 ```yaml
 Type: PswsHashtable[]


### PR DESCRIPTION
Appended the additional property "minConfidence" to the example for the -ContentContainsSensitiveInformation parameter. Without specifying this the default value is "-1" when the command is executed.