### PR TITLE
Update Set-MailboxCalendarConfiguration and Set-OrganizationConfig

### DIFF
--- a/exchange/exchange-ps/exchange/Set-MailboxCalendarConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxCalendarConfiguration.md
@@ -22,7 +22,6 @@ For information about the parameter sets in the Syntax section below, see [Excha
 
 ```
 Set-MailboxCalendarConfiguration [-Identity] <MailboxIdParameter>
- [-AddOnlineMeetingToAllEvents <Boolean>]
  [-AgendaMailEnabled <Boolean>]
  [-AgendaMailIntroductionEnabled <Boolean>]
  [-AgendaPaneEnabled <Boolean>]
@@ -121,24 +120,6 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True
-Accept wildcard characters: False
-```
-
-### -AddOnlineMeetingToAllEvents
-This parameter is available only in the cloud-based service.
-
-{{ Fill AddOnlineMeetingToAllEvents Description }}
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/exchange/exchange-ps/exchange/Set-OrganizationConfig.md
+++ b/exchange/exchange-ps/exchange/Set-OrganizationConfig.md
@@ -2522,6 +2522,7 @@ The OnlineMeetingsByDefaultEnabled parameter specifies whether to set all meetin
 
 - $true: All meetings are online by default.
 - $false: All meetings are not online by default. This is the default value.
+- $null: If the organization value has not been specified, the default behavior is for meetings to be online.
 
 You can override this setting on individual mailboxes by using the OnlineMeetingsByDefaultEnabled parameter on the Set-MailboxCalendarConfiguration cmdlet.
 


### PR DESCRIPTION
Set-MailboxCalendarConfiguration: Updated this doc to remove the AddOnlineMeetingToAllEvents prop from the list of available configurations since it is no longer supported.
Set-OrganizationConfig: Added  $null as a valid set value for OnlineMeetingsByDefaultEnabled. The behavior was changed to allow the admin to use the fallback default value.

Please contact Julia Foran <juforan> or me<askhetan> for further questions.