### PR TITLE
Update Add-RecipientPermission.md

### DIFF
--- a/exchange/exchange-ps/exchange/Add-RecipientPermission.md
+++ b/exchange/exchange-ps/exchange/Add-RecipientPermission.md
@@ -24,9 +24,6 @@ For information about the parameter sets in the Syntax section below, see [Excha
 
 ```
 Add-RecipientPermission [-Identity] <RecipientIdParameter> -AccessRights <MultiValuedProperty> -Trustee <SecurityPrincipalIdParameter>
- [-SkipDomainValidationForMailContact]
- [-SkipDomainValidationForMailUser]
- [-SkipDomainValidationForSharedMailbox]
  [-Confirm]
  [-WhatIf]
  [<CommonParameters>]
@@ -127,54 +124,6 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True
-Accept wildcard characters: False
-```
-
-### -SkipDomainValidationForMailContact
-The SkipDomainValidationForMailContact switch skips the check that confirms the proxy addresses of the external contact specified by the Identity parameter are in the accepted domains of the organization. You don't need to specify a value with this switch.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SkipDomainValidationForMailUser
-The SkipDomainValidationForMailUser switch skips the check that confirms the proxy addresses of the mail user specified by the Identity parameter are in the accepted domains of the organization. You don't need to specify a value with this switch.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -SkipDomainValidationForSharedMailbox
-The SkipDomainValidationForSharedMailbox switch skips the check that confirms the proxy addresses of the shared mailbox specified by the Identity parameter are in the accepted domains of the organization. You don't need to specify a value with this switch.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
The SkipDomainValidationFor* parameters have been removed from scope of tenant admins.