### PR TITLE
Update Import-ExchangeCertificate.md

### DIFF
--- a/exchange/exchange-ps/exchange/Import-ExchangeCertificate.md
+++ b/exchange/exchange-ps/exchange/Import-ExchangeCertificate.md
@@ -77,16 +77,16 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Import-ExchangeCertificate -Server Mailbox01 -FileName "\\FileServer01\Data\Exported Fabrikam Cert.pfx" -Password (ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force)
+Import-ExchangeCertificate -Server Mailbox01 -FileName "\\FileServer01\Data\Exported Fabrikam Cert.pfx" -Password:(Get-Credential).password -AsPlainText -Force)
 ```
 
-In **Exchange 2013**, this example imports the certificate from the PKCS #12 file from \\\\FileServer01\\Data\\Exported Fabrikam Cert.pfx to the Exchange server named Mailbox01. This file requires the password P@ssw0rd1. This certificate could have been exported from another server, or issued by a certification authority.
+In **Exchange 2013**, this example imports the certificate from the PKCS #12 file from \\\\FileServer01\\Data\\Exported Fabrikam Cert.pfx to the Exchange server named Mailbox01. This file requires the password of the file. This certificate could have been exported from another server, or issued by a certification authority.
 
 To export the certificate in Exchange 2016 or Exchange 2019, use the FileData parameter as described in Example 2.
 
 ### Example 2
 ```powershell
-Import-ExchangeCertificate -Server Mailbox01 -FileData ([System.IO.File]::ReadAllBytes('\\FileServer01\Data\Exported Fabrikam Cert.pfx')) -Password (ConvertTo-SecureString -String 'P@ssw0rd1' -AsPlainText -Force)
+Import-ExchangeCertificate -Server Mailbox01 -FileData ([System.IO.File]::ReadAllBytes('\\FileServer01\Data\Exported Fabrikam Cert.pfx')) -Password:(Get-Credential).password
 ```
 
 This example imports the same certificate file from Example 1. This method is required in Exchange 2016 and Exchange 2019 because the FileName parameter is not available.
@@ -223,6 +223,7 @@ Accept wildcard characters: False
 The Password parameter specifies the password that's required to import the certificate.
 
 This parameter uses the syntax `(ConvertTo-SecureString -String '<password>' -AsPlainText -Force)`. Or, before you run this command, store the password as a variable (for example, `$password = Read-Host "Enter password" -AsSecureString`), and then use the variable name (`$password`) for this parameter.
+You can use too a credential box to enter it securely '(Get-Credential).password'
 
 ```yaml
 Type: SecureString

--- a/exchange/exchange-ps/exchange/Import-ExchangeCertificate.md
+++ b/exchange/exchange-ps/exchange/Import-ExchangeCertificate.md
@@ -77,7 +77,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Import-ExchangeCertificate -Server Mailbox01 -FileName "\\FileServer01\Data\Exported Fabrikam Cert.pfx" -Password:(Get-Credential).password -AsPlainText -Force)
+Import-ExchangeCertificate -Server Mailbox01 -FileName "\\FileServer01\Data\Exported Fabrikam Cert.pfx" -Password (Get-Credential).password -AsPlainText -Force)
 ```
 
 In **Exchange 2013**, this example imports the certificate from the PKCS #12 file from \\\\FileServer01\\Data\\Exported Fabrikam Cert.pfx to the Exchange server named Mailbox01. This file requires the password of the file. This certificate could have been exported from another server, or issued by a certification authority.
@@ -86,7 +86,7 @@ To export the certificate in Exchange 2016 or Exchange 2019, use the FileData pa
 
 ### Example 2
 ```powershell
-Import-ExchangeCertificate -Server Mailbox01 -FileData ([System.IO.File]::ReadAllBytes('\\FileServer01\Data\Exported Fabrikam Cert.pfx')) -Password:(Get-Credential).password
+Import-ExchangeCertificate -Server Mailbox01 -FileData ([System.IO.File]::ReadAllBytes('\\FileServer01\Data\Exported Fabrikam Cert.pfx')) -Password (Get-Credential).password
 ```
 
 This example imports the same certificate file from Example 1. This method is required in Exchange 2016 and Exchange 2019 because the FileName parameter is not available.
@@ -222,8 +222,11 @@ Accept wildcard characters: False
 ### -Password
 The Password parameter specifies the password that's required to import the certificate.
 
-This parameter uses the syntax `(ConvertTo-SecureString -String '<password>' -AsPlainText -Force)`. Or, before you run this command, store the password as a variable (for example, `$password = Read-Host "Enter password" -AsSecureString`), and then use the variable name (`$password`) for this parameter.
-You can use too a credential box to enter it securely '(Get-Credential).password'
+You can use the following methods as a value for this parameter:
+
+- `(ConvertTo-SecureString -String '<password>' -AsPlainText -Force)`.
+- Before you run this command, store the password as a variable (for example, `$password = Read-Host "Enter password" -AsSecureString`), and then use the variable (`$password`) for the value.
+- `(Get-Credential).password` to be prompted to enter the password securely when you run this command.
 
 ```yaml
 Type: SecureString


### PR DESCRIPTION
Hello,
I think that suggesting customer to use a defaut password like P@ssw0rd1 with is a well know one and use in all brute force attack is really not a good habbit to provide to customer to Manage their certificate Private Key.
Huge security breach IMO
asking for a docs change for the export-exchangecertificate cmdlet too