### PR TITLE
Delete note

### DIFF
--- a/exchange/exchange-ps/exchange/Set-UserBriefingConfig.md
+++ b/exchange/exchange-ps/exchange/Set-UserBriefingConfig.md
@@ -14,8 +14,6 @@ ms.author: chrisda
 ## SYNOPSIS
 This cmdlet is available only in the Exchange Online PowerShell V2 module. For more information, see [About the Exchange Online PowerShell V2 module](https://docs.microsoft.com/powershell/exchange/exchange-online-powershell-v2).
 
-**Note**: This cmdlet is being replaced by the [Set-MyAnalyticsFeatureConfig](https://docs.microsoft.com/powershell/module/exchange/set-myanalyticsfeatureconfig) cmdlet.
-
 Use the Set-UserBriefingConfig cmdlet to enable or disable the Briefing for a user. For more details about configuring the Briefing, see [Configure Briefing email](https://docs.microsoft.com/Briefing/be-admin).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).


### PR DESCRIPTION
Per PM vikgup@microsoft.com, we need to delete the Note near the top of the page that states "This cmdlet is being replaced by the Set-MyAnalyticsFeatureConfig cmdlet." I've made the same change in the Get-UserBriefingConfig topic (https://docs.microsoft.com/powershell/module/exchange/get-userbriefingconfig?view=exchange-ps).