### PR TITLE
Updates to emergency calling and trunks

### DIFF
--- a/skype/skype-ps/skype/New-CsOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/New-CsOnlinePSTNGateway.md
@@ -202,7 +202,7 @@ Accept wildcard characters: False
 ```
 
 ### -GatewayLbrEnabledUserOverride
-Allow an LBR enabled user working from a network site outside the corporate network or a network site on the corporate network not configured using tenant network site to make outbound PSTN calls or receive inbound PSTN calls via an LBR enabled gateway. The default value is False.
+Allows an LBR enabled user working from a network site outside the corporate network or a network site on the corporate network not configured using a tenant network site to make outbound PSTN calls or receive inbound PSTN calls via an LBR enabled gateway. The default value is False.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/New-CsOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/New-CsOnlinePSTNGateway.md
@@ -202,8 +202,7 @@ Accept wildcard characters: False
 ```
 
 ### -GatewayLbrEnabledUserOverride
-Allow an LBR enabled user working from a network site outside the corporate network, i.e. a network site not configured using tenant network site - typically when working from
-home, to make outbound PSTN calls  via an LBR enabled gateway. The default value is False.
+Allow an LBR enabled user working from a network site outside the corporate network or a network site on the corporate network not configured using tenant network site to make outbound PSTN calls or receive inbound PSTN calls via an LBR enabled gateway. The default value is False.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallingExtendedNotification.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallingExtendedNotification.md
@@ -22,6 +22,9 @@ New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString <string> [-
 ```
 
 ## DESCRIPTION
+
+**Note**: The use of extended notifications for emergency calling and this cmdlet is currently not supported.
+
 This cmdlet supports creating specific emergency calling notification settings per emergency phone number. It is used with TeamsEmergencyCallingPolicy.
 
 ## EXAMPLES
@@ -107,6 +110,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Object
 ## NOTES
+
+The use of extended notifications for emergency calling and this cmdlet is currently not supported.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
@@ -41,23 +41,6 @@ New-CsTeamsEmergencyCallingPolicy -Identity "TestECP2" -NotificationGroup "123@c
 
 This example creates a Teams Emergency Calling policy that has an identity of TestECP2, with default settings, except for the Notification Group. This parameter expects a single string with all users and groups separated by ";".
 
-### Example 3
-```powershell
-$en1 = New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString "112" -NotificationGroup "alert2@contoso.com" -NotificationMode ConferenceUnMuted
-$en2 = New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString "911" -NotificationGroup "alert3@contoso.com" -NotificationMode NotificationOnly -NotificationDialOutNumber "+14255551234"
-Set-CsTeamsEmergencyCallingPolicy -Identity "TestECP3" -ExtendedNotifications @{add=$en1,$en2}
-```
-
-This example creates specific emergency calling notification settings for two emergency phone numbers and adds them to the existing TestECP3 policy instance.
-
-### Example 4
-```powershell
-$en2 = New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString "911" -NotificationGroup "alert3@contoso.com" -NotificationMode NotificationOnly -NotificationDialOutNumber "+14255551234"
-Set-CsTeamsEmergencyCallingPolicy -Identity "TestECP3" -ExtendedNotifications @{remove=$en2}
-```
-
-This example removes a specific emergency calling notification setting from the existing TestECP3 policy instance.
-
 ## PARAMETERS
 
 ### -Identity

--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
@@ -89,6 +89,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExtendedNotifications
+
 **Note**: The use of extended notifications and this parameter is currently not supported.
 
 A list of one or more instances of TeamsEmergencyCallingExtendedNotification. Each TeamsEmergencyCallingExtendedNotification should use a unique EmergencyDialString.

--- a/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsEmergencyCallingPolicy.md
@@ -89,6 +89,8 @@ Accept wildcard characters: False
 ```
 
 ### -ExtendedNotifications
+**Note**: The use of extended notifications and this parameter is currently not supported.
+
 A list of one or more instances of TeamsEmergencyCallingExtendedNotification. Each TeamsEmergencyCallingExtendedNotification should use a unique EmergencyDialString.
 
 If an extended notification is found for an emergency phone number based on the EmergencyDialString parameter the extended notification will be controlling the notification. If no extended notification is found the notification settings on the policy instance itself will be used.

--- a/skype/skype-ps/skype/Set-CsOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePSTNGateway.md
@@ -158,7 +158,7 @@ Accept wildcard characters: False
 ```
 
 ### -GatewayLbrEnabledUserOverride
-Allow an LBR enabled user working from a network site outside the corporate network or a network site on the corporate network not configured using tenant network site to make outbound PSTN calls or receive inbound PSTN calls via an LBR enabled gateway. The default value is False.
+Allows an LBR enabled user working from a network site outside the corporate network or a network site on the corporate network not configured using a tenant network site to make outbound PSTN calls or receive inbound PSTN calls via an LBR enabled gateway. The default value is False.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsOnlinePSTNGateway.md
+++ b/skype/skype-ps/skype/Set-CsOnlinePSTNGateway.md
@@ -158,8 +158,7 @@ Accept wildcard characters: False
 ```
 
 ### -GatewayLbrEnabledUserOverride
-Allow an LBR enabled user working from a network site outside the corporate network, i.e. a network site not configured using tenant network site - typically when working from
-home, to make outbound PSTN calls  via an LBR enabled gateway. The default value is False.
+Allow an LBR enabled user working from a network site outside the corporate network or a network site on the corporate network not configured using tenant network site to make outbound PSTN calls or receive inbound PSTN calls via an LBR enabled gateway. The default value is False.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsEmergencyCallingPolicy.md
@@ -69,6 +69,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExtendedNotifications
+
 **Note**: The use of extended notifications and this parameter is currently not supported.
 
 A list of one or more instances of TeamsEmergencyCallingExtendedNotification. Each TeamsEmergencyCallingExtendedNotification should use a unique EmergencyDialString.

--- a/skype/skype-ps/skype/Set-CsTeamsEmergencyCallingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsEmergencyCallingPolicy.md
@@ -36,23 +36,6 @@ Set-CsTeamsEmergencyCallingPolicy -Identity "TestECP" -NotificationGroup "123@co
 
 This example modifies an existing policy instance with identity TestECP.
 
-### Example 2
-```powershell
-$en1 = New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString "112" -NotificationGroup "alert2@contoso.com" -NotificationMode ConferenceUnMuted
-$en2 = New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString "911" -NotificationGroup "alert3@contoso.com" -NotificationMode NotificationOnly -NotificationDialOutNumber "+14255551234"
-Set-CsTeamsEmergencyCallingPolicy -Identity "TestECP" -ExtendedNotifications @{add=$en1,$en2}
-```
-
-This example creates specific emergency calling notification settings for two emergency phone numbers and adds them to the existing TestECP policy instance.
-
-### Example 3
-```powershell
-$en2 = New-CsTeamsEmergencyCallingExtendedNotification -EmergencyDialString "911" -NotificationGroup "alert3@contoso.com" -NotificationMode NotificationOnly -NotificationDialOutNumber "+14255551234"
-Set-CsTeamsEmergencyCallingPolicy -Identity "TestECP" -ExtendedNotifications @{remove=$en2}
-```
-
-This example removes a specific emergency calling notification setting from the existing TestECP policy instance.
-
 ## PARAMETERS
 
 ### -Description
@@ -86,6 +69,8 @@ Accept wildcard characters: False
 ```
 
 ### -ExtendedNotifications
+**Note**: The use of extended notifications and this parameter is currently not supported.
+
 A list of one or more instances of TeamsEmergencyCallingExtendedNotification. Each TeamsEmergencyCallingExtendedNotification should use a unique EmergencyDialString.
 
 If an extended notification is found for an emergency phone number based on the EmergencyDialString parameter the extended notification will be controlling the notification. If no extended notification is found the notification settings on the policy instance itself will be used.


### PR DESCRIPTION
Temporarily specifying that the use of extended notifications for emergency calling is not supported.

Updating the meaning of GatewayLbrEnabledUserOverride to also include inbound PSTN calls.