### PR TITLE
Add DiscoveryHolds value and its description for 'SourceFolder' param.

### DIFF
--- a/exchange/exchange-ps/exchange/Get-RecoverableItems.md
+++ b/exchange/exchange-ps/exchange/Get-RecoverableItems.md
@@ -245,7 +245,7 @@ Accept wildcard characters: False
 The SourceFolder parameter specifies where to search for deleted items in the mailbox. Valid values are:
 
 - DeletedItems: The Deleted Items folder.
-- DiscoveryHolds: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold.
+- DiscoveryHoldsItems: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold.
 - RecoverableItems: The Recoverable Items\Deletions folder. This folder contains items that have been deleted from the Deleted Items folder (soft-deleted items).
 - PurgedItems: The Recoverable Items\Purges folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items).
 
@@ -255,7 +255,6 @@ If you don't use this parameter, the command will search all of these folders.
 Type: RecoverableItemsFolderType
 Parameter Sets: (All)
 Aliases:
-Accepted values: DeletedItems | DiscoveryHolds | RecoverableItems | PurgedItems
 Applicable: Exchange Server 2016, Exchange Server 2019, Exchange Online
 
 Required: False

--- a/exchange/exchange-ps/exchange/Get-RecoverableItems.md
+++ b/exchange/exchange-ps/exchange/Get-RecoverableItems.md
@@ -245,6 +245,7 @@ Accept wildcard characters: False
 The SourceFolder parameter specifies where to search for deleted items in the mailbox. Valid values are:
 
 - DeletedItems: The Deleted Items folder.
+- DiscoveryHolds: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold.
 - RecoverableItems: The Recoverable Items\Deletions folder. This folder contains items that have been deleted from the Deleted Items folder (soft-deleted items).
 - PurgedItems: The Recoverable Items\Purges folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items).
 
@@ -254,7 +255,7 @@ If you don't use this parameter, the command will search all of these folders.
 Type: RecoverableItemsFolderType
 Parameter Sets: (All)
 Aliases:
-Accepted values: DeletedItems | RecoverableItems | PurgedItems
+Accepted values: DeletedItems | DiscoveryHolds | RecoverableItems | PurgedItems
 Applicable: Exchange Server 2016, Exchange Server 2019, Exchange Online
 
 Required: False

--- a/exchange/exchange-ps/exchange/Restore-RecoverableItems.md
+++ b/exchange/exchange-ps/exchange/Restore-RecoverableItems.md
@@ -307,6 +307,7 @@ Accept wildcard characters: False
 The SourceFolder parameter specifies where to search for deleted items in the mailbox. Valid values are:
 
 - DeletedItems: The Deleted Items folder.
+- DiscoveryHoldsItems: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold.
 - RecoverableItems: The Recoverable Items\Deletions folder. This folder contains items that have been deleted from the Deleted Items folder (soft-deleted items).
 - PurgedItems: The Recoverable Items\Purges folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items).
 
@@ -316,7 +317,6 @@ If you don't use this parameter, the command will search all of these folders.
 Type: RecoverableItemsFolderType
 Parameter Sets: OnPrem
 Aliases:
-Accepted values: DeletedItems | RecoverableItems, DeletedItems | RecoverableItems | PurgedItems
 Applicable: Exchange Server 2016, Exchange Server 2019
 
 Required: False


### PR DESCRIPTION

1. Add to 'SourceFolder' parameter valid values description:

- DiscoveryHolds: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold.

2. Add 'DiscoveryHolds' to accepted values list:

Accepted values: DeletedItems | DiscoveryHolds | RecoverableItems | PurgedItems