### PR TITLE
Update Set-Label.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-Label.md
+++ b/exchange/exchange-ps/exchange/Set-Label.md
@@ -224,6 +224,8 @@ The ApplyContentMarkingFooterFontName parameter specifies the font of the footer
 
 This parameter is meaningful only when the ApplyContentMarkingFooterEnabled parameter value is either $true or $false.
 
+This parameter is supported only by the Azure Information Protection unified labeling client and not by Office apps and services that support built-in labeling.
+
 ```yaml
 Type: String
 Parameter Sets: (All)


### PR DESCRIPTION
Updating Set-Label documentation to specify that -ApplyContentMarkingFooterFontName is not supported for built-in labeling.