### PR TITLE
Details about New MeetingRecordingExpirationDays

### DIFF
--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -955,7 +955,9 @@ Accept wildcard characters: False
 ### -NewMeetingRecordingExpirationDays
 Specifies the number of days before meeting recordings will expire and move to the recycle bin. Value can be from 1 to 99,999 days. Value can also be -1 to set meeting recordings to never expire.
 
-Note: This parameter isn't yet available to be set. We'll publish an updated message center post when the setting is available for modification. Please refer to the [roadmap (Feature ID: 84580)](https://www.microsoft.com/microsoft-365/roadmap?searchterms=82057&filters=&searchterms=84580) for more information on its delivery date.
+NOTE: You may opt to set Meeting Recordings to never expire by entering the value -1.
+
+NOTE: This parameter is available to be set, but will not be effective until this feature gets general availability. Please refer to the [roadmap (Feature ID: 84580)](https://www.microsoft.com/microsoft-365/roadmap?filters=&searchterms=84580) for more information on its delivery date.
 
 ```yaml
 Type: Int32


### PR DESCRIPTION
It appears parameter MeetingRecordingExpirationDays has been replaced with It appears Set-CsTeamsMeetingPolicy has a new parameter NewMeetingRecordingExpirationDays

![image](https://user-images.githubusercontent.com/5260172/137218705-afff6654-04c6-40f9-a381-d21a8d93dfba.png)

![image](https://user-images.githubusercontent.com/5260172/137218747-17cd74f5-2080-4e32-8635-c6a1f14c1ec9.png)

And it keeps the changes:
![image](https://user-images.githubusercontent.com/5260172/137218806-6ece4779-e358-4d7e-b08d-f1a8f90e9fc8.png)
