### PR TITLE
Fix typo: extra bracket in syntax

### DIFF
--- a/exchange/exchange-ps/exchange/Get-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Get-Mailbox.md
@@ -77,7 +77,7 @@ Get-Mailbox [-Database <DatabaseIdParameter>]
 
 ### Identity
 ```
-Get-Mailbox [[-Identity] <MailboxIdParameter>]
+Get-Mailbox [-Identity] <MailboxIdParameter>]
  [-Arbitration]
  [-Archive]
  [-AuditLog]


### PR DESCRIPTION
Removed an extraneous left bracket from one of the Get-Mailbox syntax blocks.