### PR TITLE
Adds example with -AsByteStream for Get-Content. Solves #8896

### DIFF
--- a/skype/skype-ps/skype/Import-CsOnlineAudioFile.md
+++ b/skype/skype-ps/skype/Import-CsOnlineAudioFile.md
@@ -50,6 +50,14 @@ $audioFile = Import-CsOnlineAudioFile -ApplicationId TenantGlobal -FileName "MOH
 
 This example creates a new audio file using the WAV content that has a filename of MOH.wav to be used as Music On Hold for Microsoft Teams. The stored variable, $audioFile, will be used with [New-CsTeamsCallHoldPolicy] (https://docs.microsoft.com/powershell/module/skype/new-csteamscallholdpolicy) to provide the audio file id. 
 
+### -------------------------- Example 4 --------------------------
+```powershell
+$content = Get-Content "C:\Media\MOH.wav" -AsByteStream -ReadCount 0
+$audioFile = Import-CsOnlineAudioFile -ApplicationId 'TenantGlobal' -FileName 'MOH.wav' -Content $content
+```
+
+This example uses `-AsByteStream` parameter instead `-Encoding byte`. It works in PowerShell 6 and higher version, where `-Encoding byte` is no longer available. The example creates a new audio file using the WAV content that has a filename of MOH.wav to be used as Music On Hold for Microsoft Teams. The stored variable, $audioFile, will be used with [New-CsTeamsCallHoldPolicy](https://docs.microsoft.com/powershell/module/skype/new-csteamscallholdpolicy) to provide the audio file id. 
+
 
 ## PARAMETERS
 


### PR DESCRIPTION
As discussed in the thread, added one example with `-AsByteStream` parameter