### PR TITLE
Update Example 3, Add Example 4 - Fixes #9588

### DIFF
--- a/skype/skype-ps/skype/Set-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Set-CsTenantDialPlan.md
@@ -59,6 +59,35 @@ Set-CsTenantDialPlan -ExternalAccessPrefix "123" -Identity vt1tenantDialPlan9 -N
 This example updates the vt1tenantDialPlan9 tenant dial plan to have an external access prefix of 123 and use the US/US Long Distance normalization rules.
 
 
+### -------------------------- Example 3 --------------------------
+```
+$DP = Get-CsTenantDialPlan -Identity Global
+$NR = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
+$NR.Name = "RedmondRule"
+Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
+```
+
+This example changes the name of an normalization rule.
+Keep in mind that changing the name also changes the name portion of the Identity.
+The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name, we first call the `Get-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign the returned object to the variable $NR.
+We then assign the string RedmondRule to the Name property of the object.
+Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
+
+
+### -------------------------- Example 4 --------------------------
+```
+$DP = Get-CsTenantDialPlan -Identity Global
+$NR = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
+$DP.NormalizationRules.Remove($NR)
+Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
+```
+
+This example removes a normalization rule.
+We utilize the same functionality as for Example 3 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
+We first call the `Get-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign it to the variable $NR. Next, we remove this Object with the Remove Method from $DP.NormalizationRules.
+Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
+
+
 ## PARAMETERS
 
 ### -Confirm

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -103,7 +103,7 @@ Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 ```
 
 Example 5 applies to Teams only and removes a normalization rule.
-We utilize the same functionality as for Example 3 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
+We utilize the same functionality as for Example 4 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
 We first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign it to the variable $Rule. Next, we remove this Object with the Remove Method from $DP.NormalizationRules.
 Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
 

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -81,7 +81,6 @@ Next, we pass the variable to the Instance parameter of the `Set-CsVoiceNormaliz
 
 ### -------------------------- Example 4 --------------------------
 ```
-# NOTE: This Example applies to Teams only
 $DP = Get-CsTenantDialPlan -Identity Global
 $Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
 $Rule.Name = "RedmondRule"

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -67,18 +67,32 @@ For example, if the existing pattern matched any four-digit number and the numbe
 
 ### -------------------------- Example 3 --------------------------
 ```
-$a = Get-CsVoiceNormalizationRule -Identity global/RedmondFourDigit
-
-$a.name = "RedmondRule"
-
-Set-CsVoiceNormalizationRule -Instance $a
+$DP = Get-CsTenantDialPlan -Identity Global
+$Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
+$Rule.Name = "RedmondRule"
+Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 ```
 
 Example 3 changes the name of the normalization rule.
 Keep in mind that changing the name also changes the name portion of the Identity.
-The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name we first call the `Get-CsVoiceNormalizationRule` cmdlet to retrieve the rule with the Identity global/RedmondFourDigit and assign the returned object to the variable $a.
+The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name we first call `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the the rule RedmondFourDigit and assign the returned object to the variable $Rule.
 We then assign the string RedmondRule to the Name property of the object.
-Next, we pass the variable to the Instance parameter of the `Set-CsVoiceNormalizationRule` cmdlet to make the change permanent.
+Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
+
+
+### -------------------------- Example 4 --------------------------
+```
+$DP = Get-CsTenantDialPlan -Identity Global
+$Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
+$DP.NormalizationRules.Remove($Rule)
+Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
+```
+
+Example 4 removes a normalization rule.
+We utilise the same functionality as for Example 3, to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
+We first call `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the the rule RedmondFourDigit and assign it to the variable $Rule. Next we remove this Object with the Remove Method from $DP.NormalizationRules.
+Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
+
 
 
 ## PARAMETERS

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -67,7 +67,6 @@ For example, if the existing pattern matched any four-digit number and the numbe
 
 ### -------------------------- Example 3 --------------------------
 ```
-# NOTE: This Example applies to Skype for Business Server only
 $a = Get-CsVoiceNormalizationRule -Identity global/RedmondFourDigit
 $a.name = "RedmondRule"
 Set-CsVoiceNormalizationRule -Instance $a

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -90,7 +90,7 @@ Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 
 Example 4 removes a normalization rule.
 We utilize the same functionality as for Example 3 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
-We first call `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the the rule RedmondFourDigit and assign it to the variable $Rule. Next we remove this Object with the Remove Method from $DP.NormalizationRules.
+We first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign it to the variable $Rule. Next, we remove this Object with the Remove Method from $DP.NormalizationRules.
 Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
 
 

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -96,7 +96,6 @@ Finally, we pass the variable back to the NormalizationRules parameter of the `S
 
 ### -------------------------- Example 5 --------------------------
 ```
-# NOTE: This Example applies to Teams only
 $DP = Get-CsTenantDialPlan -Identity Global
 $Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
 $DP.NormalizationRules.Remove($Rule)

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -75,7 +75,7 @@ Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 
 Example 3 changes the name of the normalization rule.
 Keep in mind that changing the name also changes the name portion of the Identity.
-The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name we first call `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the the rule RedmondFourDigit and assign the returned object to the variable $Rule.
+The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name, we first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign the returned object to the variable $Rule.
 We then assign the string RedmondRule to the Name property of the object.
 Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
 

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -89,7 +89,7 @@ Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 ```
 
 Example 4 removes a normalization rule.
-We utilise the same functionality as for Example 3, to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
+We utilize the same functionality as for Example 3 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
 We first call `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the the rule RedmondFourDigit and assign it to the variable $Rule. Next we remove this Object with the Remove Method from $DP.NormalizationRules.
 Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
 

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -79,35 +79,6 @@ We then assign the string RedmondRule to the Name property of the object.
 Next, we pass the variable to the Instance parameter of the `Set-CsVoiceNormalizationRule` cmdlet to make the change permanent.
 
 
-### -------------------------- Example 4 --------------------------
-```
-$DP = Get-CsTenantDialPlan -Identity Global
-$Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
-$Rule.Name = "RedmondRule"
-Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
-```
-
-Example 4 applies to Teams only and changes the name of the normalization rule.
-Keep in mind that changing the name also changes the name portion of the Identity.
-The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name, we first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign the returned object to the variable $Rule.
-We then assign the string RedmondRule to the Name property of the object.
-Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
-
-
-### -------------------------- Example 5 --------------------------
-```
-$DP = Get-CsTenantDialPlan -Identity Global
-$Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
-$DP.NormalizationRules.Remove($Rule)
-Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
-```
-
-Example 5 applies to Teams only and removes a normalization rule.
-We utilize the same functionality as for Example 4 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
-We first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign it to the variable $Rule. Next, we remove this Object with the Remove Method from $DP.NormalizationRules.
-Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
-
-
 ## PARAMETERS
 
 ### -Identity

--- a/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
+++ b/skype/skype-ps/skype/Set-CsVoiceNormalizationRule.md
@@ -67,32 +67,48 @@ For example, if the existing pattern matched any four-digit number and the numbe
 
 ### -------------------------- Example 3 --------------------------
 ```
+# NOTE: This Example applies to Skype for Business Server only
+$a = Get-CsVoiceNormalizationRule -Identity global/RedmondFourDigit
+$a.name = "RedmondRule"
+Set-CsVoiceNormalizationRule -Instance $a
+```
+
+Example 3 applies to Skype For Business Server only and changes the name of the normalization rule.
+Keep in mind that changing the name also changes the name portion of the Identity.
+The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name we first call the `Get-CsVoiceNormalizationRule` cmdlet to retrieve the rule with the Identity global/RedmondFourDigit and assign the returned object to the variable $a.
+We then assign the string RedmondRule to the Name property of the object.
+Next, we pass the variable to the Instance parameter of the `Set-CsVoiceNormalizationRule` cmdlet to make the change permanent.
+
+
+### -------------------------- Example 4 --------------------------
+```
+# NOTE: This Example applies to Teams only
 $DP = Get-CsTenantDialPlan -Identity Global
 $Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
 $Rule.Name = "RedmondRule"
 Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 ```
 
-Example 3 changes the name of the normalization rule.
+Example 4 applies to Teams only and changes the name of the normalization rule.
 Keep in mind that changing the name also changes the name portion of the Identity.
 The `Set-CsVoiceNormalizationRule` cmdlet doesn't have a Name parameter, so in order to change the name, we first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign the returned object to the variable $Rule.
 We then assign the string RedmondRule to the Name property of the object.
 Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
 
 
-### -------------------------- Example 4 --------------------------
+### -------------------------- Example 5 --------------------------
 ```
+# NOTE: This Example applies to Teams only
 $DP = Get-CsTenantDialPlan -Identity Global
 $Rule = $DP.NormalizationRules | Where Name -eq "RedmondFourDigit")
 $DP.NormalizationRules.Remove($Rule)
 Set-CsTenantDialPlan -Identity Global -NormalizationRules $DP.NormalizationRules
 ```
 
-Example 4 removes a normalization rule.
+Example 5 applies to Teams only and removes a normalization rule.
 We utilize the same functionality as for Example 3 to manipulate the Normalization Rule Object and update it with the `Set-CsTenantDialPlan` cmdlet.
 We first call the `Set-CsTenantDialPlan` cmdlet to retrieve the Dial Plan with the Identity Global and assign the returned object to the variable $DP. Then we filter the NormalizationRules Object for the rule RedmondFourDigit and assign it to the variable $Rule. Next, we remove this Object with the Remove Method from $DP.NormalizationRules.
 Finally, we pass the variable back to the NormalizationRules parameter of the `Set-CsTenantDialPlan` cmdlet to make the change permanent.
-
 
 
 ## PARAMETERS


### PR DESCRIPTION
Example three is outdated and does not work as written.
MicrosoftTeams v4.x has a new method to facilitate Name changes and removals (Remove-CsVoiceNormalisationRule was removed in v4.x)

This will fixes #9588