### PR TITLE
PermanentlyClearPreviousMailboxInfo

### DIFF
--- a/exchange/exchange-ps/exchange/Set-User.md
+++ b/exchange/exchange-ps/exchange/Set-User.md
@@ -766,9 +766,9 @@ Accept wildcard characters: False
 ```
 
 ### -PermanentlyClearPreviousMailboxInfo
-This parameter is available or functional only in on-premise Exchange.
+This parameter is not available or functional in on-premises Exchange. It is only available in Exchange Online.
 
-The PermanentlyClearPreviousMailboxInfo switch specifies whether to clear the Exchange mailbox attributes on a user. You don't need to specify a value with this switch.
+The PermanentlyClearPreviousMailboxInfo switch specifies whether to clear the Exchange Online mailbox attributes on a user. You don't need to specify a value with this switch.
 
 Clearing these attributes might be required in mailbox move and re-licensing scenarios between on-premises Exchange and Microsoft 365. For more information, see [Permanently Clear Previous Mailbox Info](https://techcommunity.microsoft.com/t5/exchange-team-blog/permanently-clear-previous-mailbox-info/ba-p/607619).
 


### PR DESCRIPTION
I believe the published info is incorrect.  The parameter is only valid for Exchange Online, per the associated blog post.