### PR TITLE
Update Get-SPOSite.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -57,7 +57,11 @@ You need to be a SharePoint Online administrator or Global Administrator and be 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at [Intro to SharePoint Online Management Shell](https://docs.microsoft.com/powershell/sharepoint/sharepoint-online/introduction-sharepoint-online-management-shell?view=sharepoint-ps).
 
 > [!NOTE]
-> If Site Collection Storage Management is enabled for the tenant, you will not be able to set quota and will have a generic error returned. To workaround this issue, set the site collection storage management to "manual" temporarily, set your quotas and then set the site collection storage management setting back to its original setting.  
+> If Site Collection Storage Management is enabled for the tenant, you will not be able to set quota and will have a generic error returned. To workaround this issue, set the site collection storage management to "manual" temporarily, set your quotas and then set the site collection storage management setting back to its original setting.
+
+> [!NOTE]
+> If the Limit parameter is provided then the following site collection properties will not be populated and may contain a default value:
+> AllowDownloadingNonWebViewableFiles, AllowEditing, AllowSelfServiceUpgrade, AnonymousLinkExpirationInDays, ConditionalAccessPolicy, DefaultLinkPermission, DefaultLinkToExistingAccess, DefaultSharingLinkType, DenyAddAndCustomizePages, DisableCompanyWideSharingLinks, ExternalUserExpirationInDays, LimitedAccessFileType, OverrideTenantAnonymousLinkExpirationPolicy, OverrideTenantExternalUserExpirationPolicy, PWAEnabled, SandboxedCodeActivationCapability, SensitivityLabel, SharingAllowedDomainList, SharingBlockedDomainList, SharingCapability, SharingDomainRestrictionMode.
 
 ## EXAMPLES
 
@@ -234,7 +238,7 @@ Accept wildcard characters: False
 
 ### -Limit
 
-Specifies the maximum number of site collections to return. It can be any number. To retrieve all site collections, use ALL. The default value is 200.
+Specifies the maximum number of site collections to return. It can be any number. To retrieve all site collections, use ALL. The default value is 200. If this parameter is provided, then some site collection properties will not be populated and may contain a default value.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Covered the scenario that if the -Limit parameter is provided, then some site collection properties are not populated and may contain default values.