### PR TITLE
Fix spaces from line in Set-CsPhoneNumberAssignment

### DIFF
--- a/teams/teams-ps/teams/Set-CsPhoneNumberAssignment.md
+++ b/teams/teams-ps/teams/Set-CsPhoneNumberAssignment.md
@@ -24,7 +24,7 @@ This cmdlet will assign a phone number to a user or a resource account (online a
 ```powershell
 Set-CsPhoneNumberAssignment -Identity <String> -PhoneNumber <String> -PhoneNumberType <String> -LocationId <String> [<CommonParameters>]
 ```
-  
+
 ### Attribute
 ```powershell
 Set-CsPhoneNumberAssignment -Identity <String> -EnterpriseVoice <Boolean> [<CommonParameters>]


### PR DESCRIPTION
There was a blank line with 2 spaces on it. That makes PlatyPS throw up, so removing the 2 spaces