### PR TITLE
Update Set-ATPBuiltInProtectionRule.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-ATPBuiltInProtectionRule.md
+++ b/exchange/exchange-ps/exchange/Set-ATPBuiltInProtectionRule.md
@@ -172,8 +172,7 @@ The ExceptIfSentToMemberOf parameter specifies an exception that looks for messa
 - Email address
 - GUID
 
-> [!NOTE]
-> Dynamic distribution groups are not supported.
+Dynamic distribution groups are not supported.
 
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
 

--- a/exchange/exchange-ps/exchange/Set-ATPBuiltInProtectionRule.md
+++ b/exchange/exchange-ps/exchange/Set-ATPBuiltInProtectionRule.md
@@ -172,6 +172,8 @@ The ExceptIfSentToMemberOf parameter specifies an exception that looks for messa
 - Email address
 - GUID
 
+[!NOTE] Dynamic Distribution Groups (DDG) are not supported.
+
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
 
 If you remove the group after you create the rule, no exception is made for messages that are sent to members of the group.

--- a/exchange/exchange-ps/exchange/Set-ATPBuiltInProtectionRule.md
+++ b/exchange/exchange-ps/exchange/Set-ATPBuiltInProtectionRule.md
@@ -172,7 +172,8 @@ The ExceptIfSentToMemberOf parameter specifies an exception that looks for messa
 - Email address
 - GUID
 
-[!NOTE] Dynamic Distribution Groups (DDG) are not supported.
+> [!NOTE]
+> Dynamic distribution groups are not supported.
 
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
 


### PR DESCRIPTION
Need clarification that Dynamic Distribution Groups cannot be specified in Groups option of policies. They are accepted by command, but will not work as expected.

https://o365exchange.visualstudio.com/IP%20Engineering/_workitems/edit/3010772