### PR TITLE
Update Get-SafeLinksDetailReport.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-SafeLinksDetailReport.md
+++ b/exchange/exchange-ps/exchange/Get-SafeLinksDetailReport.md
@@ -98,6 +98,7 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+These values for the Action parameter is case sensitive
 
 ### -AppNameList
 The AppNameList parameter filters the results by the app where the link was found. Valid values are:


### PR DESCRIPTION
Tried troubleshooting with a customer and figured he used a small letter B. Customer is Irate because he believes there should be a disclaimer as this is not the case for most exchange Online cmdlet