### PR TITLE
Update New-ApplicationAccessPolicy.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-ApplicationAccessPolicy.md
+++ b/exchange/exchange-ps/exchange/New-ApplicationAccessPolicy.md
@@ -123,7 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyScopeGroupID
-The PolicyScopeGroupID parameter specifies the recipient to define in the policy. You can use any value that uniquely identifies the recipient. You can also specify a mail enabled security group to restrict/deny access to a large number of user mailboxes.
+The PolicyScopeGroupID parameter specifies the recipient to define in the policy. You can use any value that uniquely identifies the recipient. You can also specify a mail enabled security group to restrict/deny access to more than one user mailbox.
 For example:
 
 - Name


### PR DESCRIPTION
Clarified remark for the PolicyScopeGroupId param so it's clear that only one ACLable object may be entered (else a security enabled group).

Was unclear that multiple objects could not be specified.