### PR TITLE
Update Get-MessageTrackingReport.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-MessageTrackingReport.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTrackingReport.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Exchange.TransportMailflow-Help.xml
 online version: https://docs.microsoft.com/powershell/module/exchange/get-messagetrackingreport
-applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019, Exchange Online
+applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
 title: Get-MessageTrackingReport
 schema: 2.0.0
 author: chrisda


### PR DESCRIPTION
Removed "Exchange Online" from "applicable" - the synopsis clearly states it's only available in on-premises Exchange