### PR TITLE
Get-SPOTenant properties not documented

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenant.md
@@ -28,6 +28,8 @@ The `Get-SPOTenant` cmdlet returns organization-level site collection properties
 
 Currently, there are no parameters for this cmdlet.
 
+
+
 You must be a SharePoint Online administrator or Global Administrator to run the cmdlet.
 
 For permissions and the most current information about Windows PowerShell for SharePoint Online, see the online documentation at [Intro to SharePoint Online Management Shell](https://docs.microsoft.com/powershell/sharepoint/sharepoint-online/introduction-sharepoint-online-management-shell?view=sharepoint-ps).


### PR DESCRIPTION
When running Get-SPOTenant the following properties show up and are lacking documentation. 

SyncPrivacyProfileProperties 
EmailAttestationRequired
EmailAttestationReAuthDays
StorageQuota (confirmation on Unit)
SyncPrivacyProfileProperties