### PR TITLE
Additional info for EndDateForRetentionHold

### DIFF
--- a/exchange/exchange-ps/exchange/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Set-Mailbox.md
@@ -2588,6 +2588,9 @@ The EndDateForRetentionHold parameter specifies the end date for retention hold 
 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2018 to specify September 1, 2018. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2018 5:00 PM".
 
+> [!IMPORTANT]
+> Using the parameter *-EndDateForRetentionHold* does not change *-RetentionHoldEnabled* to False after the end date. RentionHoldEnabled still be set to True on the mailbox after the end date, but MRM will start processing mailbox items as normal. 
+
 ```yaml
 Type: DateTime
 Parameter Sets: (All)

--- a/exchange/exchange-ps/exchange/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Set-Mailbox.md
@@ -2589,7 +2589,7 @@ The EndDateForRetentionHold parameter specifies the end date for retention hold 
 Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2018 to specify September 1, 2018. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2018 5:00 PM".
 
 > [!IMPORTANT]
-> Using the parameter *-EndDateForRetentionHold* does not change *-RetentionHoldEnabled* to False after the end date. RentionHoldEnabled still be set to True on the mailbox after the end date, but MRM will start processing mailbox items as normal. 
+> Using the *-EndDateForRetentionHold* parameter does not change *-RetentionHoldEnabled* to False after the end date. RentionHoldEnabled will still be set to True on the mailbox after the end date, but MRM will start processing mailbox items as normal. 
 
 ```yaml
 Type: DateTime

--- a/exchange/exchange-ps/exchange/Set-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Set-Mailbox.md
@@ -2586,10 +2586,9 @@ Accept wildcard characters: False
 ### -EndDateForRetentionHold
 The EndDateForRetentionHold parameter specifies the end date for retention hold for messaging records management (MRM). To use this parameter, you need to set the RetentionHoldEnabled parameter to the value $true.
 
-Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2018 to specify September 1, 2018. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2018 5:00 PM".
+**Important**: Using this parameter does not change the _RetentionHoldEnabled_ value to $false after the specified date. The _RentionHoldEnabled_ will still be $true on the mailbox after the specified date, but MRM will start processing mailbox items as normal. 
 
-> [!IMPORTANT]
-> Using the *-EndDateForRetentionHold* parameter does not change *-RetentionHoldEnabled* to False after the end date. RentionHoldEnabled will still be set to True on the mailbox after the end date, but MRM will start processing mailbox items as normal. 
+Use the short date format that's defined in the Regional Options settings on the computer where you're running the command. For example, if the computer is configured to use the short date format mm/dd/yyyy, enter 09/01/2018 to specify September 1, 2018. You can enter the date only, or you can enter the date and time of day. If you enter the date and time of day, enclose the value in quotation marks ("), for example, "09/01/2018 5:00 PM".
 
 ```yaml
 Type: DateTime


### PR DESCRIPTION
We had an escalation where customer used the EndDateForRetentionHold parameter and after the end date saw that RetentionHoldEnabled was still set to True. Wanting to add this disclaimer that using this parameter does not flip it back to True.