### PR TITLE
Update Add-RoleGroupMember.md

### DIFF
--- a/exchange/exchange-ps/exchange/Add-RoleGroupMember.md
+++ b/exchange/exchange-ps/exchange/Add-RoleGroupMember.md
@@ -96,6 +96,9 @@ The Member parameter specifies who you want to add to the role group. You can sp
 - Mail-enabled security groups (don't use in Security & Compliance PowerShell)
 - Security groups (on-premises Exchange only)
 
+Kindly note that the Security Groups/Mail-enabled security groups cannot be added as a member of the role group in the Microsoft Purview Portal, please add them via PowerShell with this parameter.
+
+
 You can use any value that uniquely identifies the user or group. For example:
 
 - Name

--- a/exchange/exchange-ps/exchange/Add-RoleGroupMember.md
+++ b/exchange/exchange-ps/exchange/Add-RoleGroupMember.md
@@ -96,8 +96,7 @@ The Member parameter specifies who you want to add to the role group. You can sp
 - Mail-enabled security groups (don't use in Security & Compliance PowerShell)
 - Security groups (on-premises Exchange only)
 
-Kindly note that the Security Groups/Mail-enabled security groups cannot be added as a member of the role group in the Microsoft Purview Portal, please add them via PowerShell with this parameter.
-
+Note that you cannot add security groups and mail-enabled security groups as members of the role group in the Microsoft Purview portal. You should add them via PowerShell with this parameter.
 
 You can use any value that uniquely identifies the user or group. For example:
 

--- a/exchange/exchange-ps/exchange/Add-RoleGroupMember.md
+++ b/exchange/exchange-ps/exchange/Add-RoleGroupMember.md
@@ -96,7 +96,7 @@ The Member parameter specifies who you want to add to the role group. You can sp
 - Mail-enabled security groups (don't use in Security & Compliance PowerShell)
 - Security groups (on-premises Exchange only)
 
-Note that you cannot add security groups and mail-enabled security groups as members of the role group in the Microsoft Purview portal. You should add them via PowerShell with this parameter.
+You can't add security groups or mail-enabled security groups as members of the role group in the Microsoft Purview portal. You should add them via PowerShell with this parameter.
 
 You can use any value that uniquely identifies the user or group. For example:
 


### PR DESCRIPTION
Confirmed with the engineering team who manages the UI in the Microsoft Purview Portal, the current legacy picker to select the members has no ability to select Security Groups and will be retired in the following months. The new picker is able to select Security Group and will replace the old one. 
Hence, we need to update this article for now to inform customer and guide them to use the cmdlet.