### PR TITLE
Update Get-VivaInsightsSettings.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
+++ b/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
@@ -16,7 +16,7 @@ This cmdlet is available only in the Exchange Online PowerShell V2 module. For m
 
 **Note**: This cmdlet is available only in version 2.0.5-Preview2 or later of the EXO V2 module.
 
-Use the Get-VivaInsightsSettings cmdlet to check whether a user has access to features in Microsoft Viva Insights in Microsoft Teams.
+Use the Get-VivaInsightsSettings cmdlet to check whether a user has access to features in Microsoft Viva Insights in Microsoft Teams. Only users with provisioned Exchange Online mailboxes can access features within the Viva Insights app in Teams.
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 
@@ -52,7 +52,7 @@ This example shows the configuration of Microsoft Viva Insights in Microsoft Tea
 ## PARAMETERS
 
 ### -Identity
-The Identity parameter specifies the user that you want to view. You identify the user by their account name (for example, roy@contoso.onmicrosoft.com).
+The Identity parameter specifies the user that you want to view. You identify the user by their User Principal Name (UPN) (for example, roy@contoso.onmicrosoft.com).
 
 ```yaml
 Type: String


### PR DESCRIPTION
Clarify that only users with EXO mailboxes will have access to Viva Insights app in Teams. This was mentioned in MC257054.

Also need clarification that Identity parameter requires User Principal Name (UPN) instead of the generic team "account name".