### PR TITLE
Update Get/Set-VivaInsightsSettings to include Meeting Effectiveness Survey feature

### DIFF
--- a/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
+++ b/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
@@ -52,7 +52,7 @@ IsInsightsHeadspaceEnabled : True
 This example shows the configuration of Microsoft Viva Insights in Microsoft Teams for the user roy@contoso.onmicrosoft.com. The output of the command shows that the features of Headspace are available to Roy.
 
 ### Example 2
-**Note**: This output is available only in version 2.0.6-Preview1 or later of the EXO V2 module. This output will not show unless you belong to the Private Preview.
+
 ```powershell
 PS C:\> Get-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com
 
@@ -61,16 +61,20 @@ IsInsightsHeadspaceEnabled : True
 MeetingEffectivenessMode : Enabled
 ```
 
+**Note**: This example is available only in version 2.0.6-Preview1 or later of the EXO V2 module, and only if you belong to the Private Preview for Meeting Effectiveness Survey.
+
 This example shows the configuration of Microsoft Viva Insights in Microsoft Teams for the user roy@contoso.onmicrosoft.com. The output of the command shows that the features of Headspace and Meeting Effectiveness Survey are available to Roy.
 
 ### Example 3
-**Note**: This syntax is available only in version 2.0.6-Preview1 or later of the EXO V2 module. The syntax will not work unless you belong to the Private Preview.
+
 ```powershell
 PS C:\> Get-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com -Feature MeetingEffectivenessSurvey
 
 UserId : roy@contoso.onmicrosoft.com
 MeetingEffectivenessMode : Enabled
 ```
+
+**Note**: This example is available only in version 2.0.6-Preview1 or later of the EXO V2 module, and only if you belong to the Private Preview for Meeting Effectiveness Survey.
 
 This example shows the configuration of Microsoft Viva Insights in Microsoft Teams, specifically for the Meeting Effectiveness Survey feature, for the user roy@contoso.onmicrosoft.com. The output of the command shows that the features of Meeting Effectiveness Survey are available to Roy.
 
@@ -93,12 +97,14 @@ Accept wildcard characters: False
 ```
 
 ### -Feature
+**Note**: This parameter is available only in version 2.0.6-Preview1 or later of the EXO V2 module. The parameter will not work unless you belong to the Private Preview for Meeting Effectiveness Survey.
 
-**Note**: This parameter is available only in version 2.0.6-Preview1 or later of the EXO V2 module. The parameter will not work unless you belong to the Private Preview.\
-The optional Feature parameter specifies feature of Microsoft Viva Insights in Microsoft Teams for the user. If this parameter is omitted, the configurations for all Microsoft Viva Insights features will be displayed. Current valid values are:
+The Feature parameter filters the results by the feature of Microsoft Viva Insights in Microsoft Teams for the user. Valid values are:
 
-- headspace: Represents all features of Headspace.
-- meetingeffectivenesssurvey: Represents all features of Meeting Effectiveness Survey.
+- headspace: All features of Headspace.
+- meetingeffectivenesssurvey: All features of Meeting Effectiveness Survey.
+
+If you don't use this parameter, the configurations for all Microsoft Viva Insights features are displayed.
 
 ```yaml
 Type: String

--- a/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
+++ b/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
@@ -24,6 +24,7 @@ For information about the parameter sets in the Syntax section below, see [Excha
 
 ```
 Get-VivaInsightsSettings -Identity <String>
+ [-Feature <String>]
  [-ResultSize <Unlimited>]
  [<CommonParameters>]
 ```
@@ -34,6 +35,7 @@ This cmdlet requires the .NET Framework 4.7.2 or later. To run this cmdlet, you 
 - Global Administrator
 - Exchange Administrator
 - Teams Administrator
+- Insights Administrator
 
 To learn more about administrator role permissions in Azure Active Directory, see [Role template IDs](https://docs.microsoft.com/azure/active-directory/roles/permissions-reference#role-template-ids).
 
@@ -49,6 +51,29 @@ IsInsightsHeadspaceEnabled : True
 
 This example shows the configuration of Microsoft Viva Insights in Microsoft Teams for the user roy@contoso.onmicrosoft.com. The output of the command shows that the features of Headspace are available to Roy.
 
+### Example 2
+**Note**: This output is available only in version 2.0.6-Preview1 or later of the EXO V2 module. This output will not show unless you belong to the Private Preview.
+```powershell
+PS C:\> Get-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com
+
+UserId : roy@contoso.onmicrosoft.com
+IsInsightsHeadspaceEnabled : True
+MeetingEffectivenessMode : Enabled
+```
+
+This example shows the configuration of Microsoft Viva Insights in Microsoft Teams for the user roy@contoso.onmicrosoft.com. The output of the command shows that the features of Headspace and Meeting Effectiveness Survey are available to Roy.
+
+### Example 3
+**Note**: This syntax is available only in version 2.0.6-Preview1 or later of the EXO V2 module. The syntax will not work unless you belong to the Private Preview.
+```powershell
+PS C:\> Get-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com -Feature MeetingEffectivenessSurvey
+
+UserId : roy@contoso.onmicrosoft.com
+MeetingEffectivenessMode : Enabled
+```
+
+This example shows the configuration of Microsoft Viva Insights in Microsoft Teams, specifically for the Meeting Effectiveness Survey feature, for the user roy@contoso.onmicrosoft.com. The output of the command shows that the features of Meeting Effectiveness Survey are available to Roy.
+
 ## PARAMETERS
 
 ### -Identity
@@ -61,6 +86,27 @@ Aliases:
 Applicable: Exchange Online
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Feature
+
+**Note**: This parameter is available only in version 2.0.6-Preview1 or later of the EXO V2 module. The parameter will not work unless you belong to the Private Preview.\
+The optional Feature parameter specifies feature of Microsoft Viva Insights in Microsoft Teams for the user. If this parameter is omitted, the configurations for all Microsoft Viva Insights features will be displayed. Current valid values are:
+
+- headspace: Represents all features of Headspace.
+- meetingeffectivenesssurvey: Represents all features of Meeting Effectiveness Survey.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Exchange Online
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
+++ b/exchange/exchange-ps/exchange/Get-VivaInsightsSettings.md
@@ -104,6 +104,7 @@ The optional Feature parameter specifies feature of Microsoft Viva Insights in M
 Type: String
 Parameter Sets: (All)
 Aliases:
+Accepted values: headspace, meetingeffectivenesssurvey
 Applicable: Exchange Online
 
 Required: False

--- a/exchange/exchange-ps/exchange/Set-VivaInsightsSettings.md
+++ b/exchange/exchange-ps/exchange/Set-VivaInsightsSettings.md
@@ -34,6 +34,7 @@ This cmdlet requires the .NET Framework 4.7.2 or later. To run this cmdlet, you 
 - Global Administrator
 - Exchange Administrator
 - Teams Administrator
+- Insights Administrator
 
 To learn more about administrator role permissions in Azure Active Directory, see [Role template IDs](https://docs.microsoft.com/azure/active-directory/roles/permissions-reference#role-template-ids).
 
@@ -45,6 +46,14 @@ Set-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com -Enabled $false -
 ```
 
 This example disables access to all the Headspace features in Microsoft Viva Insights in Microsoft Teams for the specified user.
+
+### Example 2
+**Note**: This output is available only in version 2.0.6-Preview1 or later of the EXO V2 module. This output will not show unless you belong to the Private Preview.
+```powershell
+Set-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com -Enabled $false -Feature meetingeffectivenesssurvey
+```
+
+This example disables access to all the Meeting Effectiveness Survey features in Microsoft Viva Insights in Microsoft Teams for the specified user.
 
 ## PARAMETERS
 
@@ -87,12 +96,13 @@ Accept wildcard characters: False
 The Feature parameter specifies feature of Microsoft Viva Insights in Microsoft Teams for the user. Current valid values are:
 
 - headspace: Represents all features of Headspace.
+- meetingeffectivenesssurvey: Represents all features of Meeting Effectiveness Survey.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
-Accepted values: headspace
+Accepted values: headspace, meetingeffectivenesssurvey
 Applicable: Exchange Online
 
 Required: True

--- a/exchange/exchange-ps/exchange/Set-VivaInsightsSettings.md
+++ b/exchange/exchange-ps/exchange/Set-VivaInsightsSettings.md
@@ -48,10 +48,10 @@ Set-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com -Enabled $false -
 This example disables access to all the Headspace features in Microsoft Viva Insights in Microsoft Teams for the specified user.
 
 ### Example 2
-**Note**: This output is available only in version 2.0.6-Preview1 or later of the EXO V2 module. This output will not show unless you belong to the Private Preview.
 ```powershell
 Set-VivaInsightsSettings -Identity roy@contoso.onmicrosoft.com -Enabled $false -Feature meetingeffectivenesssurvey
 ```
+**Note**: This example is available only in version 2.0.6-Preview1 or later of the EXO V2 module, and only if you belong to the Private Preview for Meeting Effectiveness Survey.
 
 This example disables access to all the Meeting Effectiveness Survey features in Microsoft Viva Insights in Microsoft Teams for the specified user.
 
@@ -93,10 +93,10 @@ Accept wildcard characters: False
 ```
 
 ### -Feature
-The Feature parameter specifies feature of Microsoft Viva Insights in Microsoft Teams for the user. Current valid values are:
+The Feature parameter specifies feature of Microsoft Viva Insights in Microsoft Teams for the user. Valid values are:
 
-- headspace: Represents all features of Headspace.
-- meetingeffectivenesssurvey: Represents all features of Meeting Effectiveness Survey.
+- headspace: All features of Headspace.
+- meetingeffectivenesssurvey: All features of Meeting Effectiveness Survey. This value is available only in version 2.0.6-Preview1 or later of the EXO V2 module, and is effective only if you belong to the Private Preview for Meeting Effectiveness Survey.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Adding a new feature under VivaInsightsSettings called "Meeting Effectiveness Survey". Admins can get/set a users meeting effectiveness survey configuration.

Expanding Get-VivaInsightsSettings to have an optional -Feature parameter that lets Admins get only the configuration for a specific feature. If the -Feature parameter is omitted, it will simply Get all settings.

This will be included in 2.0.6-Preview1 onwards.