### PR TITLE
Update Rotate-DkimSigningConfig.md

### DIFF
--- a/exchange/exchange-ps/exchange/Rotate-DkimSigningConfig.md
+++ b/exchange/exchange-ps/exchange/Rotate-DkimSigningConfig.md
@@ -14,7 +14,7 @@ ms.reviewer:
 ## SYNOPSIS
 This cmdlet is available only in the cloud-based service.
 
-Use the Rotate-DkimSigningConfig cmdlet to rotate the public and private DomainKeys Identified Mail (DKIM) signing policy keys for domains in a cloud-based organization. This cmdlet creates new DKIM keys and uses the alternate DKIM selector. Typically, you don't need to use this cmdlet, because Microsoft 365 automatically rotates your DKIM keys.
+Use the Rotate-DkimSigningConfig cmdlet to rotate the public and private DomainKeys Identified Mail (DKIM) signing policy keys for domains in a cloud-based organization. This cmdlet creates new DKIM keys and uses the alternate DKIM selector.
 
 **Note**: We recommend that you use the Exchange Online PowerShell V2 module to connect to Exchange Online PowerShell. For instructions, see [Connect to Exchange Online PowerShell](https://docs.microsoft.com/powershell/exchange/connect-to-exchange-online-powershell).
 


### PR DESCRIPTION
"Typically, you don't need to use this cmdlet, because Microsoft 365 automatically rotates your DKIM keys." -- this should be removed. I just confirmed with a EEE this is not accurate information. DKIM keys need to be rotated manually.