### PR TITLE
Application parameter incorrect

### DIFF
--- a/exchange/exchange-ps/exchange/New-RetentionCompliancePolicy.md
+++ b/exchange/exchange-ps/exchange/New-RetentionCompliancePolicy.md
@@ -99,8 +99,8 @@ The Applications parameter specifies the target when Microsoft 365 Groups are in
 
 - `Group:Exchange` for the mailbox that's connected to the Microsoft 365 Group.
 - `Group:SharePoint` for the SharePoint site that's connected to the Microsoft 365 Group.
-- `"Group:Exchange","Group:SharePoint"` for both the mailbox and the SharePoint site that are connected to the Microsoft 365 Group.
-- blank (`$null`): This is the default value, and is functionally equivalent to the value `"Group:Exchange","Group:SharePoint"`.
+- `"Group:Exchange,SharePoint"` for both the mailbox and the SharePoint site that are connected to the Microsoft 365 Group.
+- blank (`$null`): This is the default value, and is functionally equivalent to the value `"Group:Exchange,SharePoint"`. To return to the default value of both the mailbox and SharePoint site for the selected Microsoft 365 groups, specify `"Group:Exchange,SharePoint"`.
 
 ```yaml
 Type: MultiValuedProperty

--- a/exchange/exchange-ps/exchange/New-RetentionCompliancePolicy.md
+++ b/exchange/exchange-ps/exchange/New-RetentionCompliancePolicy.md
@@ -100,7 +100,7 @@ The Applications parameter specifies the target when Microsoft 365 Groups are in
 - `Group:Exchange` for the mailbox that's connected to the Microsoft 365 Group.
 - `Group:SharePoint` for the SharePoint site that's connected to the Microsoft 365 Group.
 - `"Group:Exchange,SharePoint"` for both the mailbox and the SharePoint site that are connected to the Microsoft 365 Group.
-- blank (`$null`): This is the default value, and is functionally equivalent to the value `"Group:Exchange,SharePoint"`. To return to the default value of both the mailbox and SharePoint site for the selected Microsoft 365 groups, specify `"Group:Exchange,SharePoint"`.
+- blank (`$null`): This is the default value, and is functionally equivalent to the value `"Group:Exchange,SharePoint"`.
 
 ```yaml
 Type: MultiValuedProperty


### PR DESCRIPTION
Accepted value for Exchange & SharePoint location in M365 group is `New-RetentionCompliancePolicy [identity] -Applications "Group:Exchange,SharePoint"`.  Current value will not be accepted.  See [https://docs.microsoft.com/en-us/microsoft-365/compliance/create-retention-policies?view=o365-worldwide#configuration-information-for-microsoft-365-groups](https://docs.microsoft.com/en-us/microsoft-365/compliance/create-retention-policies?view=o365-worldwide#configuration-information-for-microsoft-365-groups)