### PR TITLE
Update Get-CsOnlineUser.md

### DIFF
--- a/skype/skype-ps/skype/Get-CsOnlineUser.md
+++ b/skype/skype-ps/skype/Get-CsOnlineUser.md
@@ -162,7 +162,6 @@ The following updates are applicable for TeamsOnly customers using Microsoft Tea
 - WebPage
 - AssignedLicenses
 - OnPremisesUserPrincipalName
-- HostedVoiceMail
 - LicenseAssignmentStates
 - OnPremDomainName
 - OnPremSecurityIdentifier
@@ -172,7 +171,7 @@ The following updates are applicable for TeamsOnly customers using Microsoft Tea
 - LastName
 - Office
 - Phone
-- WindowsEmailAddress*
+- WindowsEmailAddress
 
 *Supported filters* - The Filtering functionality has been limited to the following attributes:
 


### PR DESCRIPTION
- HostedVoiceMail was mentioned twice in the "Deprecated Attributes" list.
- A typo "*" was  associated to "WindowsEmailAddress"  in the "Deprecated Attributes" list.