### PR TITLE
Fixed typo in second example

### DIFF
--- a/exchange/exchange-ps/exchange/Test-TextExtraction.md
+++ b/exchange/exchange-ps/exchange/Test-TextExtraction.md
@@ -47,7 +47,7 @@ This example returns the text that's extracted from the email "financial data.ms
 ### Example 2
 ```powershell
 $content = Test-TextExtraction -FileData (Get-Content -Path '.\finalcial data.msg' -Encoding byte -ReadCount 0)
-Test-DataClassification -TestTextExtractionResults $tr.ExtractedResults
+Test-DataClassification -TestTextExtractionResults $content.ExtractedResults
 ```
 
 This example extracts the text from the email "financial data.msg" and returns the sensitive information types, their confidence, and count.


### PR DESCRIPTION
Made the variable name the same between the two lines of the example, would not work otherwise.