### PR TITLE
Add documentation for TeamsMeetingBrandingPolicy cmdlets

### DIFF
--- a/skype/docfx.json
+++ b/skype/docfx.json
@@ -68,7 +68,7 @@
       "author": "serdarsoysal",
       "ms.author": "serdars",
       "manager": "serdars",
-      "ms.date": "09/25/2017",
+      "ms.date": "04/04/2023",
       "ms.topic": "reference",
       "ms.service": "skypeforbusiness-powershell",
       "products": [

--- a/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # Get-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
+The **CsTeamsMeetingBrandingPolicy** cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 
 ## SYNTAX
@@ -29,7 +29,7 @@ Get-CsTeamsMeetingBrandingPolicy [-Filter <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-CsTeamsMeetingBrandingPolicy cmdlet enables you to return information about all the meeting branding policies that have been configured for use in your organization.
+The `Get-CsTeamsMeetingBrandingPolicy` cmdlet enables you to return information about all the meeting branding policies that have been configured for use in your organization.
 
 ## EXAMPLES
 
@@ -45,7 +45,7 @@ In this example, the command returns a collection of all the teams meeting brand
 PS C:\> CsTeamsMeetingBrandingPolicy -Identity "policy test2"
 ```
 
-In this example, the command returns the meeting branding policy that has an Identity `policy test 2`. Because identities are unique, this command will never return more than one item.
+In this example, the command returns the meeting branding policy that has an **Identity** `policy test 2`. Because identities are unique, this command will never return more than one item.
 
 ## PARAMETERS
 
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Unique identifier of the policy to be returned. To refer to the global policy, use this syntax: -Identity global. If this parameter is omitted, then all the meeting branding policies configured for use in your organization will be returned.
+Unique identifier of the policy to be returned. To refer to the global policy, use this syntax: `-Identity global`. If this parameter is omitted, then all the meeting branding policies configured for use in your organization will be returned.
 
 ```yaml
 Type: String
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## OUTPUTS
 

--- a/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
@@ -1,0 +1,96 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/get-csteamsmeetingbrandingpolicy
+schema: 2.0.0
+title: Get-CsTeamsMeetingBrandingPolicy
+author: szymonkatraMSFT
+ms.author: szymonkatra
+ms.reviewer:
+manager: stanlythomas
+---
+
+# Get-CsTeamsMeetingBrandingPolicy
+
+## SYNOPSIS
+The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsTeamsMeetingBrandingPolicy [[-Identity] <String>] [<CommonParameters>]
+```
+
+### Filter
+```
+Get-CsTeamsMeetingBrandingPolicy [-Filter <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-CsTeamsMeetingBrandingPolicy cmdlet enables you to return information about all the meeting branding policies that have been configured for use in your organization
+
+## EXAMPLES
+
+### Return all branding policies
+```powershell
+PS C:\> Get-CsTeamsMeetingBrandingPolicy
+```
+
+In the example shown above, the command will return a collection of all the teams meeting branding policies configured for use in your organization.
+
+### Return specified policy
+```powershell
+PS C:\> CsTeamsMeetingBrandingPolicy -Identity "policy test2"
+```
+
+In the example shown above, the command will return the meeting branding policy that has an Identity `policy test 2``. Because identities are unique, this command will never return more than one item.
+
+## PARAMETERS
+
+### -Filter
+Enables you to use wildcard characters when indicating the policy (or policies) to be returned.
+
+```yaml
+Type: String
+Parameter Sets: Filter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier of the policy to be returned. To refer to the global policy, use this syntax: -Identity global. If this parameter is omitted, then all the meeting branding policies configured for use in your organization will be returned.
+
+```yaml
+Type: String
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## OUTPUTS
+
+### TeamsMeetingBrandingPolicy.Cmdlets.TeamsMeetingBrandingPolicy
+
+## NOTES
+
+Available in Teams PowerShell Module 4.9.3 or later.
+
+## RELATED LINKS
+
+[Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+[Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+[New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+[Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
+[Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)

--- a/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
@@ -29,7 +29,7 @@ Get-CsTeamsMeetingBrandingPolicy [-Filter <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-CsTeamsMeetingBrandingPolicy cmdlet enables you to return information about all the meeting branding policies that have been configured for use in your organization
+The Get-CsTeamsMeetingBrandingPolicy cmdlet enables you to return information about all the meeting branding policies that have been configured for use in your organization.
 
 ## EXAMPLES
 
@@ -45,7 +45,7 @@ In the example shown above, the command will return a collection of all the team
 PS C:\> CsTeamsMeetingBrandingPolicy -Identity "policy test2"
 ```
 
-In the example shown above, the command will return the meeting branding policy that has an Identity `policy test 2``. Because identities are unique, this command will never return more than one item.
+In the example shown above, the command will return the meeting branding policy that has an Identity `policy test 2`. Because identities are unique, this command will never return more than one item.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # Get-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 
 ## SYNTAX

--- a/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
@@ -79,6 +79,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
 ## OUTPUTS
 
 ### TeamsMeetingBrandingPolicy.Cmdlets.TeamsMeetingBrandingPolicy

--- a/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Get-CsTeamsMeetingBrandingPolicy.md
@@ -38,7 +38,7 @@ The Get-CsTeamsMeetingBrandingPolicy cmdlet enables you to return information ab
 PS C:\> Get-CsTeamsMeetingBrandingPolicy
 ```
 
-In the example shown above, the command will return a collection of all the teams meeting branding policies configured for use in your organization.
+In this example, the command returns a collection of all the teams meeting branding policies configured for use in your organization.
 
 ### Return specified policy
 ```powershell

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -54,6 +54,36 @@ In this example, the command will assign TeamsMeetingBrandingPolicy with the nam
 
 ## PARAMETERS
 
+### -Global
+Use this switch if you want to grant the specified policy to be the default policy for all users in the tenant.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GrantToTenant
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Group
+Specifies the group used for the group policy assignment.
+
+```yaml
+Type: String
+Parameter Sets: GrantToGroup
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Identity
 The user you want to grant policy to. This can be specified as an SIP address, UserPrincipalName, or ObjectId.
 
@@ -84,21 +114,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Group
-Specifies the group used for the group policy assignment.
-
-```yaml
-Type: String
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Rank
 The rank of the policy assignment, relative to other group policy assignments for the same policy type.
 
@@ -109,21 +124,6 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Global
-Use this switch if you want to grant the specified policy to be the default policy for all users in the tenant.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: GrantToTenant
-Aliases:
-
-Required: True
-Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # Grant-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
+Assigns a teams meeting branding policy at the per-user scope. The **CsTeamsMeetingBrandingPolicy** cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 
@@ -34,7 +34,7 @@ Grant-CsTeamsMeetingBrandingPolicy [[-PolicyName] <String>] [-Global] [-Force] [
 ```
 
 ## DESCRIPTION
-Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
+Assigns a teams meeting branding policy at the per-user scope. The **CsTeamsMeetingBrandingPolicy** cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## EXAMPLES
 
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyName
-The name of the custom policy that is being assigned to the user. To remove a specific assignment and fall back to the default tenant policy, you can assign it to $Null.
+The name of the custom policy that is being assigned to the user. To remove a specific assignment and fall back to the default tenant policy, you can assign it to `$Null`.
 
 ```yaml
 Type: String
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 
 ## NOTES

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyName
-The name of the custom policy that is being assigned to the user. To remove a specific assignment and fall back to the default tenant policy, you can assign to $Null.
+The name of the custom policy that is being assigned to the user. To remove a specific assignment and fall back to the default tenant policy, you can assign it to $Null.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -1,0 +1,143 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/grant-csteamsmeetingbrandingpolicy
+schema: 2.0.0
+title: Grant-CsTeamsMeetingBrandingPolicy
+author: szymonkatraMSFT
+ms.author: szymonkatra
+ms.reviewer:
+manager: stanlythomas
+---
+
+# Grant-CsTeamsMeetingBrandingPolicy
+
+## SYNOPSIS
+Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+
+## SYNTAX
+
+### GrantToUser
+```
+Grant-CsTeamsMeetingBrandingPolicy -Identity <String> [[-PolicyName] <String>] [<CommonParameters>]
+```
+
+### GrantToGroup
+```
+Grant-CsTeamsMeetingBrandingPolicy [[-PolicyName] <String>] [-Group] <String> -Rank <Int32>
+ [<CommonParameters>]
+```
+
+### GrantToTenant
+```
+Grant-CsTeamsMeetingBrandingPolicy [[-PolicyName] <String>] [-Global] [-Force] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+
+## EXAMPLES
+
+### Assign TeamsMeetingBrandingPolicy to user
+```powershell
+PS C:\> Grant-CsTeamsMeetingBrandingPolicy -identity "testuser@testtenantdomain.onmicrosoft.com" -PolicyName "Policy Test"
+```
+
+In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to user `testuser@testtenantdomain.onmicrosoft.com`.
+
+### Assign TeamsMeetingBrandingPolicy to group
+```powershell
+PS C:\> Grant-CsTeamsMeetingBrandingPolicy -Group Testgroupassignments@testtenantdomain.onmicrosoft.com -PolicyName "Policy Test" -Rank 1
+```
+
+In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to group `Testgroupassignments@testtenantdomain.onmicrosoft.com`.
+
+
+## PARAMETERS
+
+### -Global
+Use this switch if you want to grant the specified policy to be the default policy for all users in the tenant.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GrantToTenant
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Group
+Specifies the group used for the group policy assignment.
+
+```yaml
+Type: String
+Parameter Sets: GrantToGroup
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The user you want to grant policy to. This can be specified as SIP address, UserPrincipalName, or ObjectId.
+
+```yaml
+Type: String
+Parameter Sets: GrantToUser
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyName
+The name of the custom policy that is being assigned to the user. To remove a specific assignment and fall back to the default tenant policy, you can assign to $Null.
+
+```yaml
+Type: String
+Parameter Sets: GrantToUser, GrantToGroup, GrantToTenant
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Rank
+The rank of the policy assignment, relative to other group policy assignments for the same policy type.
+
+```yaml
+Type: Int32
+Parameter Sets: GrantToGroup
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## NOTES
+
+Available in Teams PowerShell Module 4.9.3 or later.
+
+## RELATED LINKS
+
+[Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+[Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+[New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+[Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
+[Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -55,7 +55,7 @@ In this example, the command will assign TeamsMeetingBrandingPolicy with the nam
 ## PARAMETERS
 
 ### -Identity
-The user you want to grant policy to. This can be specified as SIP address, UserPrincipalName, or ObjectId.
+The user you want to grant policy to. This can be specified as an SIP address, UserPrincipalName, or ObjectId.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -50,7 +50,7 @@ In the example shown above, the command will assign TeamsMeetingBrandingPolicy w
 PS C:\> Grant-CsTeamsMeetingBrandingPolicy -Group group@contoso.com -PolicyName "Policy Test" -Rank 1
 ```
 
-In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to group `group@contoso.com`.
+In this example, the command will assign TeamsMeetingBrandingPolicy with the name `Policy Test` to group `group@contoso.com`.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -45,7 +45,7 @@ PS C:\> Grant-CsTeamsMeetingBrandingPolicy -identity "alice@contoso.com" -Policy
 
 In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to user `alice@contoso.com`.
 
-### Assign TeamsMeetingBrandingPolicy to group
+### Assign TeamsMeetingBrandingPolicy to a group
 ```powershell
 PS C:\> Grant-CsTeamsMeetingBrandingPolicy -Group group@contoso.com -PolicyName "Policy Test" -Rank 1
 ```

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -150,7 +150,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Available in Teams PowerShell Module 4.9.3 or later.
+Available in Teams PowerShell Module 4.9.3 and later.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -40,50 +40,19 @@ Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetin
 
 ### Assign TeamsMeetingBrandingPolicy to user
 ```powershell
-PS C:\> Grant-CsTeamsMeetingBrandingPolicy -identity "testuser@testtenantdomain.onmicrosoft.com" -PolicyName "Policy Test"
+PS C:\> Grant-CsTeamsMeetingBrandingPolicy -identity "alice@contoso.com" -PolicyName "Policy Test"
 ```
 
-In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to user `testuser@testtenantdomain.onmicrosoft.com`.
+In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to user `alice@contoso.com`.
 
 ### Assign TeamsMeetingBrandingPolicy to group
 ```powershell
-PS C:\> Grant-CsTeamsMeetingBrandingPolicy -Group Testgroupassignments@testtenantdomain.onmicrosoft.com -PolicyName "Policy Test" -Rank 1
+PS C:\> Grant-CsTeamsMeetingBrandingPolicy -Group group@contoso.com -PolicyName "Policy Test" -Rank 1
 ```
 
-In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to group `Testgroupassignments@testtenantdomain.onmicrosoft.com`.
-
+In the example shown above, the command will assign TeamsMeetingBrandingPolicy with name `Policy Test` to group `group@contoso.com`.
 
 ## PARAMETERS
-
-### -Global
-Use this switch if you want to grant the specified policy to be the default policy for all users in the tenant.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: GrantToTenant
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Group
-Specifies the group used for the group policy assignment.
-
-```yaml
-Type: String
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### -Identity
 The user you want to grant policy to. This can be specified as SIP address, UserPrincipalName, or ObjectId.
@@ -115,6 +84,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Group
+Specifies the group used for the group policy assignment.
+
+```yaml
+Type: String
+Parameter Sets: GrantToGroup
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Rank
 The rank of the policy assignment, relative to other group policy assignments for the same policy type.
 
@@ -129,6 +113,40 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -Global
+Use this switch if you want to grant the specified policy to be the default policy for all users in the tenant.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GrantToTenant
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # Grant-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -38,7 +38,7 @@ Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetin
 
 ## EXAMPLES
 
-### Assign TeamsMeetingBrandingPolicy to user
+### Assign TeamsMeetingBrandingPolicy to a user
 ```powershell
 PS C:\> Grant-CsTeamsMeetingBrandingPolicy -identity "alice@contoso.com" -PolicyName "Policy Test"
 ```

--- a/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Grant-CsTeamsMeetingBrandingPolicy.md
@@ -34,7 +34,7 @@ Grant-CsTeamsMeetingBrandingPolicy [[-PolicyName] <String>] [-Global] [-Force] [
 ```
 
 ## DESCRIPTION
-Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+Assigns a teams meeting branding policy at the per-user scope. The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -42,40 +42,6 @@ In this example, the command will create an empty meeting branding policy with t
 
 ## PARAMETERS
 
-### -MeetingBackgroundImages
-*This parameter is reserved for Microsoft internal use only.*
-List of meeting background images.
-Image upload is not possible via cmdlets. You should upload background images via Teams Admin Center.
-
-```yaml
-Type: PSListModifier
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -MeetingBrandingThemes
-*This parameter is reserved for Microsoft internal use only.*
-List of meeting branding themes.
-Image upload is not possible via cmdlets. You should create meeting themes via Teams Admin Center.
-
-```yaml
-Type: PSListModifier
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DefaultTheme
 *This parameter is reserved for Microsoft internal use only.*
 Identity of default meeting theme.
@@ -87,21 +53,6 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Identity
-Identity of meeting branding policy that will be created.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -137,6 +88,70 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Identity
+Identity of meeting branding policy that will be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBackgroundImages
+*This parameter is reserved for Microsoft internal use only.*
+List of meeting background images.
+Image upload is not possible via cmdlets. You should upload background images via Teams Admin Center.
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBrandingThemes
+*This parameter is reserved for Microsoft internal use only.*
+List of meeting branding themes.
+Image upload is not possible via cmdlets. You should create meeting themes via Teams Admin Center.
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Force
 Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
@@ -159,21 +174,6 @@ Describes what would happen if you executed the command without actually executi
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # New-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
+The **CsTeamsMeetingBrandingPolicy** cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 
@@ -27,7 +27,7 @@ New-CsTeamsMeetingBrandingPolicy
 ```
 
 ## DESCRIPTION
-This cmdlet creates a new TeamsMeetingBrandingPolicy.  
+This cmdlet creates a new **TeamsMeetingBrandingPolicy**.  
 You can only create an empty meeting branding policy with this cmdlet, image upload is not supported.
 If you want to upload the images, you should use Teams Admin Center.
 
@@ -183,7 +183,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## NOTES
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -27,7 +27,7 @@ New-CsTeamsMeetingBrandingPolicy
 ```
 
 ## DESCRIPTION
-This cmdlet creates a new meeting branding policy.  
+This cmdlet creates a new TeamsMeetingBrandingPolicy.  
 You can only create an empty meeting branding policy with this cmdlet, image upload is not supported.
 If you want to upload the images, you should use Teams Admin Center.
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -48,7 +48,7 @@ List of meeting background images.
 Image upload is not possible via cmdlets. Please upload background images via Teams Admin Center (TAC).
 
 ```yaml
-Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
+Type: PSListModifier
 Parameter Sets: (All)
 Aliases:
 
@@ -65,7 +65,7 @@ List of meeting branding themes.
 Image upload is not possible via cmdlets. Please create meeting themes via Teams Admin Center (TAC).
 
 ```yaml
-Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
+Type: PSListModifier
 Parameter Sets: (All)
 Aliases:
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -187,7 +187,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Available in Teams PowerShell Module 4.9.3 or later.
+Available in Teams PowerShell Module 4.9.3 and later.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -1,0 +1,115 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/new-csteamsmeetingbrandingpolicy
+schema: 2.0.0
+title: New-CsTeamsMeetingBrandingPolicy
+author: szymonkatraMSFT
+ms.author: szymonkatra
+ms.reviewer:
+manager: stanlythomas
+---
+
+# New-CsTeamsMeetingBrandingPolicy
+
+## SYNOPSIS
+The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+
+## SYNTAX
+
+```
+New-CsTeamsMeetingBrandingPolicy
+ [-NdiAssuranceSlateImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.NdiAssuranceSlate]>]
+ [-MeetingBackgroundImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]>]
+ [-MeetingBrandingThemes <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]>]
+ [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>] [-EnableNdiAssuranceSlate <Boolean>]
+ [-EnableMeetingBackgroundImages <Boolean>] [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet creates a new meeting branding policy.
+However, it cannot be used to upload the images. If you want to upload the images, please use Teams Admin Center.
+
+## EXAMPLES
+
+### Create empty meeting branding policy
+```powershell
+PS C:\> New-CsTeamsMeetingBrandingPolicy -Identity "test policy"
+```
+
+In the example shown above, the command will create empty meeting branding policy with identity `test policy`.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableMeetingBackgroundImages
+Enable custom meeting backgrounds.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableMeetingOptionsThemeOverride
+Allow organizer to control meeting theme.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Identity of meeting branding policy that will be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## NOTES
+
+Available in Teams PowerShell Module 4.9.3 or later.
+
+## RELATED LINKS
+
+[Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+[Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+[New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+[Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
+[Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -38,7 +38,7 @@ If you want to upload the images, you should use Teams Admin Center.
 PS C:\> New-CsTeamsMeetingBrandingPolicy -Identity "test policy"
 ```
 
-In the example shown above, the command will create empty meeting branding policy with identity `test policy`.
+In this example, the command will create an empty meeting branding policy with the identity `test policy`.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -29,7 +29,7 @@ New-CsTeamsMeetingBrandingPolicy
 ## DESCRIPTION
 This cmdlet creates a new meeting branding policy.  
 You can only create an empty meeting branding policy with this cmdlet, image upload is not supported.
-If you want to upload the images, please use Teams Admin Center.
+If you want to upload the images, you should use Teams Admin Center.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -19,8 +19,8 @@ The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the ap
 
 ```
 New-CsTeamsMeetingBrandingPolicy
- [-MeetingBackgroundImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]>]
- [-MeetingBrandingThemes <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]>]
+ [-MeetingBackgroundImages <PSListModifier>]
+ [-MeetingBrandingThemes <PSListModifier>]
  [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>]
  [-EnableMeetingBackgroundImages <Boolean>] [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -43,8 +43,9 @@ In the example shown above, the command will create empty meeting branding polic
 ## PARAMETERS
 
 ### -MeetingBackgroundImages
+*This parameter is reserved for Microsoft internal use only.*
 List of meeting background images.
-**Note:** It should be not used since this object contains images. Image upload is not possible via cmdlets. Please upload background images via Teams Admin Center (TAC).
+Image upload is not possible via cmdlets. Please upload background images via Teams Admin Center (TAC).
 
 ```yaml
 Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
@@ -59,8 +60,9 @@ Accept wildcard characters: False
 ```
 
 ### -MeetingBrandingThemes
+*This parameter is reserved for Microsoft internal use only.*
 List of meeting branding themes.
-**Note:** It should be not used since meeting theme contains images. Image upload is not possible via cmdlets. Please create meeting themes via Teams Admin Center (TAC).
+Image upload is not possible via cmdlets. Please create meeting themes via Teams Admin Center (TAC).
 
 ```yaml
 Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
@@ -75,8 +77,8 @@ Accept wildcard characters: False
 ```
 
 ### -DefaultTheme
+*This parameter is reserved for Microsoft internal use only.*
 Identity of default meeting theme.
-**Note:** It should be not used since creation of meeting themes via cmdlet is not possible. (see *-MeetingBrandingThemes* parameter)
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -45,7 +45,7 @@ In this example, the command will create an empty meeting branding policy with t
 ### -MeetingBackgroundImages
 *This parameter is reserved for Microsoft internal use only.*
 List of meeting background images.
-Image upload is not possible via cmdlets. Please upload background images via Teams Admin Center (TAC).
+Image upload is not possible via cmdlets. You should upload background images via Teams Admin Center.
 
 ```yaml
 Type: PSListModifier

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ### -MeetingBrandingThemes
 *This parameter is reserved for Microsoft internal use only.*
 List of meeting branding themes.
-Image upload is not possible via cmdlets. Please create meeting themes via Teams Admin Center (TAC).
+Image upload is not possible via cmdlets. You should create meeting themes via Teams Admin Center.
 
 ```yaml
 Type: PSListModifier

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # New-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsMeetingBrandingPolicy.md
@@ -19,17 +19,17 @@ The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the ap
 
 ```
 New-CsTeamsMeetingBrandingPolicy
- [-NdiAssuranceSlateImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.NdiAssuranceSlate]>]
  [-MeetingBackgroundImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]>]
  [-MeetingBrandingThemes <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]>]
- [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>] [-EnableNdiAssuranceSlate <Boolean>]
+ [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>]
  [-EnableMeetingBackgroundImages <Boolean>] [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet creates a new meeting branding policy.
-However, it cannot be used to upload the images. If you want to upload the images, please use Teams Admin Center.
+This cmdlet creates a new meeting branding policy.  
+You can only create an empty meeting branding policy with this cmdlet, image upload is not supported.
+If you want to upload the images, please use Teams Admin Center.
 
 ## EXAMPLES
 
@@ -42,16 +42,64 @@ In the example shown above, the command will create empty meeting branding polic
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -MeetingBackgroundImages
+List of meeting background images.
+**Note:** It should be not used since this object contains images. Image upload is not possible via cmdlets. Please upload background images via Teams Admin Center (TAC).
 
 ```yaml
-Type: SwitchParameter
+Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
 Parameter Sets: (All)
-Aliases: cf
+Aliases:
 
 Required: False
 Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBrandingThemes
+List of meeting branding themes.
+**Note:** It should be not used since meeting theme contains images. Image upload is not possible via cmdlets. Please create meeting themes via Teams Admin Center (TAC).
+
+```yaml
+Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DefaultTheme
+Identity of default meeting theme.
+**Note:** It should be not used since creation of meeting themes via cmdlet is not possible. (see *-MeetingBrandingThemes* parameter)
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Identity of meeting branding policy that will be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -87,20 +135,53 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Identity
-Identity of meeting branding policy that will be created.
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
 ```yaml
-Type: String
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
-Required: True
-Position: 1
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -WhatIf
+Describes what would happen if you executed the command without actually executing the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -49,6 +49,21 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Force
 Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
@@ -71,21 +86,6 @@ Describes what would happen if you executed the command without actually executi
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # Remove-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
+The **CsTeamsMeetingBrandingPolicy** cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 
 ## NOTES

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -100,7 +100,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Available in Teams PowerShell Module 4.9.3 or later.
+Available in Teams PowerShell Module 4.9.3 and later.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -22,7 +22,7 @@ Remove-CsTeamsMeetingBrandingPolicy [-Identity] <String> [-Force] [-WhatIf] [-Co
 ```
 
 ## DESCRIPTION
-Deletes a previously created TeamsMeetingBrandingPolicy. Any users with no explicitly assigned policies will then fall back to the default policy in the organization. You cannot delete the global policy from the organization. If you want to remove policies currently assigned to one or more users, you should assign a different policy to them before.
+Deletes a previously created TeamsMeetingBrandingPolicy. Any users with no explicitly assigned policies will then fall back to the default policy in the organization. You cannot delete the global policy from the organization. If you want to remove policies currently assigned to one or more users, you should first assign a different policy to them.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -31,7 +31,7 @@ Deletes a previously created TeamsMeetingBrandingPolicy. Any users with no expli
 PS C:\> Remove-CsTeamsMeetingBrandingPolicy -Identity "policy test"
 ```
 
-In the example shown above, the command will delete the `policy test` meeting branding policy from the organization's list of meeting branding policies and remove all assignments of this policy from users who have had the policy assigned.
+In this example, the command deletes the `policy test` meeting branding policy from the organization's list of meeting branding policies and removes all assignments of this policy from users who have the policy assigned.
 
 ## PARAMETERS
 

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -35,6 +35,50 @@ In the example shown above, the command will delete the `policy test` meeting br
 
 ## PARAMETERS
 
+### -Identity
+Unique identifier of the policy to be deleted.
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Describes what would happen if you executed the command without actually executing the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.
 
@@ -50,20 +94,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
-### -Identity
-Unique identifier of the policy to be deleted.
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -13,7 +13,7 @@ manager: stanlythomas
 # Remove-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 

--- a/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Remove-CsTeamsMeetingBrandingPolicy.md
@@ -1,0 +1,78 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/remove-csteamsmeetingbrandingpolicy
+schema: 2.0.0
+title: Remove-CsTeamsMeetingBrandingPolicy
+author: szymonkatraMSFT
+ms.author: szymonkatra
+ms.reviewer:
+manager: stanlythomas
+---
+
+# Remove-CsTeamsMeetingBrandingPolicy
+
+## SYNOPSIS
+The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+
+## SYNTAX
+
+```
+Remove-CsTeamsMeetingBrandingPolicy [-Identity] <String> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Deletes a previously created TeamsMeetingBrandingPolicy. Any users with no explicitly assigned policies will then fall back to the default policy in the organization. You cannot delete the global policy from the organization. If you want to remove policies currently assigned to one or more users, you should assign a different policy to them before.
+
+## EXAMPLES
+
+### Remove meeting branding policy
+```powershell
+PS C:\> Remove-CsTeamsMeetingBrandingPolicy -Identity "policy test"
+```
+
+In the example shown above, the command will delete the `policy test` meeting branding policy from the organization's list of meeting branding policies and remove all assignments of this policy from users who have had the policy assigned.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### -Identity
+Unique identifier of the policy to be deleted.
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+## NOTES
+
+Available in Teams PowerShell Module 4.9.3 or later.
+
+## RELATED LINKS
+
+[Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+[Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+[New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+[Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
+[Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -48,7 +48,7 @@ In the example shown above, the commands will change brand accent color of theme
 ### -MeetingBackgroundImages
 *This parameter is reserved for Microsoft internal use only.*
 List of meeting background images.
-It is not possible to add/remove background images using cmdlets. Please use Teams Admin Center (TAC) for that purpose.
+It is not possible to add or remove background images using cmdlets. You should use Teams Admin Center for that purpose.
 
 ```yaml
 Type: PSListModifier

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -189,7 +189,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Available in Teams PowerShell Module 4.9.3 or later.
+Available in Teams PowerShell Module 4.9.3 and later.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -45,39 +45,6 @@ In the example shown above, the commands will change brand accent color of theme
 
 ## PARAMETERS
 
-### -MeetingBackgroundImages
-*This parameter is reserved for Microsoft internal use only.*
-List of meeting background images.
-It is not possible to add or remove background images using cmdlets. You should use Teams Admin Center for that purpose.
-
-```yaml
-Type: PSListModifier
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -MeetingBrandingThemes
-List of meeting branding themes. You can alter the list returned by the `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter.
-It is not possible to add or remove meeting branding themes using cmdlets. You should use Teams Admin Center for that purpose.
-
-```yaml
-Type: PSListModifier
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DefaultTheme
 *This parameter is reserved for Microsoft internal use only.*
 Identity of default meeting theme.
@@ -139,6 +106,54 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -MeetingBackgroundImages
+*This parameter is reserved for Microsoft internal use only.*
+List of meeting background images.
+It is not possible to add or remove background images using cmdlets. You should use Teams Admin Center for that purpose.
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBrandingThemes
+List of meeting branding themes. You can alter the list returned by the `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter.
+It is not possible to add or remove meeting branding themes using cmdlets. You should use Teams Admin Center for that purpose.
+
+```yaml
+Type: PSListModifier
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Force
 Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
@@ -161,21 +176,6 @@ Describes what would happen if you executed the command without actually executi
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
 
 Required: False
 Position: Named

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -14,7 +14,7 @@ applicable: Skype for Business Online
 # Set-CsTeamsMeetingBrandingPolicy
 
 ## SYNOPSIS
-The CsTeamsMeetingBrandingPolicy cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
+The **CsTeamsMeetingBrandingPolicy** cmdlet enables administrators to control the appearance in meetings by defining custom backgrounds, logos, and colors.
 
 ## SYNTAX
 
@@ -28,7 +28,7 @@ Set-CsTeamsMeetingBrandingPolicy
 ```
 
 ## DESCRIPTION
-The Set-CsTeamsMeetingBrandingPolicy cmdlet allows administrators to update existing meeting branding policies.
+The `Set-CsTeamsMeetingBrandingPolicy` cmdlet allows administrators to update existing meeting branding policies.
 However, it cannot be used to upload the images. If you want to upload the images, you should use Teams Admin Center.
 
 ## EXAMPLES
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-Identity of meeting branding policy that will be updated. To refer to the global policy, use this syntax: -Identity global.
+Identity of meeting branding policy that will be updated. To refer to the global policy, use this syntax: `-Identity global`.
 
 ```yaml
 Type: String
@@ -185,7 +185,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableMeetingBackgroundImages
-Enable custom meeting backgrounds.
+Enables custom meeting backgrounds.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -110,7 +110,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableMeetingOptionsThemeOverride
-Allow organizer to control meeting theme.
+Allows organizers to control meeting themes.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -63,8 +63,8 @@ Accept wildcard characters: False
 ```
 
 ### -MeetingBrandingThemes
-List of meeting branding themes. You can alter list returned by `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter. (see example 1).
-It is not possible to add new/remove meeting branding themes using cmdlets. Please use Teams Admin Center (TAC) for that purpose.
+List of meeting branding themes. You can alter the list returned by the `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter.
+It is not possible to add or remove meeting branding themes using cmdlets. You should use Teams Admin Center for that purpose.
 
 ```yaml
 Type: PSListModifier

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -29,7 +29,7 @@ Set-CsTeamsMeetingBrandingPolicy
 
 ## DESCRIPTION
 The Set-CsTeamsMeetingBrandingPolicy cmdlet allows administrators to update existing meeting branding policies.
-However, it cannot be used to upload the images. If you want to upload the images, please use Teams Admin Center.
+However, it cannot be used to upload the images. If you want to upload the images, you should use Teams Admin Center.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -51,7 +51,7 @@ List of meeting background images.
 It is not possible to add/remove background images using cmdlets. Please use Teams Admin Center (TAC) for that purpose.
 
 ```yaml
-Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
+Type: PSListModifier
 Parameter Sets: (All)
 Aliases:
 
@@ -67,7 +67,7 @@ List of meeting branding themes. You can alter list returned by `Get-CsTeamsMeet
 It is not possible to add new/remove meeting branding themes using cmdlets. Please use Teams Admin Center (TAC) for that purpose.
 
 ```yaml
-Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
+Type: PSListModifier
 Parameter Sets: (All)
 Aliases:
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -20,10 +20,9 @@ The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the ap
 
 ```
 Set-CsTeamsMeetingBrandingPolicy
- [-NdiAssuranceSlateImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.NdiAssuranceSlate]>]
  [-MeetingBackgroundImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]>]
  [-MeetingBrandingThemes <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]>]
- [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>] [-EnableNdiAssuranceSlate <Boolean>]
+ [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>]
  [-EnableMeetingBackgroundImages <Boolean>] [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
@@ -46,8 +45,38 @@ In the example shown above, the commands will change brand accent color of theme
 
 ## PARAMETERS
 
+### -MeetingBackgroundImages
+List of meeting background images. You can alter list returned by `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter.
+
+```yaml
+Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBrandingThemes
+List of meeting branding themes. You can alter list returned by `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter. (see example 1).
+
+```yaml
+Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DefaultTheme
-Identity of default meeting theme.
+Identity of default meeting theme. It should not be changed manually.
 
 ```yaml
 Type: String
@@ -106,13 +135,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -MeetingBackgroundImages
-List of meeting background images.
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
 ```yaml
-Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
 Position: Named
@@ -121,13 +150,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -MeetingBrandingThemes
-List of meeting branding themes.
+### -WhatIf
+Describes what would happen if you executed the command without actually executing the command.
 
 ```yaml
-Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: wi
 
 Required: False
 Position: Named
@@ -135,6 +164,24 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -1,0 +1,149 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/set-csteamsmeetingbrandingpolicy
+schema: 2.0.0
+title: Set-CsTeamsMeetingBrandingPolicy
+author: szymonkatraMSFT
+ms.author: szymonkatra
+ms.reviewer:
+manager: stanlythomas
+applicable: Skype for Business Online
+---
+
+# Set-CsTeamsMeetingBrandingPolicy
+
+## SYNOPSIS
+The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the appearance in meetings by defining custom background, logo and colors.
+
+## SYNTAX
+
+```
+Set-CsTeamsMeetingBrandingPolicy
+ [-NdiAssuranceSlateImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.NdiAssuranceSlate]>]
+ [-MeetingBackgroundImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]>]
+ [-MeetingBrandingThemes <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]>]
+ [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>] [-EnableNdiAssuranceSlate <Boolean>]
+ [-EnableMeetingBackgroundImages <Boolean>] [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-CsTeamsMeetingBrandingPolicy cmdlet allows administrators to update existing meeting branding policies.
+However, it cannot be used to upload the images. If you want to upload the images, please use Teams Admin Center.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-CsTeamsMeetingBrandingPolicy
+PS C:\> $brandingPolicy = Get-CsTeamsMeetingBrandingPolicy -Identity "demo branding"
+PS C:\> $brandingPolicy.MeetingBrandingThemes[0].BrandAccentColor = "#FF0000"
+PS C:\> Set-CsTeamsMeetingBrandingPolicy -Identity "demo branding" -MeetingBrandingThemes $brandingPolicy.MeetingBrandingThemes
+```
+
+In the example shown above, the commands will change brand accent color of theme inside the `demo branding` meeting branding policy to `#FF0000`. 
+
+## PARAMETERS
+
+### -DefaultTheme
+Identity of default meeting theme.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableMeetingBackgroundImages
+Enable custom meeting backgrounds.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableMeetingOptionsThemeOverride
+Allow organizer to control meeting theme.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Identity of meeting branding policy that will be updated. To refer to the global policy, use this syntax: -Identity global.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBackgroundImages
+List of meeting background images.
+
+```yaml
+Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MeetingBrandingThemes
+List of meeting branding themes.
+
+```yaml
+Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+## NOTES
+
+Available in Teams PowerShell Module 4.9.3 or later.
+
+## RELATED LINKS
+
+[Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+[Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+[New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+[Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
+[Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)

--- a/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsMeetingBrandingPolicy.md
@@ -20,8 +20,8 @@ The CsTeamsMeetingBrandingPolicy cmdlets enable administrators to control the ap
 
 ```
 Set-CsTeamsMeetingBrandingPolicy
- [-MeetingBackgroundImages <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]>]
- [-MeetingBrandingThemes <System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]>]
+ [-MeetingBackgroundImages <PSListModifier>]
+ [-MeetingBrandingThemes <PSListModifier>]
  [-DefaultTheme <String>] [-EnableMeetingOptionsThemeOverride <Boolean>]
  [-EnableMeetingBackgroundImages <Boolean>] [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -46,7 +46,9 @@ In the example shown above, the commands will change brand accent color of theme
 ## PARAMETERS
 
 ### -MeetingBackgroundImages
-List of meeting background images. You can alter list returned by `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter.
+*This parameter is reserved for Microsoft internal use only.*
+List of meeting background images.
+It is not possible to add/remove background images using cmdlets. Please use Teams Admin Center (TAC) for that purpose.
 
 ```yaml
 Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBackgroundImage]
@@ -62,6 +64,7 @@ Accept wildcard characters: False
 
 ### -MeetingBrandingThemes
 List of meeting branding themes. You can alter list returned by `Get-CsTeamsMeetingBrandingPolicy` cmdlet and pass it to this parameter. (see example 1).
+It is not possible to add new/remove meeting branding themes using cmdlets. Please use Teams Admin Center (TAC) for that purpose.
 
 ```yaml
 Type: System.Management.Automation.PSListModifier`1[Microsoft.Teams.Policy.Administration.Cmdlets.Core.MeetingBrandingTheme]
@@ -76,7 +79,8 @@ Accept wildcard characters: False
 ```
 
 ### -DefaultTheme
-Identity of default meeting theme. It should not be changed manually.
+*This parameter is reserved for Microsoft internal use only.*
+Identity of default meeting theme.
 
 ```yaml
 Type: String

--- a/skype/skype-ps/skype/skype.md
+++ b/skype/skype-ps/skype/skype.md
@@ -758,7 +758,7 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 {{Manually Enter Get-CsTeamsMeetingPolicy Description Here}}
 
 ### [Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
-{{Manually Enter Get-CsTeamsMeetingBrandingPolicy Description Here}}
+The Get-CsTeamsMeetingBrandingPolicy cmdlet enables you to return information about all the meeting branding policies that have been configured for use in your organization.
 
 ### [Get-CsTelemetryConfiguration](Get-CsTelemetryConfiguration.md)
 {{Manually Enter Get-CsTelemetryConfiguration Description Here}}
@@ -1013,7 +1013,7 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 {{Manually Enter Grant-CsTeamsMeetingPolicy Description Here}}
 
 ### [Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
-{{Manually Enter Grant-CsTeamsMeetingBrandingPolicy Description Here}}
+Assigns a teams meeting branding policy at the per-user scope.
 
 ### [Grant-CsTenantDialPlan](Grant-CsTenantDialPlan.md)
 {{Manually Enter Grant-CsTenantDialPlan Description Here}}
@@ -1592,7 +1592,7 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 {{Manually Enter New-CsTeamsMeetingPolicy Description Here}}
 
 ### [New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
-{{Manually Enter New-CsTeamsMeetingBrandingPolicy Description Here}}
+This cmdlet creates a new TeamsMeetingBrandingPolicy.  
 
 ### [New-CsTelemetryConfiguration](New-CsTelemetryConfiguration.md)
 {{Manually Enter New-CsTelemetryConfiguration Description Here}}
@@ -2090,7 +2090,7 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 {{Manually Enter Remove-CsTeamsMeetingPolicy Description Here}}
 
 ### [Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
-{{Manually Enter Remove-CsTeamsMeetingBrandingPolicy Description Here}}
+Deletes a previously created TeamsMeetingBrandingPolicy.
 
 ### [Remove-CsTelemetryConfiguration](Remove-CsTelemetryConfiguration.md)
 {{Manually Enter Remove-CsTelemetryConfiguration Description Here}}
@@ -2723,7 +2723,7 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 {{Manually Enter Set-CsTeamsMeetingPolicy Description Here}}
 
 ### [Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)
-{{Manually Enter Set-CsTeamsMeetingBrandingPolicy Description Here}}
+The Set-CsTeamsMeetingBrandingPolicy cmdlet allows administrators to update existing meeting branding policies.
 
 ### [Set-CsTelemetryConfiguration](Set-CsTelemetryConfiguration.md)
 {{Manually Enter Set-CsTelemetryConfiguration Description Here}}

--- a/skype/skype-ps/skype/skype.md
+++ b/skype/skype-ps/skype/skype.md
@@ -757,6 +757,9 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 ### [Get-CsTeamsMeetingPolicy](Get-CsTeamsMeetingPolicy.md)
 {{Manually Enter Get-CsTeamsMeetingPolicy Description Here}}
 
+### [Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+{{Manually Enter Get-CsTeamsMeetingBrandingPolicy Description Here}}
+
 ### [Get-CsTelemetryConfiguration](Get-CsTelemetryConfiguration.md)
 {{Manually Enter Get-CsTelemetryConfiguration Description Here}}
 
@@ -1008,6 +1011,9 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 
 ### [Grant-CsTeamsMeetingPolicy](Grant-CsTeamsMeetingPolicy.md)
 {{Manually Enter Grant-CsTeamsMeetingPolicy Description Here}}
+
+### [Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+{{Manually Enter Grant-CsTeamsMeetingBrandingPolicy Description Here}}
 
 ### [Grant-CsTenantDialPlan](Grant-CsTenantDialPlan.md)
 {{Manually Enter Grant-CsTenantDialPlan Description Here}}
@@ -1585,6 +1591,9 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 ### [New-CsTeamsMeetingPolicy](New-CsTeamsMeetingPolicy.md)
 {{Manually Enter New-CsTeamsMeetingPolicy Description Here}}
 
+### [New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+{{Manually Enter New-CsTeamsMeetingBrandingPolicy Description Here}}
+
 ### [New-CsTelemetryConfiguration](New-CsTelemetryConfiguration.md)
 {{Manually Enter New-CsTelemetryConfiguration Description Here}}
 
@@ -2079,6 +2088,9 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 
 ### [Remove-CsTeamsMeetingPolicy](Remove-CsTeamsMeetingPolicy.md)
 {{Manually Enter Remove-CsTeamsMeetingPolicy Description Here}}
+
+### [Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
+{{Manually Enter Remove-CsTeamsMeetingBrandingPolicy Description Here}}
 
 ### [Remove-CsTelemetryConfiguration](Remove-CsTelemetryConfiguration.md)
 {{Manually Enter Remove-CsTelemetryConfiguration Description Here}}
@@ -2710,6 +2722,9 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 ### [Set-CsTeamsMeetingPolicy](Set-CsTeamsMeetingPolicy.md)
 {{Manually Enter Set-CsTeamsMeetingPolicy Description Here}}
 
+### [Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)
+{{Manually Enter Set-CsTeamsMeetingBrandingPolicy Description Here}}
+
 ### [Set-CsTelemetryConfiguration](Set-CsTelemetryConfiguration.md)
 {{Manually Enter Set-CsTelemetryConfiguration Description Here}}
 
@@ -3197,6 +3212,16 @@ The following cmdlet references are for Skype for Business and Microsoft Teams. 
 ### [Grant-CsTeamsMeetingPolicy](Grant-CsTeamsMeetingPolicy.md)
 
 ### [Remove-CsTeamsMeetingPolicy](Remove-CsTeamsMeetingPolicy.md)
+
+### [Get-CsTeamsMeetingBrandingPolicy](Get-CsTeamsMeetingBrandingPolicy.md)
+
+### [Set-CsTeamsMeetingBrandingPolicy](Set-CsTeamsMeetingBrandingPolicy.md)
+
+### [New-CsTeamsMeetingBrandingPolicy](New-CsTeamsMeetingBrandingPolicy.md)
+
+### [Grant-CsTeamsMeetingBrandingPolicy](Grant-CsTeamsMeetingBrandingPolicy.md)
+
+### [Remove-CsTeamsMeetingBrandingPolicy](Remove-CsTeamsMeetingBrandingPolicy.md)
 
 ### [Set-CsAuthConfig](Set-CsAuthConfig.md)
 


### PR DESCRIPTION
Adding documentation for TeamsMeetingBrandingPolicy cmdlets:
- Get-CsTeamsMeetingBrandingPolicy
- Grant-CsTeamsMeetingBrandingPolicy
- New-CsTeamsMeetingBrandingPolicy
- Remove-CsTeamsMeetingBrandingPolicy
- Set-CsTeamsMeetingBrandingPolicy