### PR TITLE
Adding hint to troubleshoot Basic Auth WinRM error

### DIFF
--- a/exchange/docs-conceptual/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online-powershell-v2.md
@@ -243,9 +243,24 @@ The EXO V2 module is supported in the following versions of Windows:
 
   > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
 
+If you receive the following error:
+  > Create Powershell Session is failed using OAuth.
+
+  ![image](https://user-images.githubusercontent.com/61047131/156006031-68d37b96-7d95-4b1e-8cf5-c59a121a8bb7.png)
+  
+  This indicates that the Basic authentication setting of WinRM is disabled, which block the client from authenticating.
+  Enable the Basic authentication setting of WinRM using this cmdlet:
+  
+  ```powershell
+   Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowBasic' -Type DWord -Value '1'
+  ```
+ Afterwards the EXO v2 PowerShell should load correctly
+ ![image](https://user-images.githubusercontent.com/61047131/156005836-b8cd9fcb-8305-4bf3-b246-9c04b96ad962.png)
+  
 > [!TIP]
 > Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
 
+  
 ### Install the EXO V2 module
 
 To install the EXO V2 module for the first time, complete the following steps:

--- a/exchange/docs-conceptual/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online-powershell-v2.md
@@ -243,19 +243,22 @@ The EXO V2 module is supported in the following versions of Windows:
 
   > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
 
-If you receive the following error:
+  
+- Connecting to Exchange Online using EXO v2 may result in this error:
   > Create Powershell Session is failed using OAuth.
 
   ![image](https://user-images.githubusercontent.com/61047131/156006031-68d37b96-7d95-4b1e-8cf5-c59a121a8bb7.png)
   
-  This indicates that the Basic authentication setting of WinRM is disabled, which block the client from authenticating.
-  Enable the Basic authentication setting of WinRM using this cmdlet:
+  This indicate that the Basic authentication setting of WinRM is disabled, which prevents the client authentication.
+  
+  Enable Basic authentication for WinRM using this cmdlet:
   
   ```powershell
-   Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowBasic' -Type DWord -Value '1'
+  Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowBasic' -Type DWord -Value '1'
   ```
- Afterwards the EXO v2 PowerShell should load correctly
- ![image](https://user-images.githubusercontent.com/61047131/156005836-b8cd9fcb-8305-4bf3-b246-9c04b96ad962.png)
+  Now verify that EXO v2 PowerShell load properly.
+  
+  ![image](https://user-images.githubusercontent.com/61047131/156005836-b8cd9fcb-8305-4bf3-b246-9c04b96ad962.png)
   
 > [!TIP]
 > Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).

--- a/exchange/docs-conceptual/exchange-online-powershell-v2.md
+++ b/exchange/docs-conceptual/exchange-online-powershell-v2.md
@@ -223,46 +223,42 @@ The EXO V2 module is supported in the following versions of Windows:
   > [!NOTE]
   > As described [earlier in this article](#updates-for-version-206), v2.0.6 of the EXO V2 module does not require Basic authentication in WinRM for many cmdlets.
   >
-  > You must temporarily enable WinRM to run the following commands. You can enable WinRM by running the command: `winrm quickconfig`.
+  > You must temporarily enable WinRM to run the following winrm commands. You can enable WinRM by running the command: `winrm quickconfig`.
 
-  To verify that Basic authentication is enabled for WinRM, run this command **in a Command Prompt** (not in PowerShell):
+  To verify that Basic authentication is enabled for WinRM, run the following command in a **Command Prompt** or **Windows PowerShell**:
 
-  ```dos
+  ```DOS
   winrm get winrm/config/client/auth
   ```
 
-  If you don't see the value `Basic = true`, you need to run this command **in a Command Prompt** (not in PowerShell) to enable Basic authentication for WinRM:
+  If you don't see the value `Basic = true`, you need to run **one** of the following commands to enable Basic authentication for WinRM:
 
-  ```dos
-  winrm set winrm/config/client/auth @{Basic="true"}
-  ```
+  - **In a Command Prompt**:
 
-  **Note**: If you'd rather run the command in PowerShell, enclose this part of the command in quotation marks: `'@{Basic="true"}'`.
+    ```DOS
+    winrm set winrm/config/client/auth @{Basic="true"}
+    ```
 
-  If Basic authentication for WinRM is disabled, you'll get this error when you try to connect:
+  - **In Windows PowerShell**:
+
+      ```DOS
+    winrm set winrm/config/client/auth '@{Basic="true"}'
+    ```
+
+  - **In Windows PowerShell to modify the registry**:
+  
+    ```PowerShell
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowBasic' -Type DWord -Value '1'
+    ```
+
+  If Basic authentication for WinRM is disabled, you'll get one of the following errors when you try to connect:
 
   > The WinRM client cannot process the request. Basic authentication is currently disabled in the client configuration. Change the client configuration and try the request again.
 
-  
-- Connecting to Exchange Online using EXO v2 may result in this error:
   > Create Powershell Session is failed using OAuth.
-
-  ![image](https://user-images.githubusercontent.com/61047131/156006031-68d37b96-7d95-4b1e-8cf5-c59a121a8bb7.png)
-  
-  This indicate that the Basic authentication setting of WinRM is disabled, which prevents the client authentication.
-  
-  Enable Basic authentication for WinRM using this cmdlet:
-  
-  ```powershell
-  Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client' -Name 'AllowBasic' -Type DWord -Value '1'
-  ```
-  Now verify that EXO v2 PowerShell load properly.
-  
-  ![image](https://user-images.githubusercontent.com/61047131/156005836-b8cd9fcb-8305-4bf3-b246-9c04b96ad962.png)
   
 > [!TIP]
 > Having problems? Ask for help in the Exchange forums. Visit the forums at: [Exchange Online](https://go.microsoft.com/fwlink/p/?linkId=267542), or [Exchange Online Protection](https://go.microsoft.com/fwlink/p/?linkId=285351).
-
   
 ### Install the EXO V2 module
 


### PR DESCRIPTION
Adding hint to help troubleshoot and resolve common error with disabled Basic authentication setting in WinRM when connecting to EXO v2 Powershell.
#ATCP