### PR TITLE
Updates to write commands with "-Encoding Byte"

### DIFF
--- a/exchange/exchange-ps/exchange/Export-DlpPolicyCollection.md
+++ b/exchange/exchange-ps/exchange/Export-DlpPolicyCollection.md
@@ -37,8 +37,8 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-$file = Export-DlpPolicyCollection
-Set-Content -Path "C:\My Documents\Contoso PII.xml" -Value $file.FileData -Encoding Byte
+$DlpPol = Export-DlpPolicyCollection
+[System.IO.File]::WriteAllBytes('C:\My Documents\Contoso PII.xml', $DlpPol.FileData)
 ```
 
 This example exports all the elements of the existing DLP policies to the file C:\\My Documents\\Contoso PII.xml.

--- a/exchange/exchange-ps/exchange/Export-JournalRuleCollection.md
+++ b/exchange/exchange-ps/exchange/Export-JournalRuleCollection.md
@@ -39,7 +39,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 ### Example 1
 ```powershell
 $file = Export-JournalRuleCollection
-Set-Content -Path "C:\MyDocs\JournalRules.xml" -Value $file.FileData -Encoding Byte
+[System.IO.File]::WriteAllBytes('C:\MyDocs\JournalRules.xml', $file.FileData)
 ```
 
 This example exports journal rules in a two-step process. In the first step, the Export-JournalRuleCollection cmdlet exports journal rules to the variable $file. In the second step, the Set-Content cmdlet saves the exported data to the XML file JournalRules.xml.
@@ -47,10 +47,10 @@ This example exports journal rules in a two-step process. In the first step, the
 ### Example 2
 ```powershell
 $file = Export-JournalRuleCollection -ExportLegacyRules
-Set-Content -Path "C:\MyDocs\Ex2007-JournalRules.xml" -Value $file.FileData -Encoding Byte
+[System.IO.File]::WriteAllBytes('C:\MyDocs\LegacyJournalRules.xml', $file.FileData)
 ```
 
-In Exchange Server 2010, this example exports legacy journal rules to an XML file using the two-step process similar to the preceding example. In the first step, the Export-JournalRuleCollection cmdlet is used with the ExportLegacyRules switch to export legacy rules to the array $file. In the second step, the exported data is saved to the XML file Ex2007-JournallRules.xml.
+In Exchange Server 2010, this example exports legacy journal rules that were created in Exchange 2007 to an XML file. The first command uses the ExportLegacyRules switch to export legacy journal rules to the variable named $file. The second step saves the exported data to the XML file named LegacyJournalRules.xml.
 
 ## PARAMETERS
 

--- a/exchange/exchange-ps/exchange/Export-RecipientDataProperty.md
+++ b/exchange/exchange-ps/exchange/Export-RecipientDataProperty.md
@@ -47,14 +47,16 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Export-RecipientDataProperty -Identity tony@contoso.com -SpokenName | ForEach { $_.FileData | Add-Content C:\tonysmith.wma -Encoding Byte}
+$SN = Export-RecipientDataProperty -Identity tonys@contoso.com -SpokenName
+[System.IO.File]::WriteAllBytes('C:\tonysmith.wma', $SN.FileData)
 ```
 
 This example exports Tony Smith's spoken name audio file and saves it to the local computer.
 
 ### Example 2
 ```powershell
-Export-RecipientDataProperty -Identity "Ayla" -Picture | ForEach { $_.FileData | Add-Content C:\aylakol.jpg -Encoding Byte}
+$Pic = Export-RecipientDataProperty -Identity "Ayla Kol" -Picture
+[System.IO.File]::WriteAllBytes('C:\Data\aylakol.jpg', $Pic.FileData)
 ```
 
 This example exports Ayla Kol's picture file to the local computer.

--- a/exchange/exchange-ps/exchange/Export-TransportRuleCollection.md
+++ b/exchange/exchange-ps/exchange/Export-TransportRuleCollection.md
@@ -42,20 +42,22 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 ### Example 1
 ```powershell
 $file = Export-TransportRuleCollection
-Set-Content -Path "C:\My Docs\Rules.xml" -Value $file.FileData -Encoding Byte
+[System.IO.File]::WriteAllBytes('C:\My Docs\Rules.xml', $file.FileData)
 ```
 
 This example exports transport rules. Rule data is first exported to the variable $file, and then written to the XML file Rules.xml in the C:\\My Docs folder.
 
-**Note**: In PowerShell 6.0 or later, replace `-Encoding Byte` with `-AsByteStream`.
-
 ### Example 2
 ```powershell
 $file = Export-TransportRuleCollection -ExportLegacyRules
-Set-Content -Path "C:\MyDocs\LegacyRules.xml" -Value $file.FileData -Encoding Byte
+[System.IO.File]::WriteAllBytes('C:\My Docs\LegacyRules.xml', $file.FileData)
 ```
 
-In Exchange Server 2010, this example exports legacy transport rules created in Exchange 2007 using the ExportLegacyRules switch. The cmdlet should be run from an Exchange 2010 Hub Transport server. The exported rules collection can then be imported to Exchange 2010 using the Import-TransportRuleCollection cmdlet.
+In Exchange Server 2010, this example exports legacy transport rules that were created in Exchange 2007 to an XML file. The first command uses the ExportLegacyRules switch to export legacy transport rules to the variable named $file. The second step saves the exported data to the XML file named LegacyRules.xml.
+
+You can import the exported rules collection to Exchange 2010 using the Import-TransportRuleCollection cmdlet.
+
+You need to run these commands in this example on an Exchange 2010 Hub Transport server.
 
 ## PARAMETERS
 

--- a/exchange/exchange-ps/exchange/Export-UMPrompt.md
+++ b/exchange/exchange-ps/exchange/Export-UMPrompt.md
@@ -50,7 +50,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 ### Example 1
 ```powershell
 $prompt = Export-UMPrompt -PromptFileName "customgreeting.mp3" -UMDialPlan MyUMDialPlan
-Set-Content -Path "d:\DialPlanPrompts\welcomegreeting.mp3" -Value $prompt.AudioData -Encoding Byte
+[System.IO.File]::WriteAllBytes('D:\DialPlanPrompts\welcomegreeting.mp3', $prompt.AudioData)
 ```
 
 This example exports the welcome greeting for the UM dial plan MyUMDialPlan and saves it as the file welcomegreeting.mp3.
@@ -58,7 +58,7 @@ This example exports the welcome greeting for the UM dial plan MyUMDialPlan and 
 ### Example 2
 ```powershell
 $prompt = Export-UMPrompt -PromptFileName "welcomegreeting.mp3" -UMAutoAttendant MyUMAutoAttendant
-Set-Content -Path "e:\UMPromptsBackup\welcomegreetingbackup.mp3" -Value $prompt.AudioData -Encoding Byte
+[System.IO.File]::WriteAllBytes('E:\UMPromptsBackup\welcomegreetingbackup.mp3', $prompt.AudioData)
 ```
 
 This example exports a custom greeting for the UM auto attendant MyUMAutoAttendant and saves it to the file welcomegreetingbackup.mp3.

--- a/exchange/exchange-ps/exchange/New-DataClassification.md
+++ b/exchange/exchange-ps/exchange/New-DataClassification.md
@@ -41,9 +41,9 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-$Employee_Template = Get-Content "C:\My Documents\Contoso Employee Template.docx" -Encoding byte
+$Employee_Template = [System.IO.File]::ReadAllBytes('C:\My Documents\Contoso Employee Template.docx')
 $Employee_Fingerprint = New-Fingerprint -FileData $Employee_Template -Description "Contoso Employee Template"
-$Customer_Template = Get-Content "D:\Data\Contoso Customer Template.docx" -Encoding byte
+$Customer_Template = [System.IO.File]::ReadAllBytes('D:\Data\Contoso Customer Template.docx')
 $Customer_Fingerprint = New-Fingerprint -FileData $Customer_Template -Description "Contoso Customer Template"
 New-DataClassification -Name "Contoso Employee-Customer Confidential" -Fingerprints $Employee_Fingerprint,$Customer_Fingerprint -Description "Message contains Contoso employee or customer information."
 ```

--- a/exchange/exchange-ps/exchange/New-OMEConfiguration.md
+++ b/exchange/exchange-ps/exchange/New-OMEConfiguration.md
@@ -47,7 +47,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-New-OMEConfiguration -Identity "Contoso Marketing" -EmailText "Encrypted message enclosed." -PortalText "This portal is encrypted." -DisclaimerText "Encryption security disclaimer." -Image (Get-Content "C:\Temp\OME Logo.gif" -Encoding byte)
+New-OMEConfiguration -Identity "Contoso Marketing" -EmailText "Encrypted message enclosed." -PortalText "This portal is encrypted." -DisclaimerText "Encryption security disclaimer." -Image ([System.IO.File]::ReadAllBytes('C:\Temp\OME Logo.gif'))
 ```
 
 This example creates a new OME configuration named "Contoso Marketing" with the specified values specified. Unused parameters get the default values.

--- a/exchange/exchange-ps/exchange/New-PublicFolderMigrationRequest.md
+++ b/exchange/exchange-ps/exchange/New-PublicFolderMigrationRequest.md
@@ -55,7 +55,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-New-PublicFolderMigrationRequest -SourceDatabase PFDB01 -CSVData (Get-Content C:\PFMigration\CSVData.csv -Encoding Byte)
+New-PublicFolderMigrationRequest -SourceDatabase PFDB01 -CSVData ([System.IO.File]::ReadAllBytes('C:\PFMigration\CSVData.csv'))
 ```
 
 This example creates a public folder migration request from the Exchange 2010 source public folder database PFDB01 and uses the CSVData.csv file that was created using the Export-PublicFolderStatistics.ps1 script. For more information, see [Use serial migration to migrate public folders to Exchange 2013 from previous versions](https://docs.microsoft.com/previous-versions/exchange-server/exchange-150/jj150486(v=exchg.150)).

--- a/exchange/exchange-ps/exchange/Set-DataClassification.md
+++ b/exchange/exchange-ps/exchange/Set-DataClassification.md
@@ -58,7 +58,7 @@ This example removes the existing Spanish translation from the data classificati
 
 ### Example 3
 ```powershell
-$Benefits_Template = Get-Content "C:\My Documents\Contoso Benefits Template.docx" -Encoding byte
+$Benefits_Template = [System.IO.File]::ReadAllBytes('C:\My Documents\Contoso Benefits Template.docx')
 $Benefits_Fingerprint = New-Fingerprint -FileData $Benefits_Template -Description "Contoso Benefits Template"
 $Contoso_Confidential = Get-DataClassification "Contoso Confidential"
 $Array = [System.Collections.ArrayList]($Contoso_Confidential.Fingerprints)

--- a/exchange/exchange-ps/exchange/Set-OMEConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-OMEConfiguration.md
@@ -47,7 +47,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Set-OMEConfiguration -Identity "OME Configuration" -EmailText "Encrypted message enclosed." -PortalText "This portal is encrypted." -DisclaimerText "Encryption security disclaimer." -Image (Get-Content "C:\Temp\OME Logo.gif" -Encoding byte)
+Set-OMEConfiguration -Identity "OME Configuration" -EmailText "Encrypted message enclosed." -PortalText "This portal is encrypted." -DisclaimerText "Encryption security disclaimer." -Image ([System.IO.File]::ReadAllBytes('C:\Temp\OME Logo.gif'))
 ```
 
 This example configures the specified values for the default OME configuration named "OME Configuration". Note the use of the Get-Content command to provide the input for the Image parameter.

--- a/exchange/exchange-ps/exchange/Test-SystemHealth.md
+++ b/exchange/exchange-ps/exchange/Test-SystemHealth.md
@@ -60,11 +60,11 @@ This example gathers data about your Exchange system.
 
 ### Example 2
 ```powershell
-$temp=Test-SystemHealth -OutData
-Set-Content -Value $temp.FileData -Path d:\temp\SystemHealthOutData.xml -Encoding Byte
+$SysHealth = Test-SystemHealth -OutData
+[System.IO.File]::WriteAllBytes('D:\temp\SystemHealthOutData.xml', $SysHealth.FileData)
 ```
 
-This example saves the output data as a byte stream to the temporary variable $temp. Then the content is written to the file SystemHealthOutData.xml using the Set-Content cmdlet.
+This example saves the output data as a byte stream to the variable named $SysHealth. The content is then written to the SystemHealthOutData.xml file in the D:\\temp folder.
 
 ## PARAMETERS
 


### PR DESCRIPTION
"-Encoding Byte" doesn't work in PS 6 or later. Updated syntax tested and works in any version of PS (.NET 2.0 or later). This is the corollary to the similar fixes for read commands that were using "-Encoding Byte" in Issue #8839.