### PR TITLE
Set-CsTeamsCallingPolicy - update for CAPTCHA IVR spam detection

### DIFF
--- a/skype/skype-ps/skype/Set-CsTeamsCallingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsCallingPolicy.md
@@ -405,10 +405,11 @@ Accept wildcard characters: False
 ```
 
 ### -SpamFilteringEnabledType
-Determines if Spam filtering is enabled.
+Determines if Spam filtering is enabled and if CAPTCHA IVR is also used.
 
 Possible values:
 - Enabled
+- EnabledWithoutIVR
 - Disabled
 
 ```yaml


### PR DESCRIPTION
The CAPTCHA IVR spam detection feature can be enabled/disabled by tenant admin in CsTeamsCallingPolicy Cmdlet. 
The existing param SpamFilteringEnabledType is extended with **EnabledWithoutIVR**.