### PR TITLE
Remove the "Antispam agents" word from the IsInternal parameter

### DIFF
--- a/exchange/exchange-ps/exchange/Set-RemoteDomain.md
+++ b/exchange/exchange-ps/exchange/Set-RemoteDomain.md
@@ -328,7 +328,7 @@ Accept wildcard characters: False
 ### -IsInternal
 The IsInternal parameter specifies whether the recipients in the remote domain are considered to be internal recipients. Valid values are:
 
-- $true: All transport components (for example, transport rules or antispam agents) treat recipients in the remote domain as internal recipients. Typically, you use this value in cross-forest deployments.
+- $true: All transport components (for example, transport rules) treat recipients in the remote domain as internal recipients. Typically, you use this value in cross-forest deployments.
 - $false: Recipients in the remote domain are treated as external recipients. This is the default value.
 
 ```yaml


### PR DESCRIPTION
Change is based on the bug https://github.com/MicrosoftDocs/office-docs-powershell/issues/9064. Verified with Antispam component team that this parameter is not used for the antispam agent logic. (internal vso: 2605132)