### PR TITLE
Improving description

### DIFF
--- a/teams/teams-ps/teams/Get-Team.md
+++ b/teams/teams-ps/teams/Get-Team.md
@@ -215,7 +215,7 @@ Accept wildcard characters: False
 ```
 
 ### -NumberOfThreads
-Specifies the number of threads to use. The accepted values range from 1 to 20.
+Specifies the number of threads to use. If you have sufficient network bandwidth and want to decrease the time required to retrieve the list of teams, use the -NumberOfThreads parameter, which supports a value from 1 through 20.
 
 ```yaml
 Type: Int32

--- a/teams/teams-ps/teams/Get-Team.md
+++ b/teams/teams-ps/teams/Get-Team.md
@@ -224,7 +224,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 20
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
The verbiage was taken from https://docs.microsoft.com/en-us/azure/information-protection/log-analyze-usage

@dariomws What do you think?
I could test that definitely the default is not "1" and that specifying 20 seems to consume more Kb/s

Closes https://github.com/MicrosoftDocs/office-docs-powershell/issues/7487