### PR TITLE
Update New-SafeLinksRule.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-SafeLinksRule.md
+++ b/exchange/exchange-ps/exchange/New-SafeLinksRule.md
@@ -311,7 +311,7 @@ Accept wildcard characters: False
 ```
 
 ### -SentToMemberOf
-The SentToMemberOf parameter specifies a condition that looks for messages sent to members of distribution groups, dynamic distribution groups, or mail-enabled security groups. You can use any value that uniquely identifies the group. For example:
+The SentToMemberOf parameter specifies a condition that looks for messages sent to members of distribution groups or mail-enabled security groups. You can use any value that uniquely identifies the group. For example:
 
 - Name
 - Alias


### PR DESCRIPTION
Remove the mention of Dynamic Distribution Groups from the documentation as they are not supported at this time.