### PR TITLE
Updated Connect-MicrosoftTeams cmdlet syntax

### DIFF
--- a/teams/teams-ps/teams/Connect-MicrosoftTeams.md
+++ b/teams/teams-ps/teams/Connect-MicrosoftTeams.md
@@ -80,10 +80,10 @@ Account                 Environment 	Tenant                                Tenan
 user@contoso.com        TeamsGCCH   xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-### Example 4: Connect to MicrosoftTeams using Accesstokens
-This example demonstrates how to sign in using AccessTokens. Admin can retrieve Access Tokens. It requires two tokens, MS Graph Access Token and Teams Resource token. 
+### Example 4: Connect to MicrosoftTeams using Access Tokens
+This example demonstrates how to sign in using Access Tokens. Admin can retrieve Access Tokens via the login.microsoftonline.com endpoint. It requires two tokens, MS Graph Access Token and Teams Resource token. 
 
-A delegated flow, such as Resource Owner Password Credentials (ROPC), must be used, with the following delegated app permissions required.
+A delegated flow, such as Resource Owner Password Credentials (ROPC) or device code, must be used, with the following delegated app permissions required.
 
 | API | Grant type | Permission |
 |-|-|-|
@@ -93,21 +93,24 @@ A delegated flow, such as Resource Owner Password Credentials (ROPC), must be us
 | Skype and Teams Tenant Admin API | Delegated | user_impersonation |
 
 ```powershell
-$tenantid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-$clientid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-$clientsecret = "..."
-$username = "user@contoso.onmicrosoft.com"
-$password = "..."
+$ClientID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+$ClientSecret = "..."
+$ClientSecret = [Net.WebUtility]::URLEncode($ClientSecret)
+$TenantID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+$Username = "user@contoso.onmicrosoft.com"
+$Password = "..."
+$Password = [Net.WebUtility]::URLEncode($Password)
 
-$uri = "https://login.microsoftonline.com/{0}/oauth2/v2.0/token" -f $tenantid
-$body = "client_id={0}&scope=https://graph.microsoft.com/.default&username={1}&password={2}&grant_type=password&client_secret={3}" -f $clientid, $username, [System.Net.WebUtility]::UrlEncode($password), [System.Net.WebUtility]::UrlEncode($clientsecret)
-$graphtoken = Invoke-RestMethod $uri -Body $body -Method Post -ContentType "application/x-www-form-urlencoded" -ErrorAction SilentlyContinue | Select-object -ExpandProperty access_token
-
-$uri = "https://login.microsoftonline.com/{0}/oauth2/v2.0/token" -f $tenantid
-$body = "client_id={0}&scope=48ac35b8-9aa8-4d74-927d-1f4a14a0b239/.default&username={1}&password={2}&grant_type=password&client_secret={3}" -f $clientid, $username, [System.Net.WebUtility]::UrlEncode($password), [System.Net.WebUtility]::UrlEncode($clientsecret)
-$teamstoken = Invoke-RestMethod $uri -Body $body -Method Post -ContentType "application/x-www-form-urlencoded" -ErrorAction SilentlyContinue | Select-object -ExpandProperty access_token
-
-Connect-MicrosoftTeams -AccessTokens @($graphtoken, $teamstoken)
+$URI = "https://login.microsoftonline.com/$TenantID/oauth2/v2.0/token"
+$Body = "client_id=$ClientID&client_secret=$ClientSecret&grant_type=password&username=$Username&password=$Password"
+$RequestParameters = @{
+  URI = $URI
+  Method = "POST"
+  ContentType = "application/x-www-form-urlencoded"
+}
+$GraphToken = (Invoke-RestMethod @RequestParameters -Body "$Body&scope=https://graph.microsoft.com/.default").access_token
+$TeamsToken = (Invoke-RestMethod @RequestParameters -Body "$Body&scope=48ac35b8-9aa8-4d74-927d-1f4a14a0b239/.default").access_token
+Connect-MicrosoftTeams -AccessTokens @($GraphToken, $TeamsToken)
 
 Account                 Environment 	Tenant                                TenantId                         
 -------                 -----------  ------------------------------------  ------------------------------------


### PR DESCRIPTION
Removed -f (format) for substitution, replacing them with string interpolation. Also switched to using Splatting for the request parameters, to reduce code reuse.