### PR TITLE
Update New-DlpCompliancePolicy.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-DlpCompliancePolicy.md
+++ b/exchange/exchange-ps/exchange/New-DlpCompliancePolicy.md
@@ -24,8 +24,6 @@ For information about the parameter sets in the Syntax section below, see [Excha
 New-DlpCompliancePolicy [-Name] <String>
  [-Comment <String>]
  [-Confirm]
- [-EndpointDlpLocation <MultiValuedProperty>]
- [-EndpointDlpLocationException <MultiValuedProperty>]
  [-ExceptIfOneDriveSharedBy <RecipientIdParameter[]>]
  [-ExceptIfOneDriveSharedByMemberOf <RecipientIdParameter[]>]
  [-ExchangeLocation <MultiValuedProperty>]
@@ -33,6 +31,8 @@ New-DlpCompliancePolicy [-Name] <String>
  [-ExchangeSenderMemberOfException <RecipientIdParameter[]>]
  [-Force]
  [-Mode <PolicyMode>]
+ [-OneDriveLocation <MultiValuedProperty>]
+ [-OneDriveLocationException <MultiValuedProperty>]
  [-OneDriveSharedBy <RecipientIdParameter[]>]
  [-OneDriveSharedByMemberOf <RecipientIdParameter[]>]
  [-OnPremisesScannerDlpLocation <MultiValuedProperty>]
@@ -44,8 +44,6 @@ New-DlpCompliancePolicy [-Name] <String>
  [-SharePointServerLocation <MultiValuedProperty>]
  [-TeamsLocation <MultiValuedProperty>]
  [-TeamsLocationException <MultiValuedProperty>]
- [-ThirdPartyAppDlpLocation <MultiValuedProperty>]
- [-ThirdPartyAppDlpLocationException <MultiValuedProperty>]
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -122,47 +120,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -EndpointDlpLocation
-The EndpointDLPLocation parameter specifies the user accounts to include in the DLP policy when they are logged on to an onboarded device. You identify the account by name or email address. You can use the value All for this parameter to include all user accounts.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: (All)
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EndpointDlpLocationException
-The EndpointDlpLocationException parameter specifies the user accounts to exclude when you use the value All for the EndpointDlpLocation parameter. You identify the account by name or email address.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: (All)
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -ExceptIfOneDriveSharedBy
 The ExceptIfOneDriveSharedBy parameter specifies the users to exclude in the DLP policy. You identify the user by its email address.
 
 To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`.
-
 
 ```yaml
 Type: RecipientIdParameter[]
@@ -194,7 +155,6 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
-
 
 ### -ExchangeLocation
 The ExchangeLocation parameter specifies Exchange Online mailboxes to include in the DLP policy. You can only use the value All for this parameter to include all mailboxes.
@@ -252,7 +212,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -Force
 The Force switch specifies whether to suppress warning or confirmation messages. You can use this switch to run tasks programmatically where prompting for administrative input is inappropriate. You don't need to specify a value with this switch.
 
@@ -290,11 +249,40 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OneDriveLocation
+Don't use this parameter. Use the OneDriveSharedBy and OneDriveSharedByMemberOf parameters instead.
+
+```yaml
+Type: MultiValuedProperty
+Parameter Sets: (All)
+Aliases:
+Applicable: Security & Compliance Center
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OneDriveLocationException
+Don't use this parameter. Use the ExceptIfOneDriveSharedBy and ExceptIfOneDriveSharedByMemberOf parameters instead.
+
+```yaml
+Type: MultiValuedProperty
+Parameter Sets: (All)
+Aliases:
+Applicable: Security & Compliance Center
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OneDriveSharedBy
 The OneDriveSharedBy parameter specifies the users to include in the DLP policy. You identify the user by email address.
 
 To enter multiple values, use the following syntax: `<value1>,<value2>,...<valueX>`.
-
 
 ```yaml
 Type: RecipientIdParameter[]
@@ -473,38 +461,6 @@ Accept wildcard characters: False
 The TeamsLocation parameter specifies the Teams accounts to exclude form the DLP policy when you use the value All for the TeamsLocation parameter. You identify the account by its name or email address.
 
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: (All)
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ThirdPartyAppDlpLocation
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: (All)
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ThirdPartyAppDlpLocationException
-This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: MultiValuedProperty

--- a/exchange/exchange-ps/exchange/Set-DlpCompliancePolicy.md
+++ b/exchange/exchange-ps/exchange/Set-DlpCompliancePolicy.md
@@ -23,8 +23,6 @@ For information about the parameter sets in the Syntax section below, see [Excha
 ### Identity
 ```
 Set-DlpCompliancePolicy [-Identity] <PolicyIdParameter>
- [-AddEndpointDlpLocation <MultiValuedProperty>]
- [-AddEndpointDlpLocationException <MultiValuedProperty>]
  [-AddExchangeLocation <MultiValuedProperty>]
  [-AddOneDriveLocation <MultiValuedProperty>]
  [-AddOneDriveLocationException <MultiValuedProperty>]
@@ -34,8 +32,6 @@ Set-DlpCompliancePolicy [-Identity] <PolicyIdParameter>
  [-AddSharePointLocationException <MultiValuedProperty>]
  [-AddTeamsLocation <MultiValuedProperty>]
  [-AddTeamsLocationException <MultiValuedProperty>]
- [-AddThirdPartyAppDlpLocation <MultiValuedProperty>]
- [-AddThirdPartyAppDlpLocationException <MultiValuedProperty>]
  [-Comment <String>]
  [-Confirm]
  [-ExceptIfOneDriveSharedBy <RecipientIdParameter[]>]
@@ -47,8 +43,6 @@ Set-DlpCompliancePolicy [-Identity] <PolicyIdParameter>
  [-OneDriveSharedBy <RecipientIdParameter[]>]
  [-OneDriveSharedByMemberOf <RecipientIdParameter[]>]
  [-Priority <Int32>]
- [-RemoveEndpointDlpLocation <MultiValuedProperty>]
- [-RemoveEndpointDlpLocationException <MultiValuedProperty>]
  [-RemoveExchangeLocation <MultiValuedProperty>]
  [-RemoveOneDriveLocation <MultiValuedProperty>]
  [-RemoveOneDriveLocationException <MultiValuedProperty>]
@@ -58,8 +52,6 @@ Set-DlpCompliancePolicy [-Identity] <PolicyIdParameter>
  [-RemoveSharePointLocationException <MultiValuedProperty>]
  [-RemoveTeamsLocation <MultiValuedProperty>]
  [-RemoveTeamsLocationException <MultiValuedProperty>]
- [-RemoveThirdPartyAppDlpLocation <MultiValuedProperty>]
- [-RemoveThirdPartyAppDlpLocationException <MultiValuedProperty>]
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -134,42 +126,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -AddEndpointDlpLocation
-The AddEndpointDLPLocation parameter specifies the user accounts to add to the list of included accounts when you aren't using the value All for the EndpointDLPLocation parameter. You identify the account by name or email address.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AddEndpointDlpLocationException
-The AddEndpointDlpLocationException parameter specifies the user accounts to add to the list of excluded accounts when you use the value All for the EndpointDLPLocation parameter. You identify the account by name or email address.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -AddExchangeLocation
 This parameter is reserved for internal Microsoft use.
 
@@ -187,9 +143,7 @@ Accept wildcard characters: False
 ```
 
 ### -AddOneDriveLocation
-The AddOneDriveLocation parameter specifies the OneDrive for Business sites to add to the list of included sites when you aren't using the value All for the OneDriveLocation parameter. You identify the site by its URL value.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
+Don't use this parameter. Use the OneDriveSharedBy and OneDriveSharedByMemberOf parameters instead.
 
 ```yaml
 Type: MultiValuedProperty
@@ -205,9 +159,7 @@ Accept wildcard characters: False
 ```
 
 ### -AddOneDriveLocationException
-This parameter specifies the OneDrive for Business sites to add to the list of excluded sites when you use the value All for the OneDriveLocation parameter. You identify the site by its URL value.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
+Don't use this parameter. Use the OneDriveSharedBy and OneDriveSharedByMemberOf parameters instead.
 
 ```yaml
 Type: MultiValuedProperty
@@ -314,38 +266,6 @@ Accept wildcard characters: False
 The AddTeamsLocationException parameter specifies the Teams accounts to add to the list of excluded accounts when you use the value All for the TeamsLocation parameter. You identify the account by its name or email address.
 
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AddThirdPartyAppDlpLocation
-{{ Fill AddThirdPartyAppDlpLocation Description }}
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -AddThirdPartyAppDlpLocationException
-{{ Fill AddThirdPartyAppDlpLocationException Description }}
 
 ```yaml
 Type: MultiValuedProperty
@@ -568,42 +488,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RemoveEndpointDlpLocation
-The RemoveEndpointDlpLocation parameter specifies the user accounts to remove from the list of included accounts when you aren't using the value All for the EndpointDLPLocation parameter. You identify the account by name or email address.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RemoveEndpointDlpLocationException
-The RemoveEndpointDlpLocation parameter specifies the user accounts to remove from the list of excluded accounts when you use the value All for the EndpointDLPLocation parameter. You identify the account by name or email address.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -RemoveExchangeLocation
 This parameter is reserved for internal Microsoft use.
 
@@ -621,9 +505,7 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveOneDriveLocation
-The RemoveOneDriveLocation parameter specifies the OneDrive for Business sites to remove from the list of included sites when you aren't using the value All for the OneDriveLocation parameter. You identify the site by its URL value.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
+Don't use this parameter. Use the OneDriveSharedBy and OneDriveSharedByMemberOf parameters instead.
 
 ```yaml
 Type: MultiValuedProperty
@@ -639,9 +521,7 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveOneDriveLocationException
-This parameter specifies the OneDrive for Business sites to remove from the list of excluded sites when you use the value All for the OneDriveLocation parameter. You identify the site by its URL value.
-
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
+Don't use this parameter. Use the OneDriveSharedBy and OneDriveSharedByMemberOf parameters instead.
 
 ```yaml
 Type: MultiValuedProperty
@@ -746,38 +626,6 @@ Accept wildcard characters: False
 The RemoveTeamsLocation parameter specifies the Teams accounts to remove from the list of excluded accounts when you aren't using the value All for the TeamsLocation parameter. You identify the account by its name or email address.
 
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RemoveThirdPartyAppDlpLocation
-{{ Fill RemoveThirdPartyAppDlpLocation Description }}
-
-```yaml
-Type: MultiValuedProperty
-Parameter Sets: Identity
-Aliases:
-Applicable: Security & Compliance Center
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RemoveThirdPartyAppDlpLocationException
-{{ Fill RemoveThirdPartyAppDlpLocationException Description }}
 
 ```yaml
 Type: MultiValuedProperty


### PR DESCRIPTION
OneDrive policy scoping on UX is now through users & groups. While OneDriveLocation is still supported through powershell, OneDriveSharedBy & SharedByMemberOf should be used