### PR TITLE
Add details to get-sposite for the -GroupIdDefined parameter

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -320,7 +320,7 @@ Default value: None
 
 Filters the list of sites returned to sites with a Group ID (ie: Sites connected to an Microsoft 365 Group) when the value is set to $true.  Filters the list of sites to only sites without a Group ID when the value is $false.
 
-The values are $true, $false, and not defined. By default, the value is not defined which means that the filter does not apply.
+The values are **$true**, **$false**, and **not defined**. By default, the value is **not defined**, which means that the filter does not apply.
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -144,7 +144,7 @@ This example uses client-side filtering to return a list of sites connected to a
 ```powershell
 Get-SPOSite -Limit ALL -GroupIdDefined $true
 ```
-This example uses server-side filtering to return all sites that have an associated Office 365 Group.
+This example uses server-side filtering to return all sites that have an associated Microsoft 365 Group.
 
 
 ## PARAMETERS
@@ -318,7 +318,7 @@ Default value: None
 
 ### -GroupIdDefined
 
-Filters the list of sites returned to sites with a Group ID (ie: Sites connected to an Office 365 Group) when the value is set to $true.  Filters the list of sites to only sites without a Group ID when the value is $false.
+Filters the list of sites returned to sites with a Group ID (ie: Sites connected to an Microsoft 365 Group) when the value is set to $true.  Filters the list of sites to only sites without a Group ID when the value is $false.
 
 The values are $true, $false, and not defined. By default, the value is not defined which means that the filter does not apply.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -121,6 +121,13 @@ Get-SPOSite -Filter { Url -like "contoso.sharepoint.com/sites/18" }
 
 This example uses server side filtering to return sites matching 18.
 
+### -----------------------EXAMPLE 10-----------------------------
+
+```powershell
+Get-SPOSite -Limit ALL -GroupIdDefined $true
+```
+This example uses server-side filtering to return all sites that have an associated Office 365 Group.
+
 ## PARAMETERS
 
 ### -Detailed

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -28,7 +28,7 @@ Get-SPOSite [[-Identity] <SpoSitePipeBind>] [-Detailed] [-Limit <String>] [<Comm
 
 ```powershell
 Get-SPOSite [-Detailed] [-Filter <String>] [-IncludePersonalSite <Boolean>] [-Limit <String>]
- [-Template <String>] [--GroupIdDefined] [<CommonParameters>]
+ [-Template <String>] [-GroupIdDefined] [<CommonParameters>]
 ```
 
 ### ParamSet3

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOSite.md
@@ -28,7 +28,7 @@ Get-SPOSite [[-Identity] <SpoSitePipeBind>] [-Detailed] [-Limit <String>] [<Comm
 
 ```powershell
 Get-SPOSite [-Detailed] [-Filter <String>] [-IncludePersonalSite <Boolean>] [-Limit <String>]
- [-Template <String>] [<CommonParameters>]
+ [-Template <String>] [--GroupIdDefined] [<CommonParameters>]
 ```
 
 ### ParamSet3
@@ -288,6 +288,25 @@ Applicable: SharePoint Online
 Required: False
 Position: Named
 Default value: None
+```
+
+### -GroupIdDefined
+
+Filters the list of sites returned to sites with a Group ID (ie: Sites connected to an Office 365 Group) when the value is set to $true.  Filters the list of sites to only sites without a Group ID when the value is $false.
+
+The values are $true, $false, and not defined. By default, the value is not defined which means that the filter does not apply.
+
+```yaml
+Type: Boolean
+Parameter Sets: ParamSet2
+Aliases:
+Applicable: SharePoint Online
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### CommonParameters


### PR DESCRIPTION
-GroupIdDefined is a parameter that can be added to get-sposite to filter the list of sites returned based on whether they have a group ID or not.