### PR TITLE
Update filter-properties.md

### DIFF
--- a/exchange/docs-conceptual/filter-properties.md
+++ b/exchange/docs-conceptual/filter-properties.md
@@ -1833,7 +1833,7 @@ For example, `Get-User -Filter "UpgradeStatus -ne 'None'"`.
 |---|---|---|
 |_msExchUsageLocation_|**Get-Mailbox** <br> **Get-MailUser** <br> **Get-Recipient**|String or `$null`|
 
-This filter requires the ISO 3166-1 country name (for example, `United States`), or two-letter country code (for example `US`) for the user in Microsoft 365. For more information, see [Country Codes - ISO 3166](https://www.iso.org/iso-3166-country-codes.html). <br> For example, `Get-Recipient -Filter 'UsageLocation -ne $null'`.
+This filter requires the ISO 3166-1 country name (for example, `United States`), or two-letter country code (for example `US`) for the user in Microsoft 365. For more information, see [Country Codes - ISO 3166](https://www.iso.org/iso-3166-country-codes.html). <br> For example, `Get-Recipient -Filter 'UsageLocation -eq "US"'`.
 
 ### UseDatabaseQuotaDefaults
 


### PR DESCRIPTION
The example the documentation has for the UsageLocation filter is incorrect. Currently it is, Get-Recipient -Filter 'UsageLocation -ne $null'. If we run that it fails with

"Get-Recipient: Ex988CDB|Microsoft.Exchange.Data.Directory.ADFilterException|Property UsageLocation does not support Microsoft.Exchange.Data.ExistsFilter. Only Microsoft.Exchange.Data.ComparisonFilter is supported."

As the description states this filter requires the ISO 3166-1 country name. Proposed change is to update the example to

Get-Recipient -Filter 'UsageLocation -eq "US"'