### PR TITLE
Update Set-CalendarProcessing.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-CalendarProcessing.md
+++ b/exchange/exchange-ps/exchange/Set-CalendarProcessing.md
@@ -332,8 +332,8 @@ Accept wildcard characters: False
 The AutomateProcessing parameter enables or disables calendar processing on the mailbox. Valid values are:
 
 - None: Calendar processing is disabled on the mailbox. Both the resource booking attendant and the Calendar Attendant are disabled on the mailbox.
-- AutoUpdate: Only the Calendar Attendant processes meeting requests and responses. Meeting requests are tentative in the calendar until they're approved by a delegate. Meeting organizers receive only decisions from delegates.
-- AutoAccept: Both the Calendar Attendant and resource booking attendant are enabled on the mailbox. This means that the Calendar Attendant updates the calendar, and then the resource booking assistant accepts the meeting based upon the policies. Eligible meeting organizers receive the decision directly without human intervention (free = accept; busy = decline).
+- AutoUpdate: Both the Calendar Attendant and resource booking attendant are enabled on the mailbox. This means that the Calendar Attendant updates the calendar, and then the resource booking assistant accepts the meeting based upon the policies. Eligible meeting organizers receive the decision directly without human intervention (free = accept; busy = decline).
+- AutoAccept: Only the Calendar Attendant processes meeting requests and responses. Meeting requests are tentative in the calendar until they're approved by a delegate. Meeting organizers receive only decisions from delegates.
 
 In on-premises Exchange, resource mailboxes created in the Exchange admin center (EAC) have the default value AutoAccept, while resource mailboxes created in PowerShell have the default value AutoUpdate.
 


### PR DESCRIPTION
Tested in Exchange Server 2016 and 2019, the behavior described in the article for the automateprocessing is mixed 
Autoaccept sends to the delegate for the room mailbox, organizer receives it response from the room as  pending
Autoupdate doesn't send to the delegate, marked as tentative for the room and we don't receive a response from the room.