### PR TITLE
Update New-CsTeamsCallingPolicy.md

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
@@ -24,7 +24,7 @@ New-CsTeamsCallingPolicy [-Identity] <string> [-AllowCallForwardingToPhone <bool
 [-AllowCallRedirect <string>] [-AllowCloudRecordingForCalls <boolean>] [-AllowDelegation <boolean>] [-AllowPrivateCalling <boolean>]
 [-AllowSIPDevicesCalling <boolean>] [-AllowTranscriptionForCalling <boolean>] [-AllowVoicemail <string>] [-AllowWebPSTNCalling <boolean>]
 [-AutoAnswerEnabledType <string>] [-BusyOnBusyEnabledType <string>] [-CallRecordingExpirationDays <long>] [-Description <string>]
-[-LiveCaptionsEnabledTypeForCalling <string>] [-MusicOnHoldEnabledType <string>] [-PreventTollBypass <boolean>] [-PopoutAppPathForIncomingPstnCalls <string>] [-PopoutForIncomingPstnCalls <string>] [-SpamFilteringEnabledType <string>]
+[-LiveCaptionsEnabledTypeForCalling <string>] [-MusicOnHoldEnabledType <string>] [-PopoutAppPathForIncomingPstnCalls <string>] [-PopoutForIncomingPstnCalls <string>] [-PreventTollBypass <boolean>] [-SpamFilteringEnabledType <string>]
 [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 

--- a/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
@@ -343,7 +343,7 @@ Accept wildcard characters: False
 ```
 
 ### -PopoutAppPathForIncomingPstnCalls
-Reserved for internal Microsoft use
+Reserved for internal Microsoft use.
 
 ```yaml
 Type: String
@@ -358,7 +358,7 @@ Accept wildcard characters: False
 ```
 
 ### -PopoutForIncomingPstnCalls
-Reserved for internal Microsoft use
+Reserved for internal Microsoft use.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
@@ -383,6 +383,36 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PopoutForIncomingPstnCalls
+Reserved for internal Microsoft use
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: Disabled
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PopoutAppPathForIncomingPstnCalls
+Reserved for internal Microsoft use
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: ""
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.

--- a/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsCallingPolicy.md
@@ -24,7 +24,7 @@ New-CsTeamsCallingPolicy [-Identity] <string> [-AllowCallForwardingToPhone <bool
 [-AllowCallRedirect <string>] [-AllowCloudRecordingForCalls <boolean>] [-AllowDelegation <boolean>] [-AllowPrivateCalling <boolean>]
 [-AllowSIPDevicesCalling <boolean>] [-AllowTranscriptionForCalling <boolean>] [-AllowVoicemail <string>] [-AllowWebPSTNCalling <boolean>]
 [-AutoAnswerEnabledType <string>] [-BusyOnBusyEnabledType <string>] [-CallRecordingExpirationDays <long>] [-Description <string>]
-[-LiveCaptionsEnabledTypeForCalling <string>] [-MusicOnHoldEnabledType <string>] [-PreventTollBypass <boolean>] [-SpamFilteringEnabledType <string>]
+[-LiveCaptionsEnabledTypeForCalling <string>] [-MusicOnHoldEnabledType <string>] [-PreventTollBypass <boolean>] [-PopoutAppPathForIncomingPstnCalls <string>] [-PopoutForIncomingPstnCalls <string>] [-SpamFilteringEnabledType <string>]
 [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -342,6 +342,36 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -PopoutAppPathForIncomingPstnCalls
+Reserved for internal Microsoft use
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: ""
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PopoutForIncomingPstnCalls
+Reserved for internal Microsoft use
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: Disabled
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PreventTollBypass
 Setting this parameter to True will send calls through PSTN and incur charges rather than going through the network and bypassing the tolls. 
 
@@ -379,36 +409,6 @@ Applicable: Microsoft Teams
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PopoutForIncomingPstnCalls
-Reserved for internal Microsoft use
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-Required: False
-Position: Named
-Default value: Disabled
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -PopoutAppPathForIncomingPstnCalls
-Reserved for internal Microsoft use
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-Required: False
-Position: Named
-Default value: ""
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
We are in the process of integrating two new settings under TeamsCallingPolicy. While the policy settings are available via the Powershell cmdlets, these settings are not yet ready to be consumed via Teams customers. Adding "reserved for internal Microsoft use" to avoid any confusion related to public use of these two settings.