### PR TITLE
Update Get-ComplianceSearchAction.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-ComplianceSearchAction.md
+++ b/exchange/exchange-ps/exchange/Get-ComplianceSearchAction.md
@@ -94,7 +94,7 @@ This example shows details about the compliance search action named "Case 1234\_
 ### -Identity
 The Identity parameter specifies the compliance search action that you want to view. You can use any value that uniquely identifies the compliance search action. For example:
 
-- Name: The compliance search action name uses the syntax `"Compliance Search Name\_Action"`. For example, `"Case 1234\_Preview"`.
+- Name: The compliance search action name uses the syntax `"Compliance Search Name_Action"`. For example, `"Case 1234_Preview"`.
 - JobRunId (GUID)
 
 You can't use this parameter with the Export, Preview, or Purge parameters.

--- a/exchange/exchange-ps/exchange/Get-ComplianceSearchAction.md
+++ b/exchange/exchange-ps/exchange/Get-ComplianceSearchAction.md
@@ -84,10 +84,10 @@ This example shows a summary list of all compliance search actions.
 
 ### Example 2
 ```powershell
-Get-ComplianceSearchAction -Identity "Case 1234\_Preview" | Format-List
+Get-ComplianceSearchAction -Identity "Case 1234_Preview" | Format-List
 ```
 
-This example shows details about the compliance search action named "Case 1234\_Preview"
+This example shows details about the compliance search action named "Case 1234_Preview"
 
 ## PARAMETERS
 


### PR DESCRIPTION
\ is not part of valid syntax for passing ComplianceJobName.