### PR TITLE
Update TeamsMeetingPolicy commands with WM settings

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -1054,7 +1054,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowWatermarkForScreenSharing
-This setting allows scheduling meetings with watermark for video enabled
+This setting allows scheduling meetings with watermarking for video enabled.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -1039,7 +1039,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowWatermarkForScreenSharing
-This setting allows scheduling meetings with watermark for screenshare enabled
+This setting allows scheduling meetings with watermarking for screen sharing enabled.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -36,6 +36,7 @@ New-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
 [-AllowTrackingInReport <Boolean>] [-LiveCaptionsEnabledType <String>] [-RecordingStorageMode <String>] [-RoomAttributeUserOverride <String>]
 [-SpeakerAttributionMode <String>] [-WhoCanRegister <Object>] [-NewMeetingRecordingExpirationDays <Int32>]
 [-MeetingInviteLanguages <String>] [-AllowNetworkConfigurationSettingsLookup <Boolean>] [-LiveStreamingMode <String>] [-AllowedStreamingMediaInput <String>]
+[-AllowWatermarkForScreenSharing <Boolean>] [-AllowWatermarkForCameraVideo <Boolean>]
 [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -1033,6 +1034,36 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowWatermarkForScreenSharing
+This setting allows scheduling meetings with watermark for screenshare enabled
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowWatermarkForScreenSharing
+This setting allows scheduling meetings with watermark for video enabled
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingPolicy.md
@@ -1053,7 +1053,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -AllowWatermarkForScreenSharing
+### -AllowWatermarkForCameraVideo
 This setting allows scheduling meetings with watermarking for video enabled.
 
 ```yaml

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -1109,7 +1109,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowWatermarkForScreenSharing
-This setting allows scheduling meetings with watermark for screenshare enabled
+This setting allows scheduling meetings with watermarking for screen sharing enabled.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -38,7 +38,8 @@ Set-CsTeamsMeetingPolicy [-Tenant <Guid>] [-Description <String>]
 [-AllowBreakoutRooms <Boolean>] [-TeamsCameraFarEndPTZMode <String>] [-AllowMeetingReactions <Boolean>] 
 [-AllowMeetingRegistration <Boolean>] [-AllowScreenContentDigitization <Boolean>] [-AllowTrackingInReport <Boolean>] [-RoomAttributeUserOverride <String>] 
 [-SpeakerAttributionMode <String>] [-WhoCanRegister <String>] [-ChannelRecordingDownload <String>] [-NewMeetingRecordingExpirationDays <Int32>] 
-[-MeetingInviteLanguages <String>] [-AllowNetworkConfigurationSettingsLookup <Boolean>] [-LiveStreamingMode <String>] [-AllowedStreamingMediaInput <String>]
+[-MeetingInviteLanguages <String>] [-AllowNetworkConfigurationSettingsLookup <Boolean>] [-LiveStreamingMode <String>] [-AllowedStreamingMediaInput <String>] 
+[-AllowWatermarkForScreenSharing <Boolean>] [-AllowWatermarkForCameraVideo <Boolean>]
 [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -1103,6 +1104,36 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowWatermarkForScreenSharing
+This setting allows scheduling meetings with watermark for screenshare enabled
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowWatermarkForScreenSharing
+This setting allows scheduling meetings with watermark for video enabled
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -1124,7 +1124,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowWatermarkForScreenSharing
-This setting allows scheduling meetings with watermark for video enabled
+This setting allows scheduling meetings with watermarking for video enabled.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingPolicy.md
@@ -1123,7 +1123,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -AllowWatermarkForScreenSharing
+### -AllowWatermarkForCameraVideo
 This setting allows scheduling meetings with watermarking for video enabled.
 
 ```yaml


### PR DESCRIPTION
Updating docs for commands `Set-CsTeamsMeetingPolicy` and `New-CsTeamsMeetingPolicy` to include details for the `AllowWatermarkForScreenSharing` and `AllowWatermarkForCameraVideo` parameters.

This is to be consistent with other page
https://learn.microsoft.com/en-us/microsoftteams/watermark-meeting-content-video#enable-watermarks