### PR TITLE
Update New-Label.md - Contenttype

### DIFF
--- a/exchange/exchange-ps/exchange/New-Label.md
+++ b/exchange/exchange-ps/exchange/New-Label.md
@@ -601,11 +601,13 @@ Accept wildcard characters: False
 ```
 
 ### -ContentType
-The ContentType parameter specifies where the sensivity label can be applied to. Possible values are:
+The ContentType parameter specifies where the sensivity label can be applied. Valid values are:
+
 - File, Email
 - Site, UnifiedGroup
 - PurviewAssets
-Values can be combined, for example "File, Email, PurviewAssets". Splitting related content types like "File, Email" is not supported.
+
+Values can be combined, for example: "File, Email, PurviewAssets". Splitting related content types like "File, Email" into just "File" or just "Email" is not supported.
 
 ```yaml
 Type: MipLabelContentType

--- a/exchange/exchange-ps/exchange/New-Label.md
+++ b/exchange/exchange-ps/exchange/New-Label.md
@@ -601,7 +601,11 @@ Accept wildcard characters: False
 ```
 
 ### -ContentType
-{{ Fill ContentType Description }}
+The ContentType parameter specifies where the sensivity label can be applied to. Possible values are:
+- File, Email
+- Site, UnifiedGroup
+- PurviewAssets
+Values can be combined, for example "File, Email, PurviewAssets". Splitting related content types like "File, Email" is not supported.
 
 ```yaml
 Type: MipLabelContentType


### PR DESCRIPTION
We expect MipLabelContentType as input type, but this content type is not defined. Instead, administrators can add valid content types as string to configure labels. I've added the possible values to the description.