### PR TITLE
Update links in -AllowAnonymousUsersToJoinMeeting param documentation.

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -86,7 +86,7 @@ Accept wildcard characters: False
 ### -AllowAnonymousUsersToJoinMeeting
 
 > [!NOTE]
-> The experience for users is dependent on both the value of -DisableAnonymousJoin (the old tenant-wide setting) and -AllowAnonymousUsersToJoinMeeting (the new per-organizer policy). Please check https://docs.microsoft.com/microsoftteams/meeting-policies-participants-and-guests for details.
+> The experience for users is dependent on both the value of -DisableAnonymousJoin (the old tenant-wide setting) and -AllowAnonymousUsersToJoinMeeting (the new per-organizer policy). Please check https://docs.microsoft.com/microsoftteams/meeting-settings-in-teams for details.
 
 Determines whether anonymous users can join the meetings that impacted users organize. Set this to TRUE to allow anonymous users to join a meeting. Set this to FALSE to prohibit them from joining a meeting. 
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -98,7 +98,7 @@ All other policy properties will use the existing values.
 ### -AllowAnonymousUsersToJoinMeeting
 
 > [!NOTE]
-> The experience for users is dependent on both the value of -DisableAnonymousJoin (the old tenant-wide setting) and -AllowAnonymousUsersToJoinMeeting (the new per-organizer policy). Please check https://docs.microsoft.com/microsoftteams/meeting-policies-participants-and-guests for details.
+> The experience for users is dependent on both the value of -DisableAnonymousJoin (the old tenant-wide setting) and -AllowAnonymousUsersToJoinMeeting (the new per-organizer policy). Please check https://docs.microsoft.com/en-us/microsoftteams/meeting-settings-in-teams for details.
 
 Determines whether anonymous users can join the meetings that impacted users organize. Set this to TRUE to allow anonymous users to join a meeting. Set this to FALSE to prohibit them from joining a meeting. 
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -98,7 +98,7 @@ All other policy properties will use the existing values.
 ### -AllowAnonymousUsersToJoinMeeting
 
 > [!NOTE]
-> The experience for users is dependent on both the value of -DisableAnonymousJoin (the old tenant-wide setting) and -AllowAnonymousUsersToJoinMeeting (the new per-organizer policy). Please check https://docs.microsoft.com/en-us/microsoftteams/meeting-settings-in-teams for details.
+> The experience for users is dependent on both the value of -DisableAnonymousJoin (the old tenant-wide setting) and -AllowAnonymousUsersToJoinMeeting (the new per-organizer policy). Please check https://docs.microsoft.com/microsoftteams/meeting-settings-in-teams for details.
 
 Determines whether anonymous users can join the meetings that impacted users organize. Set this to TRUE to allow anonymous users to join a meeting. Set this to FALSE to prohibit them from joining a meeting. 
 


### PR DESCRIPTION
Changed the link in the disclaimer about -AllowAnonymousUsersToJoinMeeting param to point to the correct location.