### PR TITLE
Update Set-CsOnlineLisCivicAddress.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsOnlineLisCivicAddress.md
+++ b/skype/skype-ps/skype/Set-CsOnlineLisCivicAddress.md
@@ -14,7 +14,7 @@ ms.reviewer:
 
 ## SYNOPSIS
 Use the \`Set-CsOnlineLisCivicAddress\` cmdlet to modify an existing civic address which has not been validated.
-Validated civic addresses cannot be modified.
+Validated civic addresses can be modified.
 
 ## SYNTAX
 


### PR DESCRIPTION
Hello Team, 
I did a repro for the same command and using the Set-CsOnlineLisCivicAddress we are able to edit the validated addresses as well. Though this is still not achievable from the TAC directly but this powershell command can be used.
![image](https://user-images.githubusercontent.com/105933766/169557731-89381d4b-652a-45d8-bfd4-59144b05442b.png)
'test' is a validated emergency address

![image](https://user-images.githubusercontent.com/105933766/169558303-dd8ae9fe-3d02-4388-a23f-2bb2823c2490.png)
I am able to make the changes to street name from 'back street' to 'front street' using powershell

![image](https://user-images.githubusercontent.com/105933766/169558422-0d13c3c6-7a6a-49ab-b693-e2ecbd70324c.png)
The change reflects in the TAC as well.
