### PR TITLE
BlockedSenders/BlockedSenderDomains updates

### DIFF
--- a/exchange/exchange-ps/exchange/New-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/New-HostedContentFilterPolicy.md
@@ -210,7 +210,7 @@ Accept wildcard characters: False
 ```
 
 ### -BlockedSenderDomains
-The BlockedSenderDomains parameter specifies domains that are always marked as spam sources. Messages from senders in these domains are stamped with `SFV:SKB` value in the `X-Forefront-Antispam-Report` header and receive an SCL of 9 (high confidence spam). Valid values are one or more SMTP domains.
+The BlockedSenderDomains parameter specifies domains that are always marked as spam sources. Messages from senders in these domains are stamped with `SFV:SKB` value in the `X-Forefront-Antispam-Report` header and receive an SCL of 6 (spam). Valid values are one or more SMTP domains.
 
 **Note**: Manually blocking domains isn't dangerous, but it can increase your administrative workload. For more information, see [Create block sender lists in EOP](https://docs.microsoft.com/microsoft-365/security/office-365-security/create-block-sender-lists-in-office-365?).
 
@@ -232,7 +232,7 @@ Accept wildcard characters: False
 ```
 
 ### -BlockedSenders
-The BlockedSenders parameter specifies senders that are always marked as spam sources. Messages from these senders are stamped with `SFV:SKB` in the `X-Forefront-Antispam-Report` header and receive an SCL of 9 (high confidence spam). Valid values are one or more SMTP email addresses.
+The BlockedSenders parameter specifies senders that are always marked as spam sources. Messages from these senders are stamped with `SFV:SKB` in the `X-Forefront-Antispam-Report` header and receive an SCL of 6 (spam). Valid values are one or more SMTP email addresses.
 
 **Note**: Manually blocking senders isn't dangerous, but it can increase your administrative workload. For more information, see [Create block sender lists in EOP](https://docs.microsoft.com/microsoft-365/security/office-365-security/create-block-sender-lists-in-office-365?).
 

--- a/exchange/exchange-ps/exchange/Set-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-HostedContentFilterPolicy.md
@@ -212,7 +212,7 @@ Accept wildcard characters: False
 ```
 
 ### -BlockedSenderDomains
-The BlockedSenderDomains parameter specifies domains that are always marked as spam sources. Messages from senders in these domains are stamped with `SFV:SKB` value in the `X-Forefront-Antispam-Report` header and receive an SCL of 9 (high confidence spam). Valid values are one or more SMTP domains.
+The BlockedSenderDomains parameter specifies domains that are always marked as spam sources. Messages from senders in these domains are stamped with `SFV:SKB` value in the `X-Forefront-Antispam-Report` header and receive an SCL of 6 (spam). Valid values are one or more SMTP domains.
 
 **Note**: Manually blocking domains isn't dangerous, but it can increase your administrative workload. For more information, see [Create block sender lists in EOP](https://docs.microsoft.com/microsoft-365/security/office-365-security/create-block-sender-lists-in-office-365?).
 
@@ -234,7 +234,7 @@ Accept wildcard characters: False
 ```
 
 ### -BlockedSenders
-The BlockedSenders parameter specifies senders that are always marked as spam sources. Messages from these senders are stamped with `SFV:SKB` in the `X-Forefront-Antispam-Report` header and receive an SCL of 9 (high confidence spam). Valid values are one or more SMTP email addresses.
+The BlockedSenders parameter specifies senders that are always marked as spam sources. Messages from these senders are stamped with `SFV:SKB` in the `X-Forefront-Antispam-Report` header and receive an SCL of 6 (spam). Valid values are one or more SMTP email addresses.
 
 **Note**: Manually blocking senders isn't dangerous, but it can increase your administrative workload. For more information, see [Create block sender lists in EOP](https://docs.microsoft.com/microsoft-365/security/office-365-security/create-block-sender-lists-in-office-365?).
 


### PR DESCRIPTION
Blocked sender/domain entries in anti-spam policies are marked as spam, not high confidence spam per email request.