### PR TITLE
Update New-Mailbox.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-Mailbox.md
+++ b/exchange/exchange-ps/exchange/New-Mailbox.md
@@ -267,7 +267,13 @@ New-Mailbox [-Name] <String> [-Discovery] [-Password <SecureString>] [-UserPrinc
 
 ### EnableRoomMailboxAccount
 ```
-New-Mailbox [-Name] <String> -EnableRoomMailboxAccount <Boolean> [-MicrosoftOnlineServicesID <WindowsLiveId> [-Room] [-RoomMailboxPassword <SecureString>] [-UserPrincipalName <String>]
+New-Mailbox  
+ [-Name] <String>  
+ -EnableRoomMailboxAccount <Boolean>  
+ -MicrosoftOnlineServicesID <WindowsLiveId>  
+ [-Room]  
+ [-RoomMailboxPassword <SecureString>]  
+ [-UserPrincipalName <String>]
  [-ActiveSyncMailboxPolicy <MailboxPolicyIdParameter>]
  [-AddressBookPolicy <AddressBookMailboxPolicyIdParameter>]
  [-Alias <String>]

--- a/exchange/exchange-ps/exchange/New-Mailbox.md
+++ b/exchange/exchange-ps/exchange/New-Mailbox.md
@@ -267,13 +267,7 @@ New-Mailbox [-Name] <String> [-Discovery] [-Password <SecureString>] [-UserPrinc
 
 ### EnableRoomMailboxAccount
 ```
-New-Mailbox  
- [-Name] <String>  
- -EnableRoomMailboxAccount <Boolean>  
- -MicrosoftOnlineServicesID <WindowsLiveId>  
- [-Room]  
- [-RoomMailboxPassword <SecureString>]  
- [-UserPrincipalName <String>]
+New-Mailbox [-Name] <String> -EnableRoomMailboxAccount <Boolean> [-MicrosoftOnlineServicesID <WindowsLiveId>] [-Room] [-RoomMailboxPassword <SecureString>] [-UserPrincipalName <String>]
  [-ActiveSyncMailboxPolicy <MailboxPolicyIdParameter>]
  [-AddressBookPolicy <AddressBookMailboxPolicyIdParameter>]
  [-Alias <String>]


### PR DESCRIPTION
In the EnableRoomMailboxAccount parameter set, I believe there was an extra opening square bracket '[' making it ambiguous whether `MicrosoftOnlineServiceID` was a required parameter or not.  In all other parameter sets where the parameter appears, it is a named, required parameter.  
Also, a number of parameters in the same parameter set did not have double trailing spaces which can lead to unexpected rendering.