### PR TITLE
Update filters-v2.md

### DIFF
--- a/exchange/docs-conceptual/filters-v2.md
+++ b/exchange/docs-conceptual/filters-v2.md
@@ -40,7 +40,7 @@ Although the EXO V2 module supports the majority of filterable attributes, the f
 |Cmdlet|Attribute|LDAP Display Name|
 |---|---|---|
 |[Get-CASMailbox](/powershell/module/exchange/get-casmailbox)|MemberOfGroup <p> ExternalDirectoryObjectId|memberOf <p> msExchExternalDirectoryObjectId|
-|[Get-Mailbox](/powershell/module/exchange/get-mailbox)|DeletedItemFlags <p> ExternalDirectoryObjectId <p> LanguagesRaw <p> MasterAccountSid <p> MemberOfGroup <p> RequireAllSendersAreAuthenticated <p> SCLDeleteThresholdInt <p> SCLJunkThresholdInt <p> SCLQuarantineThresholdInt <p> SCLRejectThresholdInt|deletedItemFlags <p> msExchExternalDirectoryObjectId <p> msExchUserCulture <p> msExchMasterAccountSid <p> memberOf <p> msExchRequireAuthToSendTo <p> msExchMessageHygieneSCLDeleteThreshold <p> msExchMessageHygieneSCLJunkThreshold <p> msExchMessageHygieneSCLQuarantineThreshold <p> msExchMessageHygieneSCLRejectThreshold|
+|[Get-Mailbox](/powershell/module/exchange/get-mailbox)|DeletedItemFlags <p> LanguagesRaw <p> MasterAccountSid <p> MemberOfGroup <p> RequireAllSendersAreAuthenticated <p> SCLDeleteThresholdInt <p> SCLJunkThresholdInt <p> SCLQuarantineThresholdInt <p> SCLRejectThresholdInt|deletedItemFlags <p> msExchUserCulture <p> msExchMasterAccountSid <p> memberOf <p> msExchRequireAuthToSendTo <p> msExchMessageHygieneSCLDeleteThreshold <p> msExchMessageHygieneSCLJunkThreshold <p> msExchMessageHygieneSCLQuarantineThreshold <p> msExchMessageHygieneSCLRejectThreshold|
 |[Get-Recipient](/powershell/module/exchange/get-recipient)|CountryCode <p> ExternalDirectoryObjectId <p> MasterAccountSid <p> MemberOfGroup <p> Members|countryCode <p> msExchExternalDirectoryObjectId <p> msExchMasterAccountSid <p> memberOf <p> member|
 |
 


### PR DESCRIPTION
Remove ExternalDirectoryObjectId and msExchExternalDirectoryObjectId from Get-Mailbox. Change was made to allow support for filtering using these properties.