### PR TITLE
Update Initialize-PnPPowerShellAuthentication.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Initialize-PnPPowerShellAuthentication.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Initialize-PnPPowerShellAuthentication.md
@@ -98,18 +98,6 @@ Position: 8
 Accept pipeline input: False
 ```
 
-### -CertificatePath
-Password for the certificate being created
-
-```yaml
-Type: String
-Parameter Sets: Existing Certificate
-
-Required: True
-Position: Named
-Accept pipeline input: False
-```
-
 ### -CommonName
 Common Name (e.g. server FQDN or YOUR name). defaults to 'pnp.contoso.com'
 


### PR DESCRIPTION
Deleted -CertfificatePath from the documentation as this is not in the current PnP commandlet for Initialize-PnPPowerShellAuthentication and looks to be displayin the wrong data i.e. Password for the certificate being created.

I also think you should use -OutPath instead.