### PR TITLE
Update Set-TransportConfig.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-TransportConfig.md
+++ b/exchange/exchange-ps/exchange/Set-TransportConfig.md
@@ -496,7 +496,7 @@ Accept wildcard characters: False
 ```
 
 ### -HeaderPromotionModeSetting
-The HeaderPromotionModeSetting parameter specifies whether named properties are created for custom X-headers on messages received from outside the Exchange organization. Valid values are:
+The HeaderPromotionModeSetting parameter specifies whether named properties are created for custom X-headers on messages received. Valid values are:
 
 - MustCreate: Exchange creates a named property for each new custom X-header.
 - MayCreate: Exchange creates a named property for each new custom X-header on messages received from authenticated senders. No named properties are created for custom X-headers on messages received from unauthenticated senders.


### PR DESCRIPTION
The HeaderPromotionModeSetting Property DefinitionText is missleading as it says:
... on messages received from outside of the organization
But this is not true. 
The HeaderPromotionModeSetting will also affect messages received from internal and not just from outside the organization

See the options:
MustCreate (covers all internal + external)
MayCreate (covers internal only [authenticated])
NoCreate (neither internal nor external)