### PR TITLE
Adding docs for Shifts Connector

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionConnector.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionConnector.md
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionConnector [<CommonParameters>]
 
 ## DESCRIPTION
 
-This cmdlet shows the available list of Shifts Connectors that can be used to synchronize a 3rd party workforce management system with Teams and the types of data that can be synchronized.
+This cmdlet shows the available list of Shifts Connectors that can be used to synchronize a third-party workforce management system with Teams and the types of data that can be synchronized.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionConnector.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionConnector.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet supports retrieving the available Shifts Connectors.
 
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionConnector [<CommonParameters>]
 
 ## DESCRIPTION
 
-This cmdlet shows the available list of Shifts Connectors that can be used to synchronize a 3rd party workforce management system with Teams.
+This cmdlet shows the available list of Shifts Connectors that can be used to synchronize a 3rd party workforce management system with Teams and the types of data that can be synchronized.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
@@ -13,9 +13,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
-This cmdlet supports retrieving the list of connector instances.
+This cmdlet returns the list of existing connections. It can also return the configuration details for a given connection instance.
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionInstance [[-ConnectorInstanceId] <String>] [<CommonPa
 
 ## DESCRIPTION
 
-This cmdlet shows the list of connection instances that can be used to link teams.
+This cmdlet returns the list of existing connections. It can also return the configuration details for a given connection instance.
 
 ## EXAMPLES
 
@@ -47,7 +47,7 @@ Returns the list of connection instances.
 
 ### Example 2
 ```powershell
-PS C:\> Get-CsTeamsShiftsConnectionInstance -ConnectorInstanceId "WCI-01c84e58-9a03-4e56-82f1-6b224132cad8"
+PS C:\> Get-CsTeamsShiftsConnectionInstance -ConnectorInstanceId "WCI-01c84e59-9a03-4e56-82f1-6b224132cad8"
 ```
 ```output
 DesignatedActorId                    EnabledConnectorScenario                               EnabledWfiScenario      Etag                                   Id                                       Name                      SyncFrequencyInMin TenantId                             WorkforceIntegrationId
@@ -55,7 +55,7 @@ DesignatedActorId                    EnabledConnectorScenario                   
 b75bbfa7-e92b-40fb-99a7-2d23b3404712 {Shift, SwapRequest, UserShiftPreferences, OpenShift…} {Shift, TimeOffRequest} "1d004f54-0000-0400-0000-60ce37120000" WCI-01c84e58-9a03-4e56-82f1-6b224132cad8 Vijay Connector Instance3 10                 dfd24b34-ccb0-47e1-bdb7-e49db9c7c14a WFI_3fd79702-15e4-4c97-9b0e-dd725e92c…
 ```
 
-Returns the connection instances with ID `WCI-01c84e58-9a03-4e56-82f1-6b224132cad8`.
+Returns the connection instance with ID `WCI-01c84e59-9a03-4e56-82f1-6b224132cad8`.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 
 **Note:** This cmdlet is currently in private preview.
 
-This cmdlet returns the list of existing connections. It can also return the configuration details for a given connection instance.
+This cmdlet returns the list of existing connection instances. It can also return the configuration details for a given connection instance.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
@@ -49,7 +49,7 @@ Returns the list of connection instances.
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionInstance -ConnectorInstanceId "WCI-01c84e58-9a03-4e56-82f1-6b224132cad8"
 ```
-```
+```output
 DesignatedActorId                    EnabledConnectorScenario                               EnabledWfiScenario      Etag                                   Id                                       Name                      SyncFrequencyInMin TenantId                             WorkforceIntegrationId
 -----------------                    ------------------------                               ------------------      ----                                   --                                       ----                      ------------------ --------                             ----------------------
 b75bbfa7-e92b-40fb-99a7-2d23b3404712 {Shift, SwapRequest, UserShiftPreferences, OpenShift…} {Shift, TimeOffRequest} "1d004f54-0000-0400-0000-60ce37120000" WCI-01c84e58-9a03-4e56-82f1-6b224132cad8 Vijay Connector Instance3 10                 dfd24b34-ccb0-47e1-bdb7-e49db9c7c14a WFI_3fd79702-15e4-4c97-9b0e-dd725e92c…

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
@@ -33,7 +33,7 @@ This cmdlet shows the list of connection instances that can be used to link team
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionInstance
 ```
-```
+```output
 DesignatedActorId                    EnabledConnectorScenario                               EnabledWfiScenario                                             Etag                                   Id                                       Name                                   SyncFrequencyInMin TenantId
 -----------------                    ------------------------                               ------------------                                             ----                                   --                                       ----                                   ------------------ --------
 b75bbfa7-e92b-40fb-99a7-2d23b3404712 {Shift, SwapRequest, UserShiftPreferences, OpenShift…} {Shift, TimeOffRequest}                                        "1d004f54-0000-0400-0000-60ce37120000" WCI-01c84e58-9a03-4e56-82f1-6b224132cad8 Vijay Connector Instance3              10                 dfd24b34-ccb0-47e1-bdb…

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
@@ -45,7 +45,7 @@ Returns the successful and failed users in the team mapping in the instance with
 
 ### -ConnectorInstanceId
 
-The ID of the connection instance. It can be retrieved by running [Get-CsTeamsShiftsConnectionInstance](Get-CsTeamsShiftsConnectionInstance.md)
+The ID of the connection instance. It can be retrieved by running [Get-CsTeamsShiftsConnectionInstance](Get-CsTeamsShiftsConnectionInstance.md).
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
@@ -32,7 +32,8 @@ This cmdlet supports retrieving the list of successful and failed users in the m
 ### Example 1
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionSyncResult -ConnectorInstanceId "WCI-d1addd70-2684-4723-b8f2-7fa2230648c9" -TeamId "70f49d29-7ee1-4259-8999-946953feb79e"
-
+```
+```
 FailedAadUser FailedWfmUser                 SuccessfulUser
 ------------- -------------                 --------------
 {}            {FRPET, WAROS, LABRO, JOREE…} {maosha.shi@flwr0.ms, xiaoxue.chen@flwr0.ms, guchuan.sun@flwr0.ms}

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
@@ -33,7 +33,7 @@ This cmdlet supports retrieving the list of successful and failed users in the m
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionSyncResult -ConnectorInstanceId "WCI-d1addd70-2684-4723-b8f2-7fa2230648c9" -TeamId "70f49d29-7ee1-4259-8999-946953feb79e"
 ```
-```
+```output
 FailedAadUser FailedWfmUser                 SuccessfulUser
 ------------- -------------                 --------------
 {}            {FRPET, WAROS, LABRO, JOREE…} {maosha.shi@flwr0.ms, xiaoxue.chen@flwr0.ms, guchuan.sun@flwr0.ms}

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet supports retrieving the list of user details in the mapped teams.
 
@@ -39,7 +39,7 @@ FailedAadUser FailedWfmUser                 SuccessfulUser
 {}            {FRPET, WAROS, LABRO, JOREE…} {maosha.shi@flwr0.ms, xiaoxue.chen@flwr0.ms, guchuan.sun@flwr0.ms}
 ```
 
-Returns the successful and failed users in the team mapping in the instance with ID `WCI-d1addd70-2684-4723-b8f2-7fa2230648c9`.
+Returns the successful and failed users in the team mapping of Teams `70f49d29-7ee1-4259-8999-946953feb79e` in the instance with ID `WCI-d1addd70-2684-4723-b8f2-7fa2230648c9`.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
@@ -33,7 +33,7 @@ This cmdlet shows the list of mapped teams inside the connection instance. Intan
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId "WCI-d1addd70-2684-4723-b8f2-7fa2230648c9"
 ```
-```
+```output
 TeamId                               TeamName WfmTeamId WfmTeamName
 ------                               -------- --------- -----------
 89ef4689-758c-4598-9206-3e23416da8c2          1000107

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet supports retrieving the list of team mappings.
 
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId <String> [<CommonParamet
 
 ## DESCRIPTION
 
-This cmdlet shows the list of mapped teams inside the connection instance. Intance IDs can be found by running [Get-CsTeamsShiftsConnectionInstance](Get-CsTeamsShiftsConnectionInstance.md).
+Workforce management (WFM) systems have locations / sites that are mapped to a Microsoft Teams team for synchronization of shifts data.  This cmdlet shows the list of mapped teams inside the connection instance. Intance IDs can be found by running [Get-CsTeamsShiftsConnectionInstance](Get-CsTeamsShiftsConnectionInstance.md).
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
@@ -32,7 +32,8 @@ This cmdlet shows the list of mapped teams inside the connection instance. Intan
 ### Example 1
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId "WCI-d1addd70-2684-4723-b8f2-7fa2230648c9"
-
+```
+```
 TeamId                               TeamName WfmTeamId WfmTeamName
 ------                               -------- --------- -----------
 89ef4689-758c-4598-9206-3e23416da8c2          1000107

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionUser -ConnectorInstanceId <string> -WfmTeamId <string
 
 ## DESCRIPTION
 
-This cmdlet shows the list of WFM users in the connection instance.
+This cmdlet shows the list of Workforce management (WFM) users in the connection instance.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
@@ -33,7 +33,7 @@ This cmdlet shows the list of WFM users in the connection instance.
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionUser -ConnectorInstanceId "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b" -WfmTeamId "1000107"
 ```
-```
+```output
 Id      Name
 --      ----
 1000111 FRPET

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
@@ -45,7 +45,7 @@ Id      Name
 1006095 guchuan.sun
 ```
 
-Returns the users in the WFM team with ID 1000107 in the connection instances with ID `WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b`.
+Returns the users in the WFM team with ID `1000107` in the connection instances with ID `WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b`.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
@@ -32,7 +32,8 @@ This cmdlet shows the list of WFM users in the connection instance.
 ### Example 1
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionUser -ConnectorInstanceId "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b" -WfmTeamId "1000107"
-
+```
+```
 Id      Name
 --      ----
 1000111 FRPET

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionUser.md
@@ -13,9 +13,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
-This cmdlet supports retrieving the list of users in the connection instance.
+This cmdlet shows the list of Workforce management (WFM) users in a specified WFM team. 
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionUser -ConnectorInstanceId <string> -WfmTeamId <string
 
 ## DESCRIPTION
 
-This cmdlet shows the list of Workforce management (WFM) users in the connection instance.
+This cmdlet shows the list of Workforce management (WFM) users in a specified WFM team. 
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
@@ -32,7 +32,8 @@ This cmdlet shows the available WFM teams that can be mapped in the connection i
 ### Example 1
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionWfmTeam -ConnectorInstanceId "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b"
-
+```
+```
 Id      Name
 --      ----
 1000105 0002 - Bucktown

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
@@ -33,7 +33,7 @@ This cmdlet shows the available WFM teams that can be mapped in the connection i
 ```powershell
 PS C:\> Get-CsTeamsShiftsConnectionWfmTeam -ConnectorInstanceId "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b"
 ```
-```
+```output
 Id      Name
 --      ----
 1000105 0002 - Bucktown

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 
 **Note:** This cmdlet is currently in public preview.
 
-This cmdlet supports retrieving the list of available WFM teams in the connection instance.
+This cmdlet supports retrieving the list of available Workforce management (WFM) teams in the connection instance.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet supports retrieving the list of available Workforce management (WFM) teams in the connection instance.
 
@@ -25,7 +25,7 @@ Get-CsTeamsShiftsConnectionWfmTeam -ConnectorInstanceId <string> [<CommonParamet
 
 ## DESCRIPTION
 
-This cmdlet shows the available WFM teams that can be mapped in the connection instance.
+This cmdlet shows the WFM teams that are not currently mapped to a Microsoft Teams team, and thus can be mapped to a Microsoft Teams team in the connection instance.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -33,7 +33,7 @@ This cmdlet creates a Shifts connection instance. It allows the admin to set up 
 ```powershell
 New-CsTeamsShiftsConnectionInstance -ConnectorId "6A51B888-FF44-4FEA-82E1-839401E9CD74" -ConnectorSpecificSettingAdminApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/wfmadmin/api/v1-beta2" -ConnectorSpecificSettingCookieAuthUrl "https://nehstdevwfm02.replgroup.com/retail/data/login" -ConnectorSpecificSettingEssApiUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmess/api/v1-beta1" -ConnectorSpecificSettingFederatedAuthUrl "https://nehstdevfas01.replgroup.com/retail/data/login" -ConnectorSpecificSettingLoginPwd "MyPassword" -ConnectorSpecificSettingLoginUserName "MyUserName" -ConnectorSpecificSettingRetailWebApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/retailwebapi/api/v1" -ConnectorSpecificSettingSiteManagerUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmsm/api/v1-beta2" -DesignatedActorId "0c1141fa-1b17-43cc-a417-34c156b99779" -EnabledConnectorScenario "shift", "swapRequest", "openShift", "openShiftRequest", "timeOff", "timeOffRequest" -EnabledWfiScenario "swapRequest", "openShiftRequest", "timeOffRequest" -Name "MyInstance" -SyncFrequencyInMin 10
 ```
-```
+```output
 {
     "id": "WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09",
     "tenantId": "dfd24b34-ccb0-47e1-bdb7-e49db9c7c14a",

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -139,7 +139,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -EnabledWfiScenarios
+### -EnabledWfiScenario
 
 The WFI enabled scenarios that are synced from Shifts in MS Teams to WFM system. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
 

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -237,7 +237,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingEssApiUrl
 
-The essential api URL.
+The essential API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 
 ### -Name
 
-The connector's instance name.
+The connector instance's name.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 
 ### -ConnectorId
 
-The ID of the shifts connector.
+The ID of the Shifts Connector.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 
 ### -EnabledConnectorScenario
 
-The connector enabled scenarios that are synced from WFM system to Shifts in MS Teams. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
+The connector enabled scenarios that are synced from the Workforce management (WFM) system to Shifts in Microsoft Teams. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
 
 ```yaml
 Type: String[]

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -32,7 +32,8 @@ This cmdlet creates a Shifts connection instance. It allows the admin to set up 
 ### Example 1
 ```powershell
 New-CsTeamsShiftsConnectionInstance -ConnectorId "6A51B888-FF44-4FEA-82E1-839401E9CD74" -ConnectorSpecificSettingAdminApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/wfmadmin/api/v1-beta2" -ConnectorSpecificSettingCookieAuthUrl "https://nehstdevwfm02.replgroup.com/retail/data/login" -ConnectorSpecificSettingEssApiUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmess/api/v1-beta1" -ConnectorSpecificSettingFederatedAuthUrl "https://nehstdevfas01.replgroup.com/retail/data/login" -ConnectorSpecificSettingLoginPwd "MyPassword" -ConnectorSpecificSettingLoginUserName "MyUserName" -ConnectorSpecificSettingRetailWebApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/retailwebapi/api/v1" -ConnectorSpecificSettingSiteManagerUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmsm/api/v1-beta2" -DesignatedActorId "0c1141fa-1b17-43cc-a417-34c156b99779" -EnabledConnectorScenario "shift", "swapRequest", "openShift", "openShiftRequest", "timeOff", "timeOffRequest" -EnabledWfiScenario "swapRequest", "openShiftRequest", "timeOffRequest" -Name "MyInstance" -SyncFrequencyInMin 10
-
+```
+```
 {
     "id": "WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09",
     "tenantId": "dfd24b34-ccb0-47e1-bdb7-e49db9c7c14a",

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet creates a Shifts connection instance.
 
@@ -25,7 +25,7 @@ New-CsTeamsShiftsConnectionInstance -ConnectorId <string> -ConnectorSpecificSett
 
 ## DESCRIPTION
 
-This cmdlet creates a Shifts connection instance. It allows the admin to set up the environment for further shift team mapping.
+This cmdlet creates a Shifts connection instance. It allows the admin to set up the environment for further connection settings.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -205,7 +205,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingAdminApiUrl
 
-The admin api URL.
+The admin API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 
 **Note:** This cmdlet is currently in public preview.
 
-This cmdlet connects a Teams team and a WFM team.
+This cmdlet connects a Teams team and a Workforce management (WFM) team.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
@@ -32,7 +32,8 @@ This cmdlet connects a Teams team and a WFM team. Users in the Teams team and WF
 ### Example 1
 ```powershell
 PS C:\> New-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b" -TeamId 30b625bd-f0f7-4d5c-8793-9ccef5a63119 -TimeZone "America/Los_Angeles" -WfmTeamId "1000107"
-
+```
+```
 TeamId                               TeamName WfmTeamId WfmTeamName
 ------                               -------- --------- -----------
 30b625bd-f0f7-4d5c-8793-9ccef5a6311          1000107

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
@@ -13,9 +13,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
-This cmdlet connects a Teams team and a Workforce management (WFM) team.
+This cmdlet connects a Microsoft Teams team and a Workforce management (WFM) team.
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ New-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId <string> -TeamId <string
 
 ## DESCRIPTION
 
-This cmdlet connects a Teams team and a WFM team. Users in the Teams team and WFM team with the same email address will be synced.
+This cmdlet connects a Microsoft Teams team and a WFM team to allow for synchronization of shifts related data.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
@@ -33,7 +33,7 @@ This cmdlet connects a Teams team and a WFM team. Users in the Teams team and WF
 ```powershell
 PS C:\> New-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b" -TeamId 30b625bd-f0f7-4d5c-8793-9ccef5a63119 -TimeZone "America/Los_Angeles" -WfmTeamId "1000107"
 ```
-```
+```output
 TeamId                               TeamName WfmTeamId WfmTeamName
 ------                               -------- --------- -----------
 30b625bd-f0f7-4d5c-8793-9ccef5a6311          1000107

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionInstance.md
@@ -34,7 +34,7 @@ This cmdlet deletes a connection instance. All available instances can be found 
 PS C:\> Remove-CsTeamsShiftsConnectionInstance -ConnectorInstanceId WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b
 ```
 
-Deletes the connection instance with ID "WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b".
+Deletes the connection instance with ID `WCI-4c231dd2-4451-45bd-8eea-bd68b40bab8b`.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionInstance.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet deletes a Shifts connection instance.
 

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionTeamMap.md
@@ -13,9 +13,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
-This cmdlet removes the mapping between the Teams team and WFM team.
+This cmdlet removes the mapping between the Microsoft Teams team and workforce management (WFM) team.
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ Remove-CsTeamsShiftsConnectionTeamMap -ConnectorInstanceId <String> -TeamId <str
 
 ## DESCRIPTION
 
-This cmdlet removes the mapping between the Teams team and WFM team. All team mappings can be found by running [Get-CsTeamsShiftsConnectionTeamMap](Get-CsTeamsShiftsConnectionTeamMap.md).
+This cmdlet removes the mapping between the Microsoft Teams team and WFM team. All team mappings can be found by running [Get-CsTeamsShiftsConnectionTeamMap](Get-CsTeamsShiftsConnectionTeamMap.md).
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -173,7 +173,7 @@ Accept wildcard characters: False
 
 ### -EnabledWfiScenarios
 
-The WFI enabled scenarios that are synced from Shifts in MS Teams to WFM system. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios
+The WFI enabled scenarios that are synced from Shifts in Microsoft Teams to the WFM system. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
 
 ```yaml
 Type: String[]

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -32,7 +32,8 @@ This cmdlet updates a Shifts connection instance. It allows the admin to make ch
 ### Example 1
 ```powershell
 Set-CsTeamsShiftsConnectionInstance -ConnectorId "6A51B888-FF44-4FEA-82E1-839401E9CD74" -ConnectorInstanceId "WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09" -ConnectorSpecificSettingAdminApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/wfmadmin/api/v1-beta2" -ConnectorSpecificSettingCookieAuthUrl "https://nehstdevwfm02.replgroup.com/retail/data/login" -ConnectorSpecificSettingEssApiUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmess/api/v1-beta1" -ConnectorSpecificSettingFederatedAuthUrl "https://nehstdevfas01.replgroup.com/retail/data/login" -ConnectorSpecificSettingLoginPwd "MyPassword" -ConnectorSpecificSettingLoginUserName "MyUserName" -ConnectorSpecificSettingRetailWebApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/retailwebapi/api/v1" -ConnectorSpecificSettingSiteManagerUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmsm/api/v1-beta2" -DesignatedActorId "0c1141fa-1b17-43cc-a417-34c156b99779" -EnabledConnectorScenario "shift", "swapRequest", "openShift", "openShiftRequest", "timeOff", "timeOffRequest" -EnabledWfiScenario "shift", "swapRequest", "openShift", "openShiftRequest", "timeOff", "timeOffRequest" -Name "MyInstance-Updated" -SyncFrequencyInMin 10 -IfMatch '"0a005fd6-0000-0d00-0000-60a76dbf0000"'
-
+```
+```
 {
     "id": "WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09",
     "tenantId": "dfd24b34-ccb0-47e1-bdb7-e49db9c7c14a",

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -269,7 +269,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingEssApiUrl
 
-The essential api URL.
+The essential API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -171,7 +171,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -EnabledWfiScenarios
+### -EnabledWfiScenario
 
 The WFI enabled scenarios that are synced from Shifts in Microsoft Teams to the WFM system. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
 

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 
 ### -EnabledConnectorScenario
 
-The connector enabled scenarios that are synced from WFM system to Shifts in MS Teams. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
+The connector enabled scenarios that are synced from the Workforce Management (WFM) system to Shifts in Microsoft Teams. You can use [Get-CsTeamsShiftsConnectionConnector](Get-CsTeamsShiftsConnectionConnector.md) to get supported scenarios.
 
 ```yaml
 Type: String[]

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -205,7 +205,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingLoginUserName
 
-The login user name to WFM team.
+The login user name to the WFM team.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -20,7 +20,7 @@ This cmdlet updates a Shifts connection instance.
 ## SYNTAX
 
 ```
-Set-CsTeamsShiftsConnectionInstance -ConnectorId <string> -ConnectorSpecificSettingAdminApiUrl <string> -ConnectorSpecificSettingCookieAuthUrl <string> -ConnectorSpecificSettingEssApiUrl <string> -ConnectorSpecificSettingFederatedAuthUrl <string> -ConnectorSpecificSettingLoginPwd <string> -ConnectorSpecificSettingLoginUserName <string> -ConnectorSpecificSettingRetailWebApiUrl <string> -ConnectorSpecificSettingSiteManagerUrl <string> -Name <string> -DesignatedActorId <string> -EnabledConnectorScenario <string[]> -EnabledWfiScenario <string[]> -SyncFrequencyInMin <Integer> -IfMatch <string> [<CommonParameters>]
+Set-CsTeamsShiftsConnectionInstance -ConnectorId <string> -ConnectorInstanceId <string> -ConnectorSpecificSettingAdminApiUrl <string> -ConnectorSpecificSettingCookieAuthUrl <string> -ConnectorSpecificSettingEssApiUrl <string> -ConnectorSpecificSettingFederatedAuthUrl <string> -ConnectorSpecificSettingLoginPwd <string> -ConnectorSpecificSettingLoginUserName <string> -ConnectorSpecificSettingRetailWebApiUrl <string> -ConnectorSpecificSettingSiteManagerUrl <string> -Name <string> -DesignatedActorId <string> -EnabledConnectorScenario <string[]> -EnabledWfiScenario <string[]> -SyncFrequencyInMin <Integer> -IfMatch <string> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -77,7 +77,7 @@ Updates the instance with ID `WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09` with nam
 
 ### -ConnectorInstanceId
 
-The ID of the connection instance.
+The ID of the connection instance that you want to update.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 
 ### -ConnectorId
 
-The ID of the shifts connector.
+The ID of the Shifts Connector.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingLoginPwd
 
-The login password to WFM team.
+The login password to the WFM team.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -25,7 +25,7 @@ Set-CsTeamsShiftsConnectionInstance -ConnectorId <string> -ConnectorSpecificSett
 
 ## DESCRIPTION
 
-This cmdlet updates a Shifts connection instance. It allows the admin to make changes to the settings in the instance such as name, enables scenarios and sync frequency.
+This cmdlet updates a Shifts connection instance. It allows the admin to make changes to the settings in the instance such as name, enables scenarios, and sync frequency.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
 This cmdlet updates a Shifts connection instance.
 
@@ -25,7 +25,7 @@ Set-CsTeamsShiftsConnectionInstance -ConnectorId <string> -ConnectorSpecificSett
 
 ## DESCRIPTION
 
-This cmdlet updates a Shifts connection instance. It allows the admin to make changes to the settings in the instance such as name, enables scenarios, and sync frequency.
+This cmdlet updates a Shifts connection instance. It allows the admin to make changes to the settings in the instance such as name, enabled scenarios, and sync frequency. Note that the update allows for, but does not require, the -ConnectorSpecificSettingLoginPwd and ConnectorSpecificSettingLoginUserNameusername to be included.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 
 ### -IfMatch
 
-The Etag of connection instance. Note: this will be changed after each update of the connection instance. You can get it from instance details using [Get-CsTeamsShiftsConnectionInstance](Get-CsTeamsShiftsConnectionInstance.md)
+The Etag of connection instance. Note: this will be changed after each update of the connection instance. You can get it from instance details using [Get-CsTeamsShiftsConnectionInstance](Get-CsTeamsShiftsConnectionInstance.md).
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -301,7 +301,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingRetailWebApiUrl
 
-The retail web api URL.
+The retail web API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -33,7 +33,7 @@ This cmdlet updates a Shifts connection instance. It allows the admin to make ch
 ```powershell
 Set-CsTeamsShiftsConnectionInstance -ConnectorId "6A51B888-FF44-4FEA-82E1-839401E9CD74" -ConnectorInstanceId "WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09" -ConnectorSpecificSettingAdminApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/wfmadmin/api/v1-beta2" -ConnectorSpecificSettingCookieAuthUrl "https://nehstdevwfm02.replgroup.com/retail/data/login" -ConnectorSpecificSettingEssApiUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmess/api/v1-beta1" -ConnectorSpecificSettingFederatedAuthUrl "https://nehstdevfas01.replgroup.com/retail/data/login" -ConnectorSpecificSettingLoginPwd "MyPassword" -ConnectorSpecificSettingLoginUserName "MyUserName" -ConnectorSpecificSettingRetailWebApiUrl "https://nehstdevwfm02.replgroup.com/retail/data/retailwebapi/api/v1" -ConnectorSpecificSettingSiteManagerUrl "https://nehstdevfas01.replgroup.com/retail/data/wfmsm/api/v1-beta2" -DesignatedActorId "0c1141fa-1b17-43cc-a417-34c156b99779" -EnabledConnectorScenario "shift", "swapRequest", "openShift", "openShiftRequest", "timeOff", "timeOffRequest" -EnabledWfiScenario "shift", "swapRequest", "openShift", "openShiftRequest", "timeOff", "timeOffRequest" -Name "MyInstance-Updated" -SyncFrequencyInMin 10 -IfMatch '"0a005fd6-0000-0d00-0000-60a76dbf0000"'
 ```
-```
+```output
 {
     "id": "WCI-648a8c8f-0ca3-460b-b71c-0d038d6d6e09",
     "tenantId": "dfd24b34-ccb0-47e1-bdb7-e49db9c7c14a",

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -237,7 +237,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingAdminApiUrl
 
-The admin api URL.
+The admin API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 
 **Note:** This cmdlet is currently in public preview.
 
-This cmdlet validates WFM settings from given configuration.
+This cmdlet validates Workforce management (WFM) settings from a given configuration.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingLoginUserName
 
-The login user name to WFM team.
+The login user name to the WFM team.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -91,7 +91,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingLoginPwd
 
-The login password to WFM team.
+The login password to the WFM team.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -171,7 +171,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingRetailWebApiUrl
 
-The retail web api URL.
+The retail web API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -13,9 +13,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
+**Note:** This cmdlet is currently in private preview.
 
-This cmdlet validates Workforce management (WFM) settings from a given configuration.
+This cmdlet validates workforce management (WFM) connection settings.
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ Test-CsTeamsShiftsConnectionValidate -ConnectorId <string> -ConnectorSpecificSet
 
 ## DESCRIPTION
 
-This cmdlet allows the admin to test if there are conflicts to create an instance with the input settings.
+This cmdlet validates Workforce management (WFM) connection settings. It validates that the provided WFM account/password and required endpoints are set correctly. 
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -107,7 +107,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingAdminApiUrl
 
-The admin api URL.
+The admin API URL.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -139,7 +139,7 @@ Accept wildcard characters: False
 
 ### -ConnectorSpecificSettingEssApiUrl
 
-The essential api URL.
+The essential API URL.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Adding docs about instructions of Shifts Connector cmdlets usage: 
    Get-CsTeamsShiftsConnectionConnector,
    Test-CsTeamsShiftsConnectionValidate,
    New-CsTeamsShiftsConnectionInstance,
    Set-CsTeamsShiftsConnectionInstance,
    Remove-CsTeamsShiftsConnectionInstance,
    Get-CsTeamsShiftsConnectionInstance,
    Get-CsTeamsShiftsConnectionWfmTeam,
    New-CsTeamsShiftsConnectionTeamMap,
    Remove-CsTeamsShiftsConnectionTeamMap,
    Get-CsTeamsShiftsConnectionTeamMap,
    Get-CsTeamsShiftsConnectionSyncResult,
    Get-CsTeamsShiftsConnectionUser,