### PR TITLE
Delete note

### DIFF
--- a/exchange/exchange-ps/exchange/Get-UserBriefingConfig.md
+++ b/exchange/exchange-ps/exchange/Get-UserBriefingConfig.md
@@ -14,8 +14,6 @@ ms.author: chrisda
 ## SYNOPSIS
 This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [About the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
 
-**Note**: This cmdlet is being replaced by the [Get-MyAnalyticsFeatureConfig](https://docs.microsoft.com/powershell/module/exchange/get-myanalyticsfeatureconfig) cmdlet.
-
 Use the Get-UserBriefingConfig cmdlet to get the current state of the Briefing email flag for the specified user. For more details about configuring the Briefing email, see [Configure Briefing email](https://docs.microsoft.com/Briefing/be-admin).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).


### PR DESCRIPTION
Per PM vikgup@microsoft.com, we need to delete the Note near the top of the page that states "This cmdlet is being replaced by the Get-MyAnalyticsFeatureConfig cmdlet." We'll need the same change in the Set-UserBriefingConfig topic (https://docs.microsoft.com/en-us/powershell/module/exchange/set-userbriefingconfig?view=exchange-ps).