### PR TITLE
Update Set-WebServicesVirtualDirectory.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-WebServicesVirtualDirectory.md
+++ b/exchange/exchange-ps/exchange/Set-WebServicesVirtualDirectory.md
@@ -302,11 +302,11 @@ Accept wildcard characters: False
 ```
 
 ### -InternalNLBBypassUrl
+**Note:** This parameter applies only to Exchange 2010. By default, Exchange 2013 or later already has the InternalNLBBypassUrl value configured on the backend Exchange Web Services (EWS) virtual directory on Mailbox servers.
+
 The InternalNLBBypassUrl parameter specifies the URL of the Exchange server that has the Client Access server role installed, regardless of whether it's behind a Network Load Balancing (NLB) array or not.
 
 When you set the InternalUrl parameter to the URL of the NLB array, you should set the InternalNLBBypassUrl parameter to the URL of the Client Access server itself.
-
-**Note:** This should be used in Exchange 2010 only. Exchange 2013 and later has by default InternalNLBBypassUrl configured on the Mailbox Server role EWS (Exchange Back End) virtual directory.
 
 ```yaml
 Type: Uri

--- a/exchange/exchange-ps/exchange/Set-WebServicesVirtualDirectory.md
+++ b/exchange/exchange-ps/exchange/Set-WebServicesVirtualDirectory.md
@@ -306,6 +306,8 @@ The InternalNLBBypassUrl parameter specifies the URL of the Exchange server that
 
 When you set the InternalUrl parameter to the URL of the NLB array, you should set the InternalNLBBypassUrl parameter to the URL of the Client Access server itself.
 
+**Note:** This should be used in Exchange 2010 only. Exchange 2013 and later has by default InternalNLBBypassUrl configured on the Mailbox Server role EWS (Exchange Back End) virtual directory.
+
 ```yaml
 Type: Uri
 Parameter Sets: (All)


### PR DESCRIPTION
In Exchange Server 2013 and later we do not need to configure InternalNLBBypassUrl on the EWS (Default Web Site) virtual directory. This is by default set in EWS (Exchange Back End) virtual directory which is already configured to Server's FQDN and it should not be changed at all.

Applying InternalNLBBypassURL on EWS (Default Web Site) breaks eDiscovery functionality. While user is  part of compliance management and he logs into ECP and access Compliance Management node, user will get the following error:
The request has failed. The remote server returned an error: (400) Bad Request.

ServiceCache:PopulateServiceCache is called during ServiceDiscovery, this update ClientAccessType as InternalNLBBypass and the request proxied to the URL configured in InternalNLBBypassUrl instead of EWS (Exchange Back End) virtual directory.

When the get-mailboxsearch passes and user finds all searches, if he attempts to create a new search, it will fail and while viewing the failure report, user will see following:
An unknown error occurred on the search server. Please contact your administrator for assistance. The message from the server has failed. The remote server returned an error: (400) Bad Request.

So adding a note make sense or Applicable section should only include Exchange Server 2010.