### PR TITLE
Include warnings about Guest user exceptions

### DIFF
--- a/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
@@ -219,6 +219,8 @@ Group members can change their own subscription settings, which can override you
 
 The AutoSubscribeNewMembers switch overrides this switch.
 
+**Note**: This attribute is only evaluated when adding members that are internal to your organization. Guest user accounts are always subscribed when added as a member. Once added, their subscription can be manually removed using the Remove-UnifiedGroupLinks cmdlet.
+
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
@@ -257,6 +259,8 @@ The AutoSubscribeNewMembers switch specifies whether to automatically subscribe 
 
 - To subscribe new members to conversations and calendar events, use the AutoSubscribeNewMembers switch without a value.
 - If you don't want to subscribe new members to conversations and calendar events, use this exact syntax: `-AutoSubscribeNewMembers:$false`.
+
+**Note**: This attribute is only evaluated when adding members that are internal to your organization. Guest user accounts are always subscribed when added as a member. Once added, their subscription can be manually removed using the Remove-UnifiedGroupLinks cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -1171,6 +1175,8 @@ The SubscriptionEnabled switch specifies whether the group owners can enable sub
 - To change the value to $false, use this exact syntax: `-SubscriptionEnabled:$false`. The value of the AutoSubscribeNewMembers parameter must also be $false before you can use the value $false for this switch.
 
 **Note**: You should use the value $false for this switch only if you intend to disable group owner ability to change subscription options on the group. Group owners will not be able to enable subscription options on the group settings using Outlook on the web or Outlook desktop. Group owners might see the error, "The group update is in progress" error when they try to enable Subscription option. Admins trying to enable Subscription from Microsoft admin center might also see error, "Can't save 'Send copies of group conversations and events to group member's inboxes' Either your assigned product license doesn't include Exchange Online or you have recently created this group and it's still not ready for management".
+
+**Note**: This attribute is only evaluated when adding members that are internal to your organization. Guest user accounts are always subscribed when added as a member. Once added, their subscription can be manually removed using the Remove-UnifiedGroupLinks cmdlet.
 
 ```yaml
 Type: SwitchParameter

--- a/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
@@ -219,7 +219,7 @@ Group members can change their own subscription settings, which can override you
 
 The AutoSubscribeNewMembers switch overrides this switch.
 
-**Note**: This attribute is only evaluated when adding members that are internal to your organization. Guest user accounts are always subscribed when added as a member. Once added, their subscription can be manually removed using the Remove-UnifiedGroupLinks cmdlet.
+**Note**: This property is evaluated only when you add internal members from your organization. Guest user accounts are always subscribed when added as a member. You can manually remove subscriptions for guest users by using the Remove-UnifiedGroupLinks cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -260,7 +260,7 @@ The AutoSubscribeNewMembers switch specifies whether to automatically subscribe 
 - To subscribe new members to conversations and calendar events, use the AutoSubscribeNewMembers switch without a value.
 - If you don't want to subscribe new members to conversations and calendar events, use this exact syntax: `-AutoSubscribeNewMembers:$false`.
 
-**Note**: This attribute is only evaluated when adding members that are internal to your organization. Guest user accounts are always subscribed when added as a member. Once added, their subscription can be manually removed using the Remove-UnifiedGroupLinks cmdlet.
+**Note**: This property is evaluated only when you add internal members from your organization. Guest user accounts are always subscribed when added as a member. You can manually remove subscriptions for guest users by using the Remove-UnifiedGroupLinks cmdlet.
 
 ```yaml
 Type: SwitchParameter
@@ -1176,7 +1176,7 @@ The SubscriptionEnabled switch specifies whether the group owners can enable sub
 
 **Note**: You should use the value $false for this switch only if you intend to disable group owner ability to change subscription options on the group. Group owners will not be able to enable subscription options on the group settings using Outlook on the web or Outlook desktop. Group owners might see the error, "The group update is in progress" error when they try to enable Subscription option. Admins trying to enable Subscription from Microsoft admin center might also see error, "Can't save 'Send copies of group conversations and events to group member's inboxes' Either your assigned product license doesn't include Exchange Online or you have recently created this group and it's still not ready for management".
 
-**Note**: This attribute is only evaluated when adding members that are internal to your organization. Guest user accounts are always subscribed when added as a member. Once added, their subscription can be manually removed using the Remove-UnifiedGroupLinks cmdlet.
+**Note**: This property is evaluated only when you add internal members from your organization. Guest user accounts are always subscribed when added as a member. You can manually remove subscriptions for guest users by using the Remove-UnifiedGroupLinks cmdlet.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Considerable testing and a Microsoft Support case confirm that Guest user accounts added as members of Unified Groups are added as subscribers regardless of the group's AutoSubscribeNewMembers, AlwaysSubscribeMembersToCalendarEvents, and even SubscriptionEnabled attributes. The subscriber links can be manually removed and they stay gone, but there seems to be no way to prevent Guest accounts from being subscribed, and the documentation should include that limitation.