### PR TITLE
Update Set-Mailbox.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Set-Mailbox.md
@@ -2498,7 +2498,7 @@ Valid syntax for this parameter is `"Type:EmailAddress1","Type:EmailAddress2",..
 - SMTP: The primary SMTP address. You can use this value only once in a command.
 - smtp: Other SMTP email addresses.
 - X400: X.400 addresses in on-premises Exchange.
-- X500: X.500 addresses in on-premises Exchange.
+- X500: X500 addresses in on-premises Exchange.
 
 If you don't include a Type value for an email address, the value smtp is assumed. Note that Exchange doesn't validate the syntax of custom address types (including X.400 addresses). Therefore, you need to verify that any custom addresses are formatted correctly.
 


### PR DESCRIPTION
We HAVE to stop referencing X500 addresses as X.500. There is no period between X and 500. There never has been one. X500 addresses are used to represent LegacyExchangeDN addresses across orgs. If someone enters a LegacyExchangeDN address as an X.500 address, it will NOT be recognized by Exchange!