### PR TITLE
Removing any reference of Conference ID reset from the page

### DIFF
--- a/skype/skype-ps/skype/Set-CsOnlineDialInConferencingUser.md
+++ b/skype/skype-ps/skype/Set-CsOnlineDialInConferencingUser.md
@@ -24,7 +24,7 @@ Use the `Set-CsOnlineDialInConferencingUser` cmdlet to modify the properties of 
 ### TenantIdParams (Default)
 ```
 Set-CsOnlineDialInConferencingUser [-Identity] <UserIdParameter> [-BridgeId <Guid>]
- [-BridgeName <String>] [-Tenant <Guid>] [-ConferenceId <System.Int32>] [-ResetConferenceId]
+ [-BridgeName <String>] [-Tenant <Guid>] 
  [-ServiceNumber <String>] [-TollFreeServiceNumber <String>] [-AllowPSTNOnlyMeetings <Boolean>] [-Force]
  [-ResetLeaderPin] [-AllowTollFreeDialIn <Boolean>] [-SendEmailToAddress <String>]
  [-SendEmailFromAddress <String>] [-SendEmailFromDisplayName <String>] [-SendEmail] [-DomainController <Fqdn>]
@@ -34,7 +34,7 @@ Set-CsOnlineDialInConferencingUser [-Identity] <UserIdParameter> [-BridgeId <Gui
 ### TenantDomainParams
 ```
 Set-CsOnlineDialInConferencingUser [-Identity] <UserIdParameter> [-BridgeId <Guid>]
- [-BridgeName <String>] -TenantDomain <String> [-ConferenceId <Int32>] [-ResetConferenceId]
+ [-BridgeName <String>] -TenantDomain <String> 
  [-ServiceNumber <String>] [-TollFreeServiceNumber <String>] [-AllowPSTNOnlyMeetings <Boolean>] [-Force]
  [-ResetLeaderPin] [-AllowTollFreeDialIn <Boolean>] [-SendEmailToAddress <String>]
  [-SendEmailFromAddress <String>] [-SendEmailFromDisplayName <String>] [-SendEmail] [-DomainController <Fqdn>]

--- a/skype/skype-ps/skype/Set-CsOnlineDialInConferencingUser.md
+++ b/skype/skype-ps/skype/Set-CsOnlineDialInConferencingUser.md
@@ -24,8 +24,7 @@ Use the `Set-CsOnlineDialInConferencingUser` cmdlet to modify the properties of 
 ### TenantIdParams (Default)
 ```
 Set-CsOnlineDialInConferencingUser [-Identity] <UserIdParameter> [-BridgeId <Guid>]
- [-BridgeName <String>] [-Tenant <Guid>] 
- [-ServiceNumber <String>] [-TollFreeServiceNumber <String>] [-AllowPSTNOnlyMeetings <Boolean>] [-Force]
+ [-BridgeName <String>] [-Tenant <Guid>] [-ServiceNumber <String>] [-TollFreeServiceNumber <String>] [-AllowPSTNOnlyMeetings <Boolean>] [-Force]
  [-ResetLeaderPin] [-AllowTollFreeDialIn <Boolean>] [-SendEmailToAddress <String>]
  [-SendEmailFromAddress <String>] [-SendEmailFromDisplayName <String>] [-SendEmail] [-DomainController <Fqdn>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
@@ -34,8 +33,7 @@ Set-CsOnlineDialInConferencingUser [-Identity] <UserIdParameter> [-BridgeId <Gui
 ### TenantDomainParams
 ```
 Set-CsOnlineDialInConferencingUser [-Identity] <UserIdParameter> [-BridgeId <Guid>]
- [-BridgeName <String>] -TenantDomain <String> 
- [-ServiceNumber <String>] [-TollFreeServiceNumber <String>] [-AllowPSTNOnlyMeetings <Boolean>] [-Force]
+ [-BridgeName <String>] [-TenantDomain <String>] [-ServiceNumber <String>] [-TollFreeServiceNumber <String>] [-AllowPSTNOnlyMeetings <Boolean>] [-Force]
  [-ResetLeaderPin] [-AllowTollFreeDialIn <Boolean>] [-SendEmailToAddress <String>]
  [-SendEmailFromAddress <String>] [-SendEmailFromDisplayName <String>] [-SendEmail] [-DomainController <Fqdn>]
  [-WhatIf] [-Confirm] [<CommonParameters>]

--- a/skype/skype-ps/skype/Set-CsOnlineDialInConferencingUser.md
+++ b/skype/skype-ps/skype/Set-CsOnlineDialInConferencingUser.md
@@ -50,18 +50,18 @@ The cmdlet will verify that the correct license is assigned to the user.
 
 ### -------------------------- Example 1 --------------------------
 ```
-Set-CsOnlineDialInConferencingUser -Identity "Ken Meyers" -ConferenceId 3542699 -ResetLeaderPin -ServiceNumber 14255037265
+Set-CsOnlineDialInConferencingUser -Identity "Ken Meyers" -ResetLeaderPin -ServiceNumber 14255037265
 ```
 
-This example shows how to set a ConferenceId for a user, reset the meeting leader's PIN and set the audio conferencing provider default meeting phone number.
+This example shows how to reset the meeting leader's PIN and set the audio conferencing provider default meeting phone number.
 
 
 ### -------------------------- Example 2 --------------------------
 ```
-Set-CsOnlineDialInConferencingUser -Identity "Ken Meyers" -BridgeName "Conference Bridge" -ConferenceId 3542699
+Set-CsOnlineDialInConferencingUser -Identity "Ken Meyers" -BridgeName "Conference Bridge"
 ```
 
-This example sets a user's ConferenceId and conference bridge assignment.
+This example sets a user's conference bridge assignment.
 
 
 ## PARAMETERS
@@ -153,31 +153,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ConferenceId
-Specifies the ConferenceId that will be used by the user for dial-in meetings.
-The cmdlet will fail if:
-
-The ConferenceId is already being used in the bridge where the user is assigned, or to which the user would be assigned.
-
-The ConferenceId doesn't meet the ConferenceId format requirements.
-
-ConferenceId and ResetConferenceId are mutually exclusive.
-When ConferenceId is specified the new ConferenceId will be assigned to the user.
-When ResetConferenceId is specified, the user will get an auto-generated ConferenceId.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases: Passcode
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Confirm
 The Confirm switch causes the command to pause processing and requires confirmation to proceed.
 
@@ -226,28 +201,6 @@ If the Force switch isn't provided in the command, you're prompted for administr
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: 
-Applicable: Skype for Business Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ResetConferenceId
-Specifies whether to reset the ConferenceId for meetings that the user is organizing.
-If specified, the meetings using the old ConferenceId will fail.
-The user will have to reschedule his existing meetings, or run the meeting migration tool.
-
-ConferenceId and ResetConferenceId are mutually exclusive.
-When ConferenceId is specified the new ConferenceId will be assigned to the user.
-When ResetConferenceId is specified, the user will get an auto-generated ConferenceId.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: ResetPasscode
 Applicable: Skype for Business Online
 
 Required: False


### PR DESCRIPTION
Removing any reference of Conference ID reset from the page since it's no longer supported.