### PR TITLE
Adding Example 2 to illustrate NotificationGroup parameter 

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
@@ -42,7 +42,7 @@ PS C:>   New-CsTeamsEmergencyCallingPolicy -Identity testECP -Description "Test 
 PS C:>  New-CsTeamsEmergencyCallingPolicy -Identity "testECP2" -NotificationGroup "123@gh.com;567@test.com"
 ```
 
- This example creates a Teams Emergency Calling policy that has a identity of testECP2, with default settings except for the Notification Group. This parameter expects a single string with all users and groups separated with ";".
+ This example creates a Teams Emergency Calling policy that has an identity of testECP2, with default settings except for the Notification Group. This parameter expects a single string with all users and groups separated with ";".
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
@@ -37,6 +37,13 @@ PS C:>   New-CsTeamsEmergencyCallingPolicy -Identity testECP -Description "Test 
 
  This example creates a Teams Emergency Calling policy that has a identity of testECP, where a notification group and number is being defined, the external location lookup mode is enabled and also the type of notification.
 
+### Example 2
+```powershell
+PS C:>  New-CsTeamsEmergencyCallingPolicy -Identity "testECP2" -NotificationGroup "123@gh.com;567@test.com"
+```
+
+ This example creates a Teams Emergency Calling policy that has a identity of testECP2, with default settings except for the Notification Group. This parameter expects a single string with all users and groups separated with ";".
+
 ## PARAMETERS
 
 ### -Confirm


### PR DESCRIPTION
Set-CsTeamsEmergencyCallingPolicy has a good example on how to use the NotificationGroup parameter.
Copying this example here as Example 2

Addresses #9653