### PR TITLE
Remove preview tags from Cmdlets examples for GA release

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionConnector.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionConnector.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet supports retrieving the available Shifts Connectors.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionErrorReport.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionErrorReport.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet returns the list of all the team mapping error reports. It also can return the configuration details of one mapping error report with it ID provided or other filter parameters.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionErrorReport.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionErrorReport.md
@@ -13,7 +13,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-This cmdlet returns the list of all the team mapping error reports. It also can return the configuration details of one mapping error report with it ID provided or other filter parameters.
+This cmdlet returns the list of all the team mapping error reports. It can also return the configuration details of one mapping error report with its ID provided or other filter parameters.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionInstance.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet returns the list of existing connection instances. It can also return the configuration details for a given connection instance.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionOperation.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionOperation.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet gets the requested batch mapping operation. The batch mapping operation can be submitted by running [New-CsTeamsShiftsConnectionBatchTeamMap](New-CsTeamsShiftsConnectionBatchTeamMap.md).
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionSyncResult.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet supports retrieving the list of user details in the mapped teams of last sync.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionTeamMap.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet supports retrieving the list of team mappings.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmTeam.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet supports retrieving the list of available Workforce management (WFM) teams in the connection instance.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmUser.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsConnectionWfmUser.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet shows the list of Workforce management (WFM) users in a specified WFM team. 
 
 ## SYNTAX

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionBatchTeamMap.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionBatchTeamMap.md
@@ -14,8 +14,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet submits an operation connecting multiple Microsoft Teams teams and Workforce management (WFM) teams.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionInstance.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet creates a Shifts connection instance.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsConnectionTeamMap.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet connects a Microsoft Teams team and a Workforce management (WFM) team.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionInstance.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet deletes a Shifts connection instance.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionTeamMap.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsConnectionTeamMap.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet removes the mapping between the Microsoft Teams team and workforce management (WFM) team.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsScheduleRecord.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsScheduleRecord.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet enqueues the clear schedule message.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsConnectionInstance.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet updates a Shifts connection instance.
 
 ## SYNTAX

--- a/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
+++ b/teams/teams-ps/teams/Test-CsTeamsShiftsConnectionValidate.md
@@ -13,8 +13,6 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-**Note:** This cmdlet is currently in public preview.
-
 This cmdlet validates workforce management (WFM) connection settings.
 
 ## SYNTAX


### PR DESCRIPTION
We are releasing the following cmdlets in the next GA, therefore we are removing preview tags from their corresponding examples files.

_Version 4.1.0-GA (The project - Microsoft.Teams.PowerShell.Module contains these changes so far for this release)_
> Releases [Get|New|Set|Remove]-CsTeamsShiftsConnectionInstance Cmdlets
> Releases [Get|New|Remove]-CsTeamsShiftsConnectionTeamMap Cmdlets
> Releases Get-CsTeamsShiftsConnectionWfm[User|Team] Cmdlets
> Releases Get-CsTeamsShiftsConnectionConnector, Get-CsTeamsShiftsConnectionSyncResult, New-CsTeamsShiftsConnectionBatchTeamMap, Remove-CsTeamsShiftsScheduleRecord, Test-CsTeamsShiftsConnectionValidate, Get-CsTeamsShiftsConnectionOperation & Get-CsTeamsShiftsConnectionErrorReport Cmdlets.

**Note: Please only review this PR. we will merge this PR only on the same date of GA release. (29th March 2022)**

