### PR TITLE
Improved inaccurate description

### DIFF
--- a/skype/skype-ps/skype/Grant-CsApplicationAccessPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsApplicationAccessPolicy.md
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 
 ### -Global
 
-This parameter is reserved for internal Microsoft use.
+Assign the policy to all users in the tenant who do not have an application access policy assigned. For example, if the user already have application access policy "A" assigned, and tenant admin assigns "B" globally, then application access policy "A" will take effect for the user.
 
 ```yaml
 Type: SwitchParameter

--- a/skype/skype-ps/skype/Grant-CsApplicationAccessPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsApplicationAccessPolicy.md
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 
 ### -Global
 
-Assign the policy to all users in the tenant who do not have an application access policy assigned. For example, if the user already have application access policy "A" assigned, and tenant admin assigns "B" globally, then application access policy "A" will take effect for the user.
+When you use this cmdlet without specifying a user identity, the policy applies to all users in your tenant, except any that have an explicit policy assignment. For example, if the user already have application access policy "A" assigned, and tenant admin assigns "B" globally, then application access policy "A" will take effect for the user.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Customers have had doubt about the "internal user only" description and hesitated to use it. The description was wrong and needs to be updated.