### PR TITLE
Added more examples and explanations

### DIFF
--- a/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
@@ -24,7 +24,7 @@ Get-CsOnlineDialOutPolicy [[-Identity] <string>] [<CommonParameters>]
 
 ### Filter
 ```
-Get-CsOnlineDialOutPolicy [-Filter <String>] [<CommonParameters>]
+Get-CsOnlineDialOutPolicy [-Filter <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
@@ -98,4 +98,4 @@ For more information, see about_CommonParameters (https://go.microsoft.com/fwlin
 ## NOTES
 
 ## RELATED LINKS
-[Grant-CsDialoutPolicy](https://learn.microsoft.com/powershell/module/skype/grant-csdialoutpolicy)
+[Grant-CsDialoutPolicy](grant-csdialoutpolicy.md)

--- a/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
@@ -28,7 +28,7 @@ Get-CsOnlineDialOutPolicy [-Filter <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies applies to all the different PSTN connectivity options for Microsoft Teams - Calling Plan, Direct Routing and Operator Connect.
+In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies apply to all the different PSTN connectivity options for Microsoft Teams; Calling Plan, Direct Routing, and Operator Connect.
 
 To get all the available policies in your organization run `Get-CsOnlineDialOutPolicy`.
 To assign one of these policies to a user run `Grant-CsDialoutPolicy`.

--- a/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
@@ -1,12 +1,12 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml 
 online version: https://learn.microsoft.com/powershell/module/skype/get-csonlinedialoutpolicy
-applicable: Skype for Business Online
+applicable: Microsoft Teams
 title: Get-CsOnlineDialOutPolicy
 schema: 2.0.0
 manager: bulenteg
-author: tomkau
-ms.author: tomkau
+author: jenstrier
+ms.author: jenstr
 ms.reviewer:
 ---
 
@@ -19,39 +19,40 @@ Use the `Get-CsOnlineDialOutPolicy` cmdlet to get all the available outbound cal
 
 ### Identity (Default)
 ```
-Get-CsOnlineDialOutPolicy [[-Identity] <XdsIdentity>] [-LocalStore] [<CommonParameters>]
+Get-CsOnlineDialOutPolicy [[-Identity] <string>] [<CommonParameters>]
 ```
 
 ### Filter
 ```
-Get-CsOnlineDialOutPolicy [-Filter <String>] [-LocalStore] [<CommonParameters>]
+Get-CsOnlineDialOutPolicy [-Filter <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-In Skype for Business Online, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. 
-To get all the available policies in your organization run `Get-CSOnlineDialOutPolicy`.
+In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies applies to all the different PSTN connectivity options for Microsoft Teamss - Calling Plan, Direct Routing and Operator Connect.
+
+To get all the available policies in your organization run `Get-CsOnlineDialOutPolicy`.
 To assign one of these policies to a user run `Grant-CsDialoutPolicy`.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Get-CSOnlineDialOutPolicy
+Get-CsOnlineDialOutPolicy
 ```
 
-In Example 1, `Get-CSOnlineDialOutPolicy` is called without any additional parameters; this returns a collection of all the outbound calling restriction policies configured for use in your organization.
+In Example 1, `Get-CsOnlineDialOutPolicy` is called without any additional parameters; this returns a collection of all the outbound calling restriction policies configured for use in your organization.
 
 ### Example 2
 ```powershell
-PS C:\> Get-CSOnlineDialOutPolicy -Identity DialoutCPCandPSTNDisabled
+Get-CsOnlineDialOutPolicy -Identity DialoutCPCandPSTNDisabled
 ```
 
-In Example 2, `Get-CSOnlineDialOutPolicy` is used to return the per-user outbound calling restriction policy that has an Identity DialoutCPCandPSTNDisabled. Because identities are unique, this command will never return more than one item.
+In Example 2, `Get-CsOnlineDialOutPolicy` is used to return the per-user outbound calling restriction policy that has an Identity DialoutCPCandPSTNDisabled. Because identities are unique, this command will never return more than one item.
 
 ## PARAMETERS
 
 ### -Filter
-Enables you to use wildcard characters when indicating the policy (or policies) to be returned. To return a collection of all the per-user policies, use this syntax: -Filter "tag:\*".
+Enables you to use wildcard characters when indicating the policy (or policies) to be returned. To return a collection of all the per-user policies, use this syntax: -Filter "tag:*".
 
 ```yaml
 Type: String
@@ -71,27 +72,12 @@ Unique identifier of the outbound calling restriction policy to be returned. To 
 If this parameter is omitted, then all the outbound calling restriction policies configured for use in your tenant will be returned.
 
 ```yaml
-Type: XdsIdentity
+Type: String
 Parameter Sets: Identity
 Aliases:
 
 Required: False
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LocalStore
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
+++ b/skype/skype-ps/skype/Get-CsOnlineDialOutPolicy.md
@@ -28,7 +28,7 @@ Get-CsOnlineDialOutPolicy [-Filter <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies applies to all the different PSTN connectivity options for Microsoft Teamss - Calling Plan, Direct Routing and Operator Connect.
+In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies applies to all the different PSTN connectivity options for Microsoft Teams - Calling Plan, Direct Routing and Operator Connect.
 
 To get all the available policies in your organization run `Get-CsOnlineDialOutPolicy`.
 To assign one of these policies to a user run `Grant-CsDialoutPolicy`.

--- a/skype/skype-ps/skype/Grant-CsDialoutPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsDialoutPolicy.md
@@ -33,7 +33,7 @@ Grant-CsDialoutPolicy [-Group] <string> [[-PolicyName] <string>] [-PassThru] [-R
 ```
 
 ## DESCRIPTION
-In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies applies to all the different PSTN connectivity options for Microsoft Teams - Calling Plan, Direct Routing and Operator Connect.
+In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies apply to all the different PSTN connectivity options for Microsoft Teams; Calling Plan, Direct Routing, and Operator Connect.
 
 To get all the available policies in your organization run `Get-CsOnlineDialOutPolicy`.
 

--- a/skype/skype-ps/skype/Grant-CsDialoutPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsDialoutPolicy.md
@@ -33,7 +33,8 @@ Grant-CsDialoutPolicy [-Group] <string> [[-PolicyName] <string>] [-PassThru] [-R
 ```
 
 ## DESCRIPTION
-In Skype for Business Online and Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization.
+In Microsoft Teams, outbound calling restriction policies are used to restrict the type of audio conferencing and end user PSTN calls that can be made by users in your organization. The policies applies to all the different PSTN connectivity options for Microsoft Teams - Calling Plan, Direct Routing and Operator Connect.
+
 To get all the available policies in your organization run `Get-CsOnlineDialOutPolicy`.
 
 ## EXAMPLES

--- a/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
@@ -46,7 +46,8 @@ This cmdlet assigns a Teams Emergency Call Routing policy to a user, a group of 
 Grant-CsTeamsEmergencyCallRoutingPolicy -Identity user1 -PolicyName Test
 ```
 
-This example assigns a Teams Emergency Call Routing policy(Test) to a user(user1).
+This example assigns a Teams Emergency Call Routing policy (Test) to a user (user1).
+
 
 ### Example 2
 ```powershell

--- a/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
@@ -43,7 +43,7 @@ This cmdlet assigns a Teams Emergency Call Routing policy to a user, a group of 
 
 ### Example 1
 ```powershell
-PS C:> Grant-CsTeamsEmergencyCallRoutingPolicy -Identity user1 -PolicyName Test
+Grant-CsTeamsEmergencyCallRoutingPolicy -Identity user1 -PolicyName Test
 ```
 
 This example assigns a Teams Emergency Call Routing policy(Test) to a user(user1).

--- a/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
@@ -43,10 +43,17 @@ This cmdlet assigns a Teams Emergency Call Routing policy to a user, a group of 
 
 ### Example 1
 ```powershell
-PS C:> Grant-CsTeamsEmergencyCallRoutingPolicy -Identity user1 -PolicyName TestECRP
+PS C:> Grant-CsTeamsEmergencyCallRoutingPolicy -Identity user1 -PolicyName Test
 ```
 
-This example assigns a Teams Emergency Call Routing policy(TestECRP) to a user(user1)
+This example assigns a Teams Emergency Call Routing policy(Test) to a user(user1).
+
+### Example 2
+```powershell
+Grant-CsTeamsEmergencyCallRoutingPolicy -Group sales@contoso.com -Rank 10 -PolicyName Test
+```
+
+This example assigns the Teams Emergency Call Routing policy(Test) to the members of the group sales@contoso.com.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsEmergencyCallRoutingPolicy.md
@@ -54,7 +54,8 @@ This example assigns a Teams Emergency Call Routing policy (Test) to a user (use
 Grant-CsTeamsEmergencyCallRoutingPolicy -Group sales@contoso.com -Rank 10 -PolicyName Test
 ```
 
-This example assigns the Teams Emergency Call Routing policy(Test) to the members of the group sales@contoso.com.
+This example assigns the Teams Emergency Call Routing policy (Test) to the members of the group sales@contoso.com.
+
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallRoutingPolicy.md
@@ -30,7 +30,7 @@ This cmdlet creates a new Teams Emergency Call Routing policy with one or more e
 ### Example 1
 ```powershell
 $en1 =  New-CsTeamsEmergencyNumber -EmergencyDialString "911" -EmergencyDialMask "933" -OnlinePSTNUsage "USE911"
-New-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{add=$en1} -AllowEnhancedEmergencyServices:$true -Description "test"
+New-CsTeamsEmergencyCallRoutingPolicy -Identity "Test" -EmergencyNumbers @{add=$en1} -AllowEnhancedEmergencyServices:$true -Description "test"
 ```
 
 This example first creates a new Teams emergency number object and then creates a Teams Emergency Call Routing policy with this emergency number object.
@@ -148,5 +148,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Grant-CsTeamsEmergencyCallRoutingPolicy](Grant-CsTeamsEmergencyCallRoutingPolicy.md)
 
 [Remove-CsTeamsEmergencyCallRoutingPolicy](Remove-CsTeamsEmergencyCallRoutingPolicy.md)
+
+[Get-CsTeamsEmergencyCallRoutingPolicy](Get-CsTeamsEmergencyCallRoutingPolicy.md)
 
 [New-CsTeamsEmergencyNumber](New-CsTeamsEmergencyNumber.md)

--- a/skype/skype-ps/skype/Remove-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsEmergencyCallRoutingPolicy.md
@@ -28,10 +28,10 @@ This cmdlet removes an existing Teams Emergency Call Routing policy instance.
 
 ### Example 1
 ```powershell
-Remove-CsTeamsEmergencyCallRoutingPolicy -Identity TestECRP
+Remove-CsTeamsEmergencyCallRoutingPolicy -Identity Test
 ```
 
-This example removes Teams Emergency Call Routing policy with identity TestECRP.
+This example removes Teams Emergency Call Routing policy with identity Test.
 
 ### Example 2
 ```powershell

--- a/skype/skype-ps/skype/Set-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsEmergencyCallRoutingPolicy.md
@@ -29,7 +29,7 @@ This cmdlet modifies an existing Teams Emergency Call Routing Policy. Teams Emer
 
 ### Example 1
 ```powershell
-Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -AllowEnhancedEmergencyServices:$false -Description "test"
+Set-CsTeamsEmergencyCallRoutingPolicy -Identity "Test" -AllowEnhancedEmergencyServices:$false -Description "test"
 ```
 
 This example modifies an existing Teams Emergency Call Routing Policy.
@@ -38,7 +38,7 @@ This example modifies an existing Teams Emergency Call Routing Policy.
 ```powershell
 $en1 =  New-CsTeamsEmergencyNumber -EmergencyDialString "911" -EmergencyDialMask "933" -OnlinePSTNUsage "USE911"
 $en2 =  New-CsTeamsEmergencyNumber -EmergencyDialString "112" -EmergencyDialMask "9112" -OnlinePSTNUsage "DKE911"
-Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{add=$en1,$en2}
+Set-CsTeamsEmergencyCallRoutingPolicy -Identity "Test" -EmergencyNumbers @{add=$en1,$en2}
 ```
 
 This example first creates new Teams emergency number objects and then adds these Teams emergency numbers to an existing Teams Emergency Call Routing policy.
@@ -46,7 +46,7 @@ This example first creates new Teams emergency number objects and then adds thes
 ### Example 3
 ```powershell
 $en1 =  New-CsTeamsEmergencyNumber -EmergencyDialString "112" -EmergencyDialMask "9112" -OnlinePSTNUsage "DKE911"
-Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{remove=$en1}
+Set-CsTeamsEmergencyCallRoutingPolicy -Identity "Test" -EmergencyNumbers @{remove=$en1}
 ```
 
 This example first creates a new Teams emergency number object and then removes that Teams emergency number from an existing Teams Emergency Call Routing policy.

--- a/skype/skype-ps/skype/Set-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsEmergencyCallRoutingPolicy.md
@@ -41,7 +41,7 @@ $en2 =  New-CsTeamsEmergencyNumber -EmergencyDialString "112" -EmergencyDialMask
 Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{add=$en1,$en2}
 ```
 
-This example first creates new Teams emergency number objects and then adds these emergency numbers to an existing Teams Emergency Call Routing policy.
+This example first creates new Teams emergency number objects and then adds these Teams emergency numbers to an existing Teams Emergency Call Routing policy.
 
 ### Example 3
 ```powershell
@@ -49,7 +49,7 @@ $en1 =  New-CsTeamsEmergencyNumber -EmergencyDialString "112" -EmergencyDialMask
 Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{remove=$en1}
 ```
 
-This example first creates new Teams emergency number objects and then removes that emergency number from an existing Teams Emergency Call Routing policy.
+This example first creates a new Teams emergency number object and then removes that Teams emergency number from an existing Teams Emergency Call Routing policy.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Set-CsTeamsEmergencyCallRoutingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsEmergencyCallRoutingPolicy.md
@@ -34,6 +34,23 @@ Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -AllowEnhancedEmergen
 
 This example modifies an existing Teams Emergency Call Routing Policy.
 
+### Example 2
+```powershell
+$en1 =  New-CsTeamsEmergencyNumber -EmergencyDialString "911" -EmergencyDialMask "933" -OnlinePSTNUsage "USE911"
+$en2 =  New-CsTeamsEmergencyNumber -EmergencyDialString "112" -EmergencyDialMask "9112" -OnlinePSTNUsage "DKE911"
+Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{add=$en1,$en2}
+```
+
+This example first creates new Teams emergency number objects and then adds these emergency numbers to an existing Teams Emergency Call Routing policy.
+
+### Example 3
+```powershell
+$en1 =  New-CsTeamsEmergencyNumber -EmergencyDialString "112" -EmergencyDialMask "9112" -OnlinePSTNUsage "DKE911"
+Set-CsTeamsEmergencyCallRoutingPolicy -Identity "testecrp" -EmergencyNumbers @{remove=$en1}
+```
+
+This example first creates new Teams emergency number objects and then removes that emergency number from an existing Teams Emergency Call Routing policy.
+
 ## PARAMETERS
 
 ### -AllowEnhancedEmergencyServices
@@ -142,5 +159,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Grant-CsTeamsEmergencyCallRoutingPolicy](Grant-CsTeamsEmergencyCallRoutingPolicy.md)
 
 [Remove-CsTeamsEmergencyCallRoutingPolicy](Remove-CsTeamsEmergencyCallRoutingPolicy.md)
+
+[Get-CsTeamsEmergencyCallRoutingPolicy](Get-CsTeamsEmergencyCallRoutingPolicy.md)
 
 [New-CsTeamsEmergencyNumber](New-CsTeamsEmergencyNumber.md)


### PR DESCRIPTION
Updated Set-CsTeamsEmergencyCallRoutingPolicy with more examples and add link to Get. Ensured other pages for '-CsTeamsEmergencyCallRoutingPolicy also referenced the Get cmdlet.

Added more explanation to Get-CsOnlineDialOutPolicy and updated syntax