### PR TITLE
Correct information about Remove-UserPhoto and AD

### DIFF
--- a/exchange/exchange-ps/exchange/Remove-UserPhoto.md
+++ b/exchange/exchange-ps/exchange/Remove-UserPhoto.md
@@ -14,7 +14,7 @@ ms.reviewer:
 ## SYNOPSIS
 This cmdlet is available in on-premises Exchange and in the cloud-based service. Some parameters and settings may be exclusive to one environment or the other.
 
-Use the Remove-UserPhoto cmdlet to delete the photo associated with a user's account. The user photo feature allows users to associate a picture with their account. User photos appear in on-premises and cloud-based client applications, such as Outlook on the web, Lync, Skype for Business and SharePoint.
+Use the Remove-UserPhoto cmdlet to delete the photo associated with a user's account. The user photo feature allows users to associate a picture with their account. User photos appear in on-premises and cloud-based client applications, such as Outlook on the web (formerly known as Outlook Web App or OWA), Lync, Skype for Business and SharePoint.
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://docs.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 
@@ -44,7 +44,8 @@ Remove-UserPhoto [-Identity] <MailboxIdParameter>
 ```
 
 ## DESCRIPTION
-Use the Remove-UserPhoto cmdlet to delete the user photo currently associated with a user's account. This cmdlet removes the photo from user's Exchange mailbox root. If run from on-premises Exchange, it also removes the user's photo from their Active Directory account. Administrators can also use the Exchange admin center (EAC) to delete user photos by accessing the user's Outlook on the web Options page.
+Use the Remove-UserPhoto cmdlet to delete the user photo currently associated with a user's account. This cmdlet removes the photo from user's Exchange mailbox root. 
+In on-premises Exchange, it also removes the user's photo from their Active Directory account. Administrators can also use the Exchange admin center (EAC) to delete user photos by accessing the Options page in the user's mailbox in Outlook on the web.
 
 **Notes**:
 

--- a/exchange/exchange-ps/exchange/Remove-UserPhoto.md
+++ b/exchange/exchange-ps/exchange/Remove-UserPhoto.md
@@ -44,7 +44,7 @@ Remove-UserPhoto [-Identity] <MailboxIdParameter>
 ```
 
 ## DESCRIPTION
-Use the Remove-UserPhoto cmdlet to delete the user photo currently associated with a user's account. User photos are stored in the user's Active Directory account and in the root directory of the user's Exchange mailbox, both of which are deleted when you run this cmdlet. Administrators can also use the Exchange admin center (EAC) to delete user photos by accessing the user's Outlook on the web Options page.
+Use the Remove-UserPhoto cmdlet to delete the user photo currently associated with a user's account. This cmdlet removes the photo from user's Exchange mailbox root. If run from on-premises Exchange, it also removes the user's photo from their Active Directory account. Administrators can also use the Exchange admin center (EAC) to delete user photos by accessing the user's Outlook on the web Options page.
 
 **Notes**:
 


### PR DESCRIPTION
The behaviour of this cmdlet is different in on-prem vs cloud context. The AD image is only removed when the cmdlet is run on-prem.