### PR TITLE
Add restrictions for ConcurrentInvitationCount and Paired Applications in CsTeamsComplianceRecordingApplication cmdlets

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingApplication.md
@@ -240,7 +240,7 @@ Accept wildcard characters: False
 ```
 
 ### -ConcurrentInvitationCount
-Determines the number of invites to send out to the application instance of the policy-based recording application.
+Determines the number of invites to send out to the application instance of the policy-based recording application. Can be set to 1 or 2 only.
 
 In situations where application resiliency is a necessity, multiple invites can be sent to the same application for the same call or meeting.
 If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.
@@ -272,7 +272,7 @@ Accept wildcard characters: False
 ```
 
 ### -ComplianceRecordingPairedApplications
-Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
+Determines the other policy-based recording applications to pair with this application to achieve application resiliency. Can only have one paired application.
 
 In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
 If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.

--- a/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
+++ b/skype/skype-ps/skype/Set-CsTeamsComplianceRecordingApplication.md
@@ -260,7 +260,7 @@ Accept wildcard characters: False
 ```
 
 ### -ComplianceRecordingPairedApplications
-Determines the other policy-based recording applications to pair with this application to achieve application resiliency.
+Determines the other policy-based recording applications to pair with this application to achieve application resiliency. Can only have one paired application.
 
 In situations where application resiliency is a necessity, invites can be sent to separate paired applications for the same call or meeting.
 If multiple such invites are accepted, then it means that multiple instances of this application are in the call or meeting and each of those instances can record independent of the others.


### PR DESCRIPTION
Add the restrictions for ConcurrentInvitationCount and Paired Applications in CsTeamsComplianceRecordingApplication cmdlets to make it clear what and how many values can be set for these parameters.