### PR TITLE
Add periods to alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository holds reference content of Office PowerShell cmdlets for help purpose. The expert knowledge around Office PowerShell is distributed among customers, MVPs, partners, product teams, support, and other community members. Consumers have various preferences when consuming knowledge such as a website, PowerShell Get-Help, Windows app, iOS app, Android app, and others. The following diagram illustrates the point.
 
-![Contribution and Consumption model for Office PowerShell reference content](images/contrib-consumption-model.png)
+![Contribution and Consumption model for Office PowerShell reference content.](images/contrib-consumption-model.png)
 
 ## Learn How To Contribute
 
@@ -19,7 +19,7 @@ Contributors who only make infrequent or small updates can edit the file directl
 
 This brief video also covers how to contribute:
 
-[![Image of Quick Start video](images/edit_video_capture.jpg)](https://support.office.com/article/edit-powershell-cmdlet-in-github-dcd20227-3764-48ce-ad6e-763af8b48daf)
+[![Image of Quick Start video.](images/edit_video_capture.jpg)](https://support.office.com/article/edit-powershell-cmdlet-in-github-dcd20227-3764-48ce-ad6e-763af8b48daf)
 
 ### Quickly update an article using GitHub.com
 
@@ -27,11 +27,11 @@ This brief video also covers how to contribute:
 2. Go to the page you want to edit on docs.microsoft.com.
 3. On the right-hand side of the page, click **Edit** (pencil icon).
 
-   ![Edit button on docs.microsoft.com](images/quick-update-edit.png)
+   ![Edit button on docs.microsoft.com.](images/quick-update-edit.png)
 
 4. The corresponding topic file on GitHub opens, where you need to click the **Edit this file** pencil icon.
 
-   ![Edit button on github.com](images/quick-update-github.png)
+   ![Edit button on github.com.](images/quick-update-github.png)
 
 5. The topic opens in a line-numbered editing page where you can make changes to the file.
 
@@ -45,7 +45,7 @@ This brief video also covers how to contribute:
 
    - Since you are likely not a maintainer of the Git repository, GitHub will automatically 'Fork' the project into your personal GitHub account. A fork is a copy of the repository in your git account. By forking, you can freely make edits without affecting the original repository. You can always find it again by looking at your GitHub Repositories in your GitHub Profile (drop-down from your name in the top right).
 
-     ![Image of Automatic Fork message on Github](images/auto_fork.png)
+     ![Image of Automatic Fork message on Github.](images/auto_fork.png)
 
 6. You can click the **Preview changes** tab to see what the changes will look like.
 
@@ -56,15 +56,15 @@ This brief video also covers how to contribute:
 
    When you're ready, click the green **Propose file change** button.
 
-   ![Propose file change section](images/propose-file-change.png)
+   ![Propose file change section.](images/propose-file-change.png)
 
 8. On the **Comparing changes** page that appears, click the green **Create pull request** button.
 
-   ![Comparing changes page](images/comparing-changes-page.png)
+   ![Comparing changes page.](images/comparing-changes-page.png)
 
 9. On the **Open a pull request** page that appears, click the green **Create pull request** button.
 
-   ![Open a pull request page](images/open-a-pull-request-page.png)
+   ![Open a pull request page.](images/open-a-pull-request-page.png)
 
 > [!NOTE]
 > Your permissions in the repo determine what you see in the last several steps. People with no special privileges will see the **Propose file change** section and subsequent confirmation pages as described. People with permissions to create and approve their own pull requests will see a similar **Commit changes** section with extra options for creating a new branch and fewer confirmation pages.<br/><br/>The point is: click any green buttons that are presented to you until there are no more.

--- a/exchange/docs-conceptual/app-only-auth-powershell-v2.md
+++ b/exchange/docs-conceptual/app-only-auth-powershell-v2.md
@@ -110,15 +110,15 @@ For a detailed visual flow about creating applications in Azure AD, see <https:/
 
 2. Under **Manage Azure Active Directory**, click **View**.
 
-   ![Click View in the Azure AD portal under Manage Azure Active Directory](media/exo-app-only-auth-manage-ad-view.png)
+   ![Click View in the Azure AD portal under Manage Azure Active Directory.](media/exo-app-only-auth-manage-ad-view.png)
 
 3. On the **Overview** page that opens, under **Manage**, select **App registrations**.
 
-   ![Select App registrations](media/exo-app-only-auth-select-app-registrations.png)
+   ![Select App registrations.](media/exo-app-only-auth-select-app-registrations.png)
 
 4. On the **App registrations** page that opens, click **New registration**.
 
-   ![Select New registration on the App registrations page](media/exo-app-only-auth-new-app-registration.png)
+   ![Select New registration on the App registrations page.](media/exo-app-only-auth-new-app-registration.png)
 
    On the **Register an application** page that opens, configure the following settings:
 
@@ -130,7 +130,7 @@ For a detailed visual flow about creating applications in Azure AD, see <https:/
 
      Note that you can't create credentials for [native applications](/azure/active-directory/manage-apps/application-proxy-configure-native-client-application), because you can't use that type for automated applications.
 
-     ![Register an application](media/exo-app-only-auth-register-app.png)
+     ![Register an application.](media/exo-app-only-auth-register-app.png)
 
    When you're finished, click **Register**.
 
@@ -143,7 +143,7 @@ For a detailed visual flow about creating applications in Azure AD, see <https:/
 
 1. On the app page under **Management**, select **Manifest**.
 
-   ![Select Manifest on the application properties page](media/exo-app-only-auth-select-manifest.png)
+   ![Select Manifest on the application properties page.](media/exo-app-only-auth-select-manifest.png)
 
 2. On the **Manifest** page that opens, find the `requiredResourceAccess` entry (on or about line 44).
 
@@ -167,7 +167,7 @@ For a detailed visual flow about creating applications in Azure AD, see <https:/
 
 3. Still on the **Manifest** page, under **Management**, select **API permissions**.
 
-   ![Select API permissions on the application properties page](media/exo-app-only-auth-select-api-permissions.png)
+   ![Select API permissions on the application properties page.](media/exo-app-only-auth-select-api-permissions.png)
 
    On the **API permissions** page that opens, do the following steps:
 
@@ -175,13 +175,13 @@ For a detailed visual flow about creating applications in Azure AD, see <https:/
 
    - **Status**: The current incorrect value is **Not granted for \<Organization\>**, and this value needs to be changed.
 
-     ![Original incorrect API permissions](media/exo-app-only-auth-original-permissions.png)
+     ![Original incorrect API permissions.](media/exo-app-only-auth-original-permissions.png)
 
      Select **Grant admin consent for \<Organization\>**, read the confirmation dialog that opens, and then click **Yes**.
 
      The **Status** value should now be **Granted for \<Organization\>**.
 
-     ![Admin consent granted](media/exo-app-only-auth-admin-consent-granted.png)
+     ![Admin consent granted.](media/exo-app-only-auth-admin-consent-granted.png)
 
 4. Close the current **API permissions** page (not the browser tab) to return to the **App registrations** page. You'll use it in an upcoming step.
 
@@ -220,25 +220,25 @@ After you register the certificate with your application, you can use the privat
    2. Under **Manage Azure Active Directory**, click **View**.
    3. Under **Manage**, select **App registrations**.
 
-   ![Apps registration page where you select your app](media/exo-app-only-auth-app-registration-page.png)
+   ![Apps registration page where you select your app.](media/exo-app-only-auth-app-registration-page.png)
 
 2. On the application page that opens, under **Manage**, select **Certificates & secrets**.
 
-   ![Select Certificates & Secrets on the application properties page](media/exo-app-only-auth-select-certificates-and-secrets.png)
+   ![Select Certificates & Secrets on the application properties page.](media/exo-app-only-auth-select-certificates-and-secrets.png)
 
 3. On the **Certificates & secrets** page that opens, click **Upload certificate**.
 
-   ![Select Upload certificate on the Certificates & secrets page](media/exo-app-only-auth-select-upload-certificate.png)
+   ![Select Upload certificate on the Certificates & secrets page.](media/exo-app-only-auth-select-upload-certificate.png)
 
    In the dialog that opens, browse to the self-signed certificate (`.cer` file) that you created in [Step 3](#step-3-generate-a-self-signed-certificate).
 
-   ![Browse to the certificate and then click Add](media/exo-app-only-auth-upload-certificate-dialog.png)
+   ![Browse to the certificate and then click Add.](media/exo-app-only-auth-upload-certificate-dialog.png)
 
    When you're finished, click **Add**.
 
    The certificate is now shown in the **Certificates** section.
 
-   ![Application page showing that the certificate was added](media/exo-app-only-auth-certificate-successfully-added.png)
+   ![Application page showing that the certificate was added.](media/exo-app-only-auth-certificate-successfully-added.png)
 
 4. Close the current **Certificates & secrets** page, and then the **App registrations** page to return to the main <https://portal.azure.com/> page. You'll use it in the next step.
 
@@ -258,26 +258,26 @@ For general instructions about assigning roles in Azure AD, see [View and assign
 
 1. On the Azure AD portal at <https://portal.azure.com/>, under **Manage Azure Active Directory**, click **View**.
 
-   ![View in the Azure AD portal under Manage Azure Active Directory](media/exo-app-only-auth-manage-ad-view.png)
+   ![View in the Azure AD portal under Manage Azure Active Directory.](media/exo-app-only-auth-manage-ad-view.png)
 
 2. On the **Overview** page that opens, under **Manage**, select **Roles and administrators**.
 
-   ![Select Roles and administrators from the overview page](media/exo-app-only-auth-select-roles-and-administrators.png)
+   ![Select Roles and administrators from the overview page.](media/exo-app-only-auth-select-roles-and-administrators.png)
 
 3. On the **Roles and administrators** page that opens, find and select one of the supported roles by _clicking on the name of the role_ (not the check box) in the results.
 
-   ![Find and select a supported role by clicking on the role name](media/exo-app-only-auth-find-and-select-supported-role.png)
+   ![Find and select a supported role by clicking on the role name.](media/exo-app-only-auth-find-and-select-supported-role.png)
 
 4. On the **Assignments** page that opens, click **Add assignments**.
 
-   ![Select Add assignments on the role assignments page](media/exo-app-only-auth-role-assignments-click-add-assignments.png)
+   ![Select Add assignments on the role assignments page.](media/exo-app-only-auth-role-assignments-click-add-assignments.png)
 
 5. In the **Add assignments** flyout that opens, find and select the app that you created in [Step 1](#step-1-register-the-application-in-azure-ad).
 
-   ![Find and select your app on the Add assignments flyout](media/exo-app-only-auth-find-add-select-app-for-assignment.png)
+   ![Find and select your app on the Add assignments flyout.](media/exo-app-only-auth-find-add-select-app-for-assignment.png)
 
    When you're finished, click **Add**.
 
 6. Back on the **Assignments** page, verify that the app has been assigned to the role.
 
-   ![The role assignments page after to added the app to the role](media/exo-app-only-auth-app-assigned-to-role.png)
+   ![The role assignments page after to added the app to the role.](media/exo-app-only-auth-app-assigned-to-role.png)

--- a/exchange/docs-conceptual/connect-to-exchange-online-powershell.md
+++ b/exchange/docs-conceptual/connect-to-exchange-online-powershell.md
@@ -104,13 +104,13 @@ For other sign in methods that are available in PowerShell 7, see the [PowerShel
 
 3. In the sign-in window that opens, enter your password, and then click **Sign in**.
 
-   ![Enter your password in the Sign in to your account window](media/connect-exo-password-prompt.png)
+   ![Enter your password in the Sign in to your account window.](media/connect-exo-password-prompt.png)
 
 4. **MFA only**: A verification code is generated and delivered based on the response option that's configured for your account (for example, a text message or the Microsoft Authenticator app on your device).
 
    In the verification window that opens, enter the verification code, and then click **Verify**.
 
-   ![Enter your verification code in the Sign in to your account window](media/connect-exo-mfa-verify-prompt.png)
+   ![Enter your verification code in the Sign in to your account window.](media/connect-exo-mfa-verify-prompt.png)
 
 For detailed syntax and parameter information, see [Connect-ExchangeOnline](/powershell/module/exchange/connect-exchangeonline).
 

--- a/exchange/docs-conceptual/recipient-filters.md
+++ b/exchange/docs-conceptual/recipient-filters.md
@@ -202,14 +202,14 @@ When creating your own custom OPath filters, consider the following items:
 
   |Search value|OPath filter <br> enclosed in <br> double quotation marks|OPath filter <br> enclosed in <br> single quotation marks|OPath filter enclosed in <br> braces|
   |---|:---:|:---:|:---:|
-  |`'Text'`|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
-  |`"Text"`|||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
-  |`'$Variable'`|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|||
-  |`500`|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
-  |`'500'`|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |`'Text'`|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)||![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |`"Text"`|||![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |`'$Variable'`|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|||
+  |`500`|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |`'500'`|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
   |`"500"`|||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
-  |`$true`||![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
-  |`` `$true``|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |`$true`||![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
+  |`` `$true``|![Check mark.](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|![Check mark](media/f3b4c351-17d9-42d9-8540-e48e01779b31.png)|
   |
 
 - Include the hyphen before all logical or comparison operators. The most common operators include:

--- a/exchange/docs-conceptual/v1-module-mfa-connect-to-exo-powershell.md
+++ b/exchange/docs-conceptual/v1-module-mfa-connect-to-exo-powershell.md
@@ -75,11 +75,11 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
   2. In the EAC, go to **Hybrid** > **Setup** and click the appropriate **Configure** button to download the Exchange Online Remote PowerShell Module for multi-factor authentication.
 
-     ![Download the Exchange Online PowerShell Module from the Hybrid tab in the EAC](media/24645e56-8b11-4c0f-ace4-09bdb2703562.png)
+     ![Download the Exchange Online PowerShell Module from the Hybrid tab in the EAC.](media/24645e56-8b11-4c0f-ace4-09bdb2703562.png)
 
   3. In the **Application Install** window that opens, click **Install**.
 
-     ![Click Install in the Exchange Online PowerShell Module window](media/0fd389a1-a32d-4e2f-bf5f-78e9b6407d4c.png)
+     ![Click Install in the Exchange Online PowerShell Module window.](media/0fd389a1-a32d-4e2f-bf5f-78e9b6407d4c.png)
 
 - When you use the Exchange Online Remote PowerShell Module, your session will end after one hour, which can be problematic for long-running scripts or processes. To avoid this issue, use [Trusted IPs](/azure/active-directory/authentication/howto-mfa-mfasettings#trusted-ips) to bypass MFA for connections from your intranet. Trusted IPs allow you to connect to Exchange Online PowerShell from your intranet using the old instructions at [Basic auth - Connect to Exchange Online PowerShell](basic-auth-connect-to-exo-powershell.md). Also, if you have servers in a datacenter, be sure to add their public IP addresses to Trusted IPs as described [here](/azure/active-directory/authentication/howto-mfa-mfasettings#enable-the-trusted-ips-feature-by-using-service-settings).
 
@@ -132,13 +132,13 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 3. In the sign-in window that opens, enter your password, and then click **Sign in**.
 
-   ![Enter your password in the Exchange Online Remote PowerShell window](media/b85d80d9-1043-4c7c-8f14-d87d8d56b188.png)
+   ![Enter your password in the Exchange Online Remote PowerShell window.](media/b85d80d9-1043-4c7c-8f14-d87d8d56b188.png)
 
    A verification code is generated and delivered based on the verification response option that's configured for your account (for example, a text message or the Azure Authenticator app on your mobile phone).
 
 4. In the verification window that opens, enter the verification code, and then click **Sign in**.
 
-   ![Enter your verification code in the Exchange Online Remote PowerShell window](media/d3a405ce-5364-4732-a7bb-2cc9c678da2d.png)
+   ![Enter your verification code in the Exchange Online Remote PowerShell window.](media/d3a405ce-5364-4732-a7bb-2cc9c678da2d.png)
 
 > [!NOTE]
 > Be sure to disconnect the remote PowerShell session when you're finished. If you close the Exchange Online Remote PowerShell Module window without disconnecting the session, you could use up all the remote PowerShell sessions available to you, and you'll need to wait for the sessions to expire. To disconnect all currently open PowerShell sessions in the current window, run the following command:

--- a/exchange/docs-conceptual/v1-module-mfa-connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/v1-module-mfa-connect-to-scc-powershell.md
@@ -84,11 +84,11 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 2. In the EAC, go to **Hybrid** > **Setup** and click the appropriate **Configure** button to download the Exchange Online Remote PowerShell Module for multi-factor authentication.
 
-   ![Download the Exchange Online PowerShell Module from the Hybrid tab in the EAC](media/24645e56-8b11-4c0f-ace4-09bdb2703562.png)
+   ![Download the Exchange Online PowerShell Module from the Hybrid tab in the EAC.](media/24645e56-8b11-4c0f-ace4-09bdb2703562.png)
 
 3. In the **Application Install** window that opens, click **Install**.
 
-   ![Click Install in the Exchange Online PowerShell Module window](media/0fd389a1-a32d-4e2f-bf5f-78e9b6407d4c.png)
+   ![Click Install in the Exchange Online PowerShell Module window.](media/0fd389a1-a32d-4e2f-bf5f-78e9b6407d4c.png)
 
 ## Connect to Security & Compliance Center PowerShell by using MFA or federated authentication
 
@@ -130,13 +130,13 @@ You need to do the following steps in a browser that supports ClickOnce (for exa
 
 3. In the sign-in window that opens, enter your password, and then click **Sign in**.
 
-   ![Enter your password in the Exchange Online Remote PowerShell window](media/b85d80d9-1043-4c7c-8f14-d87d8d56b188.png)
+   ![Enter your password in the Exchange Online Remote PowerShell window.](media/b85d80d9-1043-4c7c-8f14-d87d8d56b188.png)
 
    For MFA, a verification code is generated and delivered based on the verification response option that's configured for your account (for example, a text message or the Azure Authenticator app on your mobile phone).
 
 4. **(MFA only)**: In the verification window that opens, enter the verification code, and then click **Sign in**.
 
-   ![Enter your verification code in the Exchange Online Remote PowerShell window](media/d3a405ce-5364-4732-a7bb-2cc9c678da2d.png)
+   ![Enter your verification code in the Exchange Online Remote PowerShell window.](media/d3a405ce-5364-4732-a7bb-2cc9c678da2d.png)
 
 5. **(Optional)**: If you want to connect to an Exchange Online PowerShell module session in the same window, you need to run
 

--- a/repo_docs/ADVANCED.md
+++ b/repo_docs/ADVANCED.md
@@ -47,11 +47,11 @@ It is highly recommended to turn on two-factor authentication for security, see 
 Fork the GitHub project into your own account so you have a place to work on it. To Fork the project, point your web browser to the repository at
 <https://github.com/MicrosoftDocs/office-docs-powershell> and then click the Fork button on the upper right corner of the repository page as shown in screenshot.
 
-![Image of Fork button on Github](../images/fork_button_on_github.png)
+![Image of Fork button on Github.](../images/fork_button_on_github.png)
 
 You now have your very own copy (fork) of the main Office PowerShell repository. You can see it by clicking on your profile drop-down in the upper right of the page and choosing Your Profile and then clicking the Repositories tab of your GitHub account as shown in the diagram.
 
-![View Your Forked Repos on Github](../images/view_your_forked_repos.png)
+![View Your Forked Repos on Github.](../images/view_your_forked_repos.png)
 
 Your repository is an exact copy of the original Office PowerShell repository and is located in your GitHub account. In GitHub terms the main Office PowerShell repository is the Upstream repository and your forked version is the Downstream repository.
 
@@ -61,7 +61,7 @@ You can update your repository with the Upstream repository at any time and it i
 
 Now that you have your own copy of the repository on GitHub the next step is to get the actual files on your local computer so you can work with them. To do this you clone your GitHub repository to your local computer. Here is a diagram:
 
-![Diagram of repository flow on Github](../images/github_flow.png)
+![Diagram of repository flow on Github.](../images/github_flow.png)
 
 > [!TIP]
 > You can clone your repository to multiple computers if you choose. You just have to make sure you save your local work by pushing it back up to your repository. And vice versa, when you start working on a new computer you have to remember to pull any changes down to your local work computer. This will be described in more detail later on.

--- a/repo_docs/NEW_CMDLETS.md
+++ b/repo_docs/NEW_CMDLETS.md
@@ -318,7 +318,7 @@ When you're done editing the topics, upload them to GitHub. Note that you need t
 
 2. Click **Upload files**
 
-   ![Upload file](../images/upload_files.png)
+   ![Upload file.](../images/upload_files.png)
 
 3. After you're done adding files, go to the **Propose file change** section at the bottom of the page:
 
@@ -327,15 +327,15 @@ When you're done editing the topics, upload them to GitHub. Note that you need t
 
    When you're ready, click the green **Propose file change** button.
 
-   ![Propose file change section](../images/propose-file-change.png)
+   ![Propose file change section.](../images/propose-file-change.png)
 
 4. On the **Comparing changes** page that appears, click the green **Create pull request** button.
 
-   ![Comparing changes page](../images/comparing-changes-page.png)
+   ![Comparing changes page.](../images/comparing-changes-page.png)
 
 5. On the **Open a pull request** page that appears, click the green **Create pull request** button.
 
-   ![Open a pull request page](../images/open-a-pull-request-page.png)
+   ![Open a pull request page.](../images/open-a-pull-request-page.png)
 
 > [!NOTE]
 >
@@ -378,15 +378,15 @@ After you're done editing the TOC files:
 
    When you're ready, click the green **Propose file change** button.
 
-   ![Propose file change section](../images/propose-file-change.png)
+   ![Propose file change section.](../images/propose-file-change.png)
 
 2. On the **Comparing changes** page that appears, click the green **Create pull request** button.
 
-   ![Comparing changes page](../images/comparing-changes-page.png)
+   ![Comparing changes page.](../images/comparing-changes-page.png)
 
 3. On the **Open a pull request** page that appears, click the green **Create pull request** button.
 
-   ![Open a pull request page](../images/open-a-pull-request-page.png)
+   ![Open a pull request page.](../images/open-a-pull-request-page.png)
 
 > [!NOTE]
 >

--- a/repo_docs/UPDATE_CMDLETS.md
+++ b/repo_docs/UPDATE_CMDLETS.md
@@ -148,15 +148,15 @@ At this point, the steps are basically identical to [Short URL: aka.ms/office-po
 
    When you're ready, click the green **Propose file change** button.
 
-   ![Propose file change section](../images/propose-file-change.png)
+   ![Propose file change section.](../images/propose-file-change.png)
 
 5. On the **Comparing changes** page that appears, click the green **Create pull request** button.
 
-   ![Comparing changes page](../images/comparing-changes-page.png)
+   ![Comparing changes page.](../images/comparing-changes-page.png)
 
 6. On the **Open a pull request** page that appears, click the green **Create pull request** button.
 
-   ![Open a pull request page](../images/open-a-pull-request-page.png)
+   ![Open a pull request page.](../images/open-a-pull-request-page.png)
 
 > [!NOTE]
 >

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTheme.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTheme.md
@@ -76,7 +76,7 @@ Get-SPOTheme
 
 This is an example of the output from this command.
 
-![Get-SPOTheme example](../../images/Get-SPOTheme-example.png)-->
+![Get-SPOTheme example.](../../images/Get-SPOTheme-example.png)-->
 
 ## INPUTS
 


### PR DESCRIPTION
Alt text for images are supposed to terminate with periods. This PR applies periods to alt text by using the Cleanup script in the Docs Authoring Pack. There are no other types of changes in this PR.