### PR TITLE
Updates to TeamsCallHoldPolicy and Get-CsOnlineVoiceUser

### DIFF
--- a/skype/skype-ps/skype/Get-CsOnlineVoiceUser.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceUser.md
@@ -24,7 +24,7 @@ Get-CsOnlineVoiceUser [-CivicAddressId <XdsCivicAddressId>] [-DomainController <
 
 ## DESCRIPTION
 
-**Note**: This cmdlet will be deprecated. You should start using the replacement cmdlets described here as soon as possible.
+**Note**: This cmdlet has been deprecated. You should use the replacement cmdlets described here.
 
 The following table lists the parameters to `Get-CsOnlineVoiceUser` and the alternative method of getting the same data using a combination of `Get-CsOnlineUser`, `Get-CsPhoneNumberAssignment`, `Get-CsOnlineLisLocation`, and `Get-CsOnlineLisCivicAddress`.
 

--- a/skype/skype-ps/skype/Get-CsOnlineVoiceUser.md
+++ b/skype/skype-ps/skype/Get-CsOnlineVoiceUser.md
@@ -24,7 +24,7 @@ Get-CsOnlineVoiceUser [-CivicAddressId <XdsCivicAddressId>] [-DomainController <
 
 ## DESCRIPTION
 
-**Note**: This cmdlet has been deprecated. You should use the replacement cmdlets described here.
+**Note**: This cmdlet has been deprecated from the public and GCC cloud instances. You should use the replacement cmdlets described here.
 
 The following table lists the parameters to `Get-CsOnlineVoiceUser` and the alternative method of getting the same data using a combination of `Get-CsOnlineUser`, `Get-CsPhoneNumberAssignment`, `Get-CsOnlineLisLocation`, and `Get-CsOnlineLisCivicAddress`.
 

--- a/skype/skype-ps/skype/Get-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsCallHoldPolicy.md
@@ -6,8 +6,8 @@ title: Get-CsTeamsCallHoldPolicy
 schema: 2.0.0
 ms.reviewer:
 manager: abnair
-ms.author: jomarque
-author: joelhmarquez
+ms.author: jenstr
+author: jenstrier
 ---
 
 # Get-CsTeamsCallHoldPolicy
@@ -16,18 +16,16 @@ author: joelhmarquez
 
 Returns information about the policies configured to customize the call hold experience for Teams clients.
 
-
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Get-CsTeamsCallHoldPolicy [-Tenant <System.Guid>] [[-Identity] <XdsIdentity>] [-LocalStore]
- [<CommonParameters>]
+Get-CsTeamsCallHoldPolicy [[-Identity] <string>] [<CommonParameters>]
 ```
 
 ### Filter
 ```
-Get-CsTeamsCallHoldPolicy [-Tenant <System.Guid>] [-Filter <String>] [-LocalStore] [<CommonParameters>]
+Get-CsTeamsCallHoldPolicy [-Filter <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -94,42 +92,12 @@ To return a policy configured at the per-user scope, use syntax like this:
 You cannot use wildcard characters when specifying the Identity.
 
 ```yaml
-Type: XdsIdentity
+Type: String
 Parameter Sets: Identity
 Aliases:
 
 Required: False
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LocalStore
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Tenant
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: System.Guid
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/skype/skype-ps/skype/Grant-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsCallHoldPolicy.md
@@ -6,8 +6,8 @@ title: Grant-CsTeamsCallHoldPolicy
 schema: 2.0.0
 ms.reviewer:
 manager: abnair
-ms.author: jomarque
-author: joelhmarquez
+ms.author: jenstr
+author: jenstrier
 ---
 
 # Grant-CsTeamsCallHoldPolicy

--- a/skype/skype-ps/skype/New-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsCallHoldPolicy.md
@@ -6,8 +6,8 @@ title: New-CsTeamsCallHoldPolicy
 schema: 2.0.0
 ms.reviewer:
 manager: abnair
-ms.author: jomarque
-author: joelhmarquez
+ms.author: jenstr
+author: jenstrier
 ---
 
 # New-CsTeamsCallHoldPolicy
@@ -16,12 +16,10 @@ author: joelhmarquez
 
 Creates a new Teams call hold policy in your tenant. The Teams call hold policy is used to customize the call hold experience for Teams clients.
 
-
 ## SYNTAX
 
 ```
-New-CsTeamsCallHoldPolicy [-Tenant <System.Guid>] [-Description <String>] [-AudioFileId <String>]
- [-Identity] <XdsIdentity> [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsTeamsCallHoldPolicy [-Identity] <string> [-Description <string>] [-AudioFileId <string>] [-StreamingSourceUrl <string>] [-StreamingSourceAuthType <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +42,38 @@ Any Microsoft Teams users who are assigned this policy will have their call hold
 
 ## PARAMETERS
 
+### -Identity
+Unique identifier to be assigned to the new Teams call hold policy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Enables administrators to provide explanatory text to accompany a Teams call hold policy.
+
+For example, the Description might include information about the users the policy should be assigned to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -AudioFileId
 A string representing the ID referencing an audio file uploaded via the Import-CsOnlineAudioFile cmdlet.
 
@@ -59,13 +89,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -StreamingSourceUrl
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
-Aliases: cf
+Aliases:
 
 Required: False
 Position: Named
@@ -74,10 +104,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Description
-Enables administrators to provide explanatory text to accompany a Teams call hold policy.
-
-For example, the Description might include information about the users the policy should be assigned to.
+### -StreamingSourceAuthType
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String
@@ -106,55 +134,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Identity
-Unique identifier to be assigned to the new Teams call hold policy.
-
-Use the "Global" Identity if you wish to assign this policy to the entire tenant.
-
-```yaml
-Type: XdsIdentity
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InMemory
-Creates an object reference without actually committing the object as a permanent change.
-
-If you assign the output of this cmdlet called with this parameter to a variable, you can make changes to the properties of the object reference and then commit those changes by calling this cmdlet's matching Set- cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Tenant
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: System.Guid
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
@@ -163,6 +142,21 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/Remove-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsCallHoldPolicy.md
@@ -6,8 +6,8 @@ title: Remove-CsTeamsCallHoldPolicy
 schema: 2.0.0
 ms.reviewer:
 manager: abnair
-ms.author: jomarque
-author: joelhmarquez
+ms.author: jenstr
+author: jenstrier
 ---
 
 # Remove-CsTeamsCallHoldPolicy
@@ -20,8 +20,7 @@ Deletes an existing Teams call hold policy in your tenant. The Teams call hold p
 ## SYNTAX
 
 ```
-Remove-CsTeamsCallHoldPolicy [-Tenant <System.Guid>] [-Identity] <XdsIdentity> [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Remove-CsTeamsCallHoldPolicy [-Identity] <string> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,41 +49,11 @@ The Filter value "Tag:*" limits the returned data to Teams call hold policies co
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses the display of any non-fatal error message that might arise when running the command.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
 Unique identifier assigned to the Teams call hold policy.
 
 ```yaml
-Type: XdsIdentity
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -95,11 +64,11 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
-### -Tenant
-This parameter is reserved for internal Microsoft use.
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
 
 ```yaml
-Type: System.Guid
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
@@ -126,12 +95,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
-
-### Microsoft.Rtc.Management.Xds.XdsIdentity
 
 ## OUTPUTS
 

--- a/skype/skype-ps/skype/Remove-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsCallHoldPolicy.md
@@ -50,7 +50,7 @@ The Filter value "Tag:*" limits the returned data to Teams call hold policies co
 ## PARAMETERS
 
 ### -Identity
-Unique identifier assigned to the Teams call hold policy.
+Unique identifier of the Teams call hold policy to be removed.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/Set-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsCallHoldPolicy.md
@@ -55,7 +55,7 @@ This policy is re-assigned the description from its existing value to "country m
 ## PARAMETERS
 
 ### -Identity
-Unique identifier to be assigned to the new Teams call hold policy.
+Unique identifier of the Teams call hold policy being modified.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/Set-CsTeamsCallHoldPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsCallHoldPolicy.md
@@ -6,8 +6,8 @@ title: Set-CsTeamsCallHoldPolicy
 schema: 2.0.0
 ms.reviewer:
 manager: abnair
-ms.author: jomarque
-author: joelhmarquez
+ms.author: jenstr
+author: jenstrier
 ---
 
 # Set-CsTeamsCallHoldPolicy
@@ -16,19 +16,11 @@ author: joelhmarquez
 
 Modifies an existing Teams call hold policy in your tenant. The Teams call hold policy is used to customize the call hold experience for Teams clients.
 
-
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Set-CsTeamsCallHoldPolicy [-Tenant <System.Guid>] [-Description <String>] [-AudioFileId <String>]
- [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### Instance
-```
-Set-CsTeamsCallHoldPolicy [-Tenant <System.Guid>] [-Description <String>] [-AudioFileId <String>]
- [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-CsTeamsCallHoldPolicy [-Identity] <string> [-Description <string>] [-AudioFileId <string>] [-StreamingSourceUrl <string>] [-StreamingSourceAuthType <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -62,6 +54,38 @@ This policy is re-assigned the description from its existing value to "country m
 
 ## PARAMETERS
 
+### -Identity
+Unique identifier to be assigned to the new Teams call hold policy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Enables administrators to provide explanatory text to accompany a Teams call hold policy.
+
+For example, the Description might include information about the users the policy should be assigned to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -AudioFileId
 A string representing the ID referencing an audio file uploaded via the Import-CsOnlineAudioFile cmdlet.
 
@@ -77,13 +101,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -StreamingSourceUrl
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
-Aliases: cf
+Aliases:
 
 Required: False
 Position: Named
@@ -92,10 +116,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Description
-Enables administrators to provide explanatory text to accompany a Teams call hold policy.
-
-For example, the Description might include information about the users the policy should be assigned to.
+### -StreamingSourceAuthType
+This parameter is reserved for internal Microsoft use.
 
 ```yaml
 Type: String
@@ -124,53 +146,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Identity
-Unique identifier assigned to the Teams call hold policy.
-
-Use the "Global" Identity if you wish modify the policy set for the entire tenant.
-
-```yaml
-Type: XdsIdentity
-Parameter Sets: Identity
-Aliases:
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Instance
-Allows you to pass a reference to an object to the cmdlet rather than set individual parameter values.
-
-```yaml
-Type: PSObject
-Parameter Sets: Instance
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Tenant
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: System.Guid
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
@@ -179,6 +154,21 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
 
 Required: False
 Position: Named


### PR DESCRIPTION
Updating the *-CsTeamsCallHoldPolicy with correct syntax and changing deprecation note in Get-CsOnlineVoiceUser to saying it has been deprecated.