### PR TITLE
Replaced commas with decimal places for GeoCoordinates

### DIFF
--- a/exchange/exchange-ps/exchange/Set-Place.md
+++ b/exchange/exchange-ps/exchange/Set-Place.md
@@ -252,6 +252,8 @@ The GeoCoordinates parameter specifies the room's location in latitude, longitud
 - Latitude and longitude: For example, "47.644125;-122.122411"
 - Latitude, longitude, and altitude: For example, "47.644125;-122.122411;161.432"
 
+**Note**: If period separators don't work for you, use commas instead.
+
 ```yaml
 Type: GeoCoordinates
 Parameter Sets: (All)

--- a/exchange/exchange-ps/exchange/Set-Place.md
+++ b/exchange/exchange-ps/exchange/Set-Place.md
@@ -249,8 +249,8 @@ Accept wildcard characters: False
 ### -GeoCoordinates
 The GeoCoordinates parameter specifies the room's location in latitude, longitude and (optionally) altitude coordinates. A valid value for this parameter uses one of the following formats:
 
-- Latitude and longitude: For example, "47,644125;-122,122411"
-- Latitude, longitude, and altitude: For example, "47,644125;-122,122411;161,432"
+- Latitude and longitude: For example, "47.644125;-122.122411"
+- Latitude, longitude, and altitude: For example, "47.644125;-122.122411;161.432"
 
 ```yaml
 Type: GeoCoordinates


### PR DESCRIPTION
Existing documentation incorrectly showed commas in the numbers, which is not accepted by the cmdlet.