### PR TITLE
Fixes broken markdown links

### DIFF
--- a/skype/skype-ps/skype/Import-CsOnlineAudioFile.md
+++ b/skype/skype-ps/skype/Import-CsOnlineAudioFile.md
@@ -32,7 +32,7 @@ $content = Get-Content "C:\Media\Welcome.wav" -Encoding byte -ReadCount 0
 $audioFile = Import-CsOnlineAudioFile -ApplicationId "OrgAutoAttendant" -FileName "Hello.wav" -Content $content
 ```
 
-This example creates a new audio file using the WAV content that has a filename of Hello.wav to be used with organizational auto attendants. The stored variable, $audioFile, will be used when running other cmdlets to update the audio file for Auto Attendant, for example: [New-CsAutoAttendantPrompt](https://docs.microsoft.com/powershell/module/skype/new-csautoattendantprompt)
+This example creates a new audio file using the WAV content that has a filename of Hello.wav to be used with organizational auto attendants. The stored variable, $audioFile, will be used when running other cmdlets to update the audio file for Auto Attendant, for example [New-CsAutoAttendantPrompt](https://docs.microsoft.com/powershell/module/skype/new-csautoattendantprompt).
 
 ### -------------------------- Example 2 --------------------------
 ```powershell

--- a/skype/skype-ps/skype/Import-CsOnlineAudioFile.md
+++ b/skype/skype-ps/skype/Import-CsOnlineAudioFile.md
@@ -32,7 +32,7 @@ $content = Get-Content "C:\Media\Welcome.wav" -Encoding byte -ReadCount 0
 $audioFile = Import-CsOnlineAudioFile -ApplicationId "OrgAutoAttendant" -FileName "Hello.wav" -Content $content
 ```
 
-This example creates a new audio file using the WAV content that has a filename of Hello.wav to be used with organizational auto attendants. The stored variable, $audioFile, will be used when running other cmdlets to update the audio file for Auto Attendant, for example: [New-CsAutoAttendantPrompt] (https://docs.microsoft.com/powershell/module/skype/new-csautoattendantprompt)
+This example creates a new audio file using the WAV content that has a filename of Hello.wav to be used with organizational auto attendants. The stored variable, $audioFile, will be used when running other cmdlets to update the audio file for Auto Attendant, for example: [New-CsAutoAttendantPrompt](https://docs.microsoft.com/powershell/module/skype/new-csautoattendantprompt)
 
 ### -------------------------- Example 2 --------------------------
 ```powershell
@@ -40,7 +40,7 @@ $content = Get-Content "C:\Media\MOH.wav" -Encoding byte -ReadCount 0
 $audioFile = Import-CsOnlineAudioFile -ApplicationId "HuntGroup" -FileName "MOH.wav" -Content $content
 ```
 
-This example creates a new audio file using the WAV content that has a filename of MOH.wav to be used as a Music On Hold file with a Call Queue. The stored variable, $audioFile, will be used with [Set-CsCallQueue] (https://docs.microsoft.com/powershell/module/skype/set-cscallqueue) to provide the audio file id. 
+This example creates a new audio file using the WAV content that has a filename of MOH.wav to be used as a Music On Hold file with a Call Queue. The stored variable, $audioFile, will be used with [Set-CsCallQueue](https://docs.microsoft.com/powershell/module/skype/set-cscallqueue) to provide the audio file id. 
 
 ### -------------------------- Example 3 --------------------------
 ```powershell
@@ -48,7 +48,7 @@ $content = Get-Content "C:\Media\MOH.wav" -Encoding byte -ReadCount 0
 $audioFile = Import-CsOnlineAudioFile -ApplicationId TenantGlobal -FileName "MOH.wav" -Content $content
 ```
 
-This example creates a new audio file using the WAV content that has a filename of MOH.wav to be used as Music On Hold for Microsoft Teams. The stored variable, $audioFile, will be used with [New-CsTeamsCallHoldPolicy] (https://docs.microsoft.com/powershell/module/skype/new-csteamscallholdpolicy) to provide the audio file id. 
+This example creates a new audio file using the WAV content that has a filename of MOH.wav to be used as Music On Hold for Microsoft Teams. The stored variable, $audioFile, will be used with [New-CsTeamsCallHoldPolicy](https://docs.microsoft.com/powershell/module/skype/new-csteamscallholdpolicy) to provide the audio file id. 
 
 
 ## PARAMETERS


### PR DESCRIPTION
The links were broken because of the space between `[ ]` and `( )`.