### PR TITLE
Update New-TeamChannel.md

### DIFF
--- a/teams/teams-ps/teams/New-TeamChannel.md
+++ b/teams/teams-ps/teams/New-TeamChannel.md
@@ -87,7 +87,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -MembershipType (available in private preview)
+### -MembershipType
 Channel membership type, Standard or Private.
 
 ```yaml
@@ -102,7 +102,7 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Owner (available in private preview)
+### -Owner
 UPN of owner that can be specified while creating a private channel.
 
 ```yaml


### PR DESCRIPTION
Removing the "(available in private preview string)" as these parameters are now exposed in the GA 2.3.1 version.