### PR TITLE
Changes for SMimeSuppressNameChecksEnabled switch

### DIFF
--- a/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
@@ -2065,6 +2065,8 @@ Accept wildcard characters: False
 ### -SMimeSuppressNameChecksEnabled
 This parameter is available only in the cloud-based service.
 
+The SMimeSuppressNameChecksEnabled switch specifies whether to suppress name check in S/MIME messages. You don't need to specify a value with this switch.
+
 ```yaml
 Type: Boolean
 Parameter Sets: (All)

--- a/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
@@ -2065,8 +2065,6 @@ Accept wildcard characters: False
 ### -SMimeSuppressNameChecksEnabled
 This parameter is available only in the cloud-based service.
 
-This parameter is reserved for internal Microsoft use.
-
 ```yaml
 Type: Boolean
 Parameter Sets: (All)


### PR DESCRIPTION
For the SMimeSuppressNameChecksEnabled switch can we modify the documentation as currently it says This parameter is reserved for internal Microsoft use. However, this is usable in PowerShell for tenants and even more this was approved/implemented as DCR somewhere in April 2022.

Tested this in test tenant and the switch works as intended (per info in the DCR)