### PR TITLE
Observed difference in behavior with -SourceFolder

### DIFF
--- a/exchange/exchange-ps/exchange/Get-RecoverableItems.md
+++ b/exchange/exchange-ps/exchange/Get-RecoverableItems.md
@@ -249,7 +249,7 @@ The SourceFolder parameter specifies where to search for deleted items in the ma
 - RecoverableItems: The Recoverable Items\Deletions folder. This folder contains items that have been deleted from the Deleted Items folder (soft-deleted items).
 - PurgedItems: The Recoverable Items\Purges folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items).
 
-If you don't use this parameter, the command will search all of these folders.
+If you don't use this parameter, the command will search all of these folders with the exception of DiscoveryHoldsItems, which will only be searched if manually specified using this parameter.
 
 ```yaml
 Type: RecoverableItemsFolderType

--- a/exchange/exchange-ps/exchange/Get-RecoverableItems.md
+++ b/exchange/exchange-ps/exchange/Get-RecoverableItems.md
@@ -245,11 +245,12 @@ Accept wildcard characters: False
 The SourceFolder parameter specifies where to search for deleted items in the mailbox. Valid values are:
 
 - DeletedItems: The Deleted Items folder.
-- DiscoveryHoldsItems: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold.
 - RecoverableItems: The Recoverable Items\Deletions folder. This folder contains items that have been deleted from the Deleted Items folder (soft-deleted items).
 - PurgedItems: The Recoverable Items\Purges folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items).
 
-If you don't use this parameter, the command will search all of these folders with the exception of DiscoveryHoldsItems, which will only be searched if manually specified using this parameter.
+  If you don't use this parameter, the command will search these three folders.
+
+- DiscoveryHoldsItems: The Recoverable Items\DiscoveryHolds folder. This folder contains items that have been purged from the Recoverable Items folder (hard-deleted items) and are protected by a hold. To search for deleted items in this folder, use this parameter with the value DiscoveryHoldsItems.
 
 ```yaml
 Type: RecoverableItemsFolderType


### PR DESCRIPTION
When this parameter isn't specified, the only Source Folders that are searched and results returned for are Deleted Items, Deletions, and Purges.  To get results from DiscoveryHolds, you have to supply -SourceFolder DiscoveryHoldsItems.  Tested, confirmed.