### PR TITLE
Update Set-Place.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-Place.md
+++ b/exchange/exchange-ps/exchange/Set-Place.md
@@ -250,8 +250,8 @@ Accept wildcard characters: False
 ### -GeoCoordinates
 The GeoCoordinates parameter specifies the room's location in latitude, longitude and (optionally) altitude coordinates. A valid value for this parameter uses one of the following formats:
 
-- Latitude and longitude: For example, "47,644125;-122,122411"
-- Latitude, longitude, and altitude: For example, "47,644125;-122,122411;161,432"
+- Latitude and longitude: For example, "47.644125;-122.122411"
+- Latitude, longitude, and altitude: For example, "47.644125;-122.122411;161,432"
 
 ```yaml
 Type: GeoCoordinates


### PR DESCRIPTION
After some testing, we found that the entries for the GeoCoordinates parameter need to use period separators, instead of commas, e.g.:
Set-Place: Cannot process argument transformation on parameter 'GeoCoordinates'. Cannot convert value "48,643546;-122,12316" to type "Microsoft.Exchange.Data.GeoCoordinates". Error: "The latitude specified in '48,643546;-122,12316' is invalid. Latitude must be a number between -90.0 and 90.0."