### PR TITLE
Update New-CsExternalAccessPolicy.md

### DIFF
--- a/skype/skype-ps/skype/New-CsExternalAccessPolicy.md
+++ b/skype/skype-ps/skype/New-CsExternalAccessPolicy.md
@@ -18,7 +18,7 @@ Enables you to create a new external access policy.
 External access policies determine whether or not your users can: 1) communicate with users who have Session Initiation Protocol (SIP) accounts with a federated organization; 2) communicate with users who have SIP accounts with a public instant messaging (IM) provider such as MSN; and, 3) access Skype for Business Server over the Internet, without having to log on to your internal network.
 This cmdlet was introduced in Lync Server 2010.
 
-
+For information about external access in Microsoft Teams, please see https://docs.microsoft.com/en-us/microsoftteams/manage-external-access and https://docs.microsoft.com/en-us/microsoftteams/teams-skype-interop for specific details.
 
 ## SYNTAX
 
@@ -166,7 +166,7 @@ The default value is False.
 Type: Boolean
 Parameter Sets: (All)
 Aliases: 
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/New-CsExternalAccessPolicy.md
+++ b/skype/skype-ps/skype/New-CsExternalAccessPolicy.md
@@ -18,7 +18,7 @@ Enables you to create a new external access policy.
 External access policies determine whether or not your users can: 1) communicate with users who have Session Initiation Protocol (SIP) accounts with a federated organization; 2) communicate with users who have SIP accounts with a public instant messaging (IM) provider such as MSN; and, 3) access Skype for Business Server over the Internet, without having to log on to your internal network.
 This cmdlet was introduced in Lync Server 2010.
 
-For information about external access in Microsoft Teams, please see https://docs.microsoft.com/en-us/microsoftteams/manage-external-access and https://docs.microsoft.com/en-us/microsoftteams/teams-skype-interop for specific details.
+For information about external access in Microsoft Teams, see [Manage external access in Microsoft Teams](/microsoftteams/manage-external-access) and [Teams and Skype interoperability](/microsoftteams/teams-skype-interop) for specific details.
 
 ## SYNTAX
 
@@ -342,5 +342,4 @@ Creates new instances of the Microsoft.Rtc.Management.WritableConfig.Policy.Exte
 [Remove-CsExternalAccessPolicy](Remove-CsExternalAccessPolicy.md)
 
 [Set-CsExternalAccessPolicy](Set-CsExternalAccessPolicy.md)
-
 


### PR DESCRIPTION
Need to direct admins to Teams documentation for these settings (Note in synopsis). Also EnableOutsideAccess is applicable to Skype Server only, not Teams and Skype online. Confirmed with engineering and okay to update documentation to make this more clear.