### PR TITLE
Update New-TransportRule -SenderAddressLocation section

### DIFF
--- a/exchange/exchange-ps/exchange/New-TransportRule.md
+++ b/exchange/exchange-ps/exchange/New-TransportRule.md
@@ -4415,11 +4415,11 @@ Accept wildcard characters: False
 ### -SenderAddressLocation
 The SenderAddressLocation parameter specifies where to look for sender addresses in conditions and exceptions that examine sender email addresses. Valid values are:
 
-- Header: Only examine senders in the message headers (**From** field). This is the default value, and is the way rules worked before Exchange 2013 Cumulative Update 1 (CU1).
+- Header: Only examine senders in the message headers. For example, in on-premises Exchange the the From, Sender, or Reply-To fields. In Exchange Online, the From field only. This is the default value, and is the way rules worked before Exchange 2013 Cumulative Update 1 (CU1).
 - Envelope: Only examine senders from the message envelope (the MAIL FROM value that was used in the SMTP transmission, which is typically stored in the Return-Path field).
 - HeaderOrEnvelope: Examine senders in the message header and the message envelope.
 
-Note that message envelope searching is only available for the following conditions and exceptions:
+Message envelope searching is only available for the following conditions and exceptions:
 
 - From and ExceptIfFrom
 - FromAddressContainsWords and ExceptIfFromAddressContainsWords

--- a/exchange/exchange-ps/exchange/New-TransportRule.md
+++ b/exchange/exchange-ps/exchange/New-TransportRule.md
@@ -4415,7 +4415,7 @@ Accept wildcard characters: False
 ### -SenderAddressLocation
 The SenderAddressLocation parameter specifies where to look for sender addresses in conditions and exceptions that examine sender email addresses. Valid values are:
 
-- Header: Only examine senders in the message headers (for example, the From, Sender, or Reply-To fields). This is the default value, and is the way rules worked before Exchange 2013 Cumulative Update 1 (CU1).
+- Header: Only examine senders in the message headers (**From** field). This is the default value, and is the way rules worked before Exchange 2013 Cumulative Update 1 (CU1).
 - Envelope: Only examine senders from the message envelope (the MAIL FROM value that was used in the SMTP transmission, which is typically stored in the Return-Path field).
 - HeaderOrEnvelope: Examine senders in the message header and the message envelope.
 


### PR DESCRIPTION
The documentation is incorrect.
When Header is used during the evaluation of the rule, only property FROM from message header is used. Sender and Reply-To properties are not used.
Confirmation of this can be found in the ADO WI.

It should state:
**Header**: Only examine senders in the message headers (**From** field). This is the default value.

The ADO Work Item to correct this mistake can be found here https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/3510129