### PR TITLE
Fix Identity Parameter for Remove cmdlet

### DIFF
--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
@@ -26,7 +26,8 @@ Remove-CsTeamsShiftsPolicy [-Identity] <XdsIdentity> [<CommonParameters>]
 PS C:\> Remove-CsTeamsShiftsPolicy -Identity OffShiftAccess_WarningMessage1_AlwaysShowMessage
 ```
 
-In this example, the policy instance to be removed is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage" 
+In this example, the policy instance to be removed is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage". 
+
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
@@ -36,7 +36,7 @@ Policy instance name.
 
 ```yaml
 Type: XdsIdentity
-Parameter Sets: Identity
+Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams
 Required: True

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
@@ -38,7 +38,7 @@ Type: XdsIdentity
 Parameter Sets: Identity
 Aliases:
 Applicable: Microsoft Teams
-Required: False
+Required: True
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsShiftsPolicy.md
@@ -9,9 +9,9 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Remove the TeamsShiftPolicy for a user.
+The `Remove-CsTeamsShiftsPolicy` cmdlet removes a previously created TeamsShiftsPolicy.
 
-Note: the command will return immediately, but the Teams application will not reflect the update immediately. The Teams application may need to be open for up to an hour before changes are reflected.
+Note: A TeamsShiftsPolicy needs to be unassigned from all the users before it can be deleted.
 
 ## SYNTAX
 
@@ -23,25 +23,25 @@ Remove-CsTeamsShiftsPolicy [-Identity] <XdsIdentity> [<CommonParameters>]
 
 ### Example 1
 ```powershell
-PS C:\> Remove-CsTeamsShiftsPolicy -Identity IsaiahL
+PS C:\> Remove-CsTeamsShiftsPolicy -Identity OffShiftAccess_WarningMessage1_AlwaysShowMessage
 ```
 
-In this example, the TeamsShiftsPolicy assigned to the user "IsaiahL" is removed.
+In this example, the policy instance to be removed is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage" 
 
 ## PARAMETERS
 
 ### -Identity
-UserId or user's email id.
+Policy instance name.
 
 ```yaml
 Type: XdsIdentity
-Parameter Sets: (All)
+Parameter Sets: Identity
 Aliases:
 Applicable: Microsoft Teams
-Required: True
+Required: False
 Position: 1
 Default value: None
-Accept pipeline input: True (ByPropertyName)
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
Parameter Identity referrers to a Policy Instance Name (XdsIdentity) for Remove Cmdlets 

If users follow the current documentation and try to pass a UserId or UserEmail, the cmdlet will not work and will throw exceptions.