### PR TITLE
Update New-Label.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-Label.md
+++ b/exchange/exchange-ps/exchange/New-Label.md
@@ -244,6 +244,8 @@ The ApplyContentMarkingFooterFontName parameter specifies the font of the footer
 
 This parameter is meaningful only when the ApplyContentMarkingFooterEnabled parameter value is either $true or $false.
 
+This parameter is supported only by the Azure Information Protection unified labeling client and not by Office apps and services that support built-in labeling.
+
 ```yaml
 Type: String
 Parameter Sets: (All)


### PR DESCRIPTION
Updating New-Label documentation to reflect that the -ApplyContentMarkingFooterFontName parameter is not supported for built-in labeling for Office apps.