### PR TITLE
Added information about UTC time format

### DIFF
--- a/exchange/exchange-ps/exchange/Get-MessageTrace.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTrace.md
@@ -46,7 +46,7 @@ To search for message data that is greater than 10 days old, use the Start-Histo
 
 By default, this cmdlet returns a maximum of 1000 results, and will timeout on very large queries. If your query returns too many results, consider splitting it up using smaller StartDate and EndDate intervals.
 
-The time stamps on the output are in UTC time format. That might be different time format than you were using for the -StartDate and the -EndDate parameters.
+The time stamps on the output are in UTC time format. That might be different from the time format that you used for the -StartDate and the -EndDate parameters.
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see [Find the permissions required to run any Exchange cmdlet](https://docs.microsoft.com/powershell/exchange/find-exchange-cmdlet-permissions).
 

--- a/exchange/exchange-ps/exchange/Get-MessageTrace.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTrace.md
@@ -46,6 +46,8 @@ To search for message data that is greater than 10 days old, use the Start-Histo
 
 By default, this cmdlet returns a maximum of 1000 results, and will timeout on very large queries. If your query returns too many results, consider splitting it up using smaller StartDate and EndDate intervals.
 
+The time stamps on the output are in UTC time format. That might be different time format than you were using for the -StartDate and the -EndDate parameters.
+
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see [Find the permissions required to run any Exchange cmdlet](https://docs.microsoft.com/powershell/exchange/find-exchange-cmdlet-permissions).
 
 ## EXAMPLES


### PR DESCRIPTION
It could be confusing for user when s/he is filtering emails on local time format, but output is showing actually UTC time format.

There is also a tiny challenge, as if you use "get-date -adddays ()" for defining the start-/enddates you are looking for, then you are getting a bit different results.

But purpose of this was just clarify the UTC time format on the output.