### PR TITLE
Update New-CsGroupPolicyAssignment.md

### DIFF
--- a/teams/teams-ps/teams/New-CsGroupPolicyAssignment.md
+++ b/teams/teams-ps/teams/New-CsGroupPolicyAssignment.md
@@ -32,7 +32,7 @@ Group policy assignment allows you to easily manage policies across different su
 Group policy assignments are only propagated to users that are direct members of the group; the assignments are not propagated to members of nested groups.
 
 Group policy assignment is currently limited to the following policy types:
-CallingLineIdentity (Caller ID policies), OnlineVoiceRoutingPolicy (Voice Routing policies), TeamsAppSetupPolicy (App Setup policies), TeamsCallingPolicy (Calling policies), TeamsCallParkPolicy (Call park policies), TeamsChannelsPolicy, TeamsComplianceRecordingPolicy, TenantDialPlan, TeamsEducationAssignmentsAppPolicy, TeamsMeetingBroadcastPolicy (Live Events policies), TeamsMeetingPolicy (Meeting policies), TeamsMessagingPolicy (Messaging policies), TeamsShiftsPolicy, TeamsUpdateManagementPolicy.
+CallingLineIdentity (Caller ID policies), TeamsAppSetupPolicy (App Setup policies), TeamsCallingPolicy (Calling policies), TeamsCallParkPolicy (Call park policies), TeamsChannelsPolicy, TeamsComplianceRecordingPolicy, TenantDialPlan, TeamsEducationAssignmentsAppPolicy, TeamsMeetingBroadcastPolicy (Live Events policies), TeamsMeetingPolicy (Meeting policies), TeamsMessagingPolicy (Messaging policies), TeamsShiftsPolicy, TeamsUpdateManagementPolicy.
 
 ## EXAMPLES
 
@@ -106,7 +106,6 @@ Accept wildcard characters: False
 The type of the policy to be assigned.
 Possible values:
 - CallingLineIdentity
-- OnlineVoiceRoutingPolicy
 - TeamsAppSetupPolicy
 - TeamsCallingPolicy
 - TeamsCallParkPolicy


### PR DESCRIPTION
OnlineVoiceRoutingPolicy is not currently supported via group policy, even though it appears to be. The service that consumes it is not group policy-aware.
Until that service is modified to support group policy assignment, the only workaround is to assign policies individually.
Whenever Teams service supports such assignment type, the article could be updated to include such PolicyType.
