### PR TITLE
EnableShiftPresence option no longer needed in -CsTeamsShiftsPolicy commands

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsPolicy.md
@@ -19,7 +19,8 @@ Get-CsTeamsShiftsPolicy [[-Identity] <XdsIdentity>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet allows you to get properties of a TeamsShiftPolicy instance. Use this to get the policy name, and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+This cmdlet allows you to get properties of a TeamsShiftPolicy instance. Use this to get the policy name and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+
 
 
 ## EXAMPLES

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsPolicy.md
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-This cmdlet allows you to get properties of a TeamsShiftPolicy instance, including user's shift based presence and Teams off shift warning message-specific settings.
+This cmdlet allows you to get properties of a TeamsShiftPolicy instance, including user's Teams off shift warning message-specific settings.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Get-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsShiftsPolicy.md
@@ -19,7 +19,7 @@ Get-CsTeamsShiftsPolicy [[-Identity] <XdsIdentity>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet allows you to get properties of a TeamsShiftPolicy instance. Use this to get the policy name, user's shift based presence (EnableShiftPresence) and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+This cmdlet allows you to get properties of a TeamsShiftPolicy instance. Use this to get the policy name, and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
 
 
 ## EXAMPLES

--- a/teams/teams-ps/teams/New-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsShiftsPolicy.md
@@ -14,13 +14,13 @@ This cmdlet allows you to create a new TeamsShiftPolicy instance and set it's pr
 ## SYNTAX
 
 ```
-New-CsTeamsShiftsPolicy [-Identity] <XdsIdentity> [-EnableShiftPresence <Boolean>]
+New-CsTeamsShiftsPolicy [-Identity] <XdsIdentity>
  [-ShiftNoticeFrequency <String>] [-ShiftNoticeMessageType <String>] [-ShiftNoticeMessageCustom <String>]
  [-AccessType <String>] [-AccessGracePeriodMinutes <Int64>] [-EnableScheduleOwnerPermissions <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet allows you to create a TeamsShiftPolicy instance. Use this to also set the policy name, schedule owner permissions, user's shift based presence (EnableShiftPresence) and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+This cmdlet allows you to create a TeamsShiftPolicy instance. Use this to also set the policy name, schedule owner permissions, and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
 
 
 ## EXAMPLES
@@ -34,7 +34,7 @@ Creates a new instance of TeamsShiftsPolicy called OffShiftAccessMessage1Always 
 
 ### Example 2
 ```powershell
-PS C:\> New-CsTeamsShiftsPolicy -Identity OffShiftAccessMessage1Always -EnableShiftPresence $true -ShiftNoticeFrequency always -ShiftNoticeMessageType Message1 -AccessType UnrestrictedAccess_TeamsApp -AccessGracePeriodMinutes 5 -EnableScheduleOwnerPermissions $false
+PS C:\> New-CsTeamsShiftsPolicy -Identity OffShiftAccessMessage1Always -ShiftNoticeFrequency always -ShiftNoticeMessageType Message1 -AccessType UnrestrictedAccess_TeamsApp -AccessGracePeriodMinutes 5 -EnableScheduleOwnerPermissions $false
 ```
 
 Creates a new instance of TeamsShiftsPolicy called OffShiftAccessMessage1Always and applies the provided values to its settings.
@@ -70,21 +70,6 @@ Applicable: Microsoft Teams
 Required: False
 Position: Named
 Default value: UnrestrictedAccess_TeamsApp
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EnableShiftPresence
-Indicates whether a user is given shift-based presence (On shift, Off shift, or Busy). This must be set in order to have any off shift warning message-specific settings.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsPolicy.md
@@ -18,7 +18,8 @@ Set-CsTeamsShiftsPolicy [[-Identity] <XdsIdentity>] [-ShiftNoticeFrequency <Stri
 ```
 
 ## DESCRIPTION
-This cmdlet allows you to set or update properties of a TeamsShiftPolicy instance. Use this to set the policy name, and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+This cmdlet allows you to set or update properties of a TeamsShiftPolicy instance. Use this to set the policy name and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+
 
 
 ## EXAMPLES

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsPolicy.md
@@ -28,7 +28,8 @@ This cmdlet allows you to set or update properties of a TeamsShiftPolicy instanc
 ```powershell
 PS C:\> Set-CsTeamsShiftsPolicy -Identity OffShiftAccess_WarningMessage1_AlwaysShowMessage -ShiftNoticeMessageType Message1 -ShiftNoticeFrequency always -AccessGracePeriodMinutes 5
 ```
-In this example, the policy instance is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage", a warning message (Message 1) will be always be displayed to the user on opening Teams during off shift hours.
+In this example, the policy instance is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage", a warning message (Message 1) will always be displayed to the user on opening Teams during off shift hours.
+
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Set-CsTeamsShiftsPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsShiftsPolicy.md
@@ -9,25 +9,25 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-This cmdlet allows you to set or update properties of a TeamsShiftPolicy instance, including user's shift based presence and Teams off shift warning message-specific settings.
+This cmdlet allows you to set or update properties of a TeamsShiftPolicy instance, including Teams off shift warning message-specific settings.
 
 ## SYNTAX
 
 ```
-Set-CsTeamsShiftsPolicy [[-Identity] <XdsIdentity>] [-EnableShiftPresence <Boolean>] [-ShiftNoticeFrequency <String>] [-ShiftNoticeMessageType <String>] [-ShiftNoticeMessageCustom <String>] [-AccessType <String>] [-AccessGracePeriodMinutes <Int64>] [-EnableScheduleOwnerPermissions <Boolean>] [<CommonParameters>]
+Set-CsTeamsShiftsPolicy [[-Identity] <XdsIdentity>] [-ShiftNoticeFrequency <String>] [-ShiftNoticeMessageType <String>] [-ShiftNoticeMessageCustom <String>] [-AccessType <String>] [-AccessGracePeriodMinutes <Int64>] [-EnableScheduleOwnerPermissions <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet allows you to set or update properties of a TeamsShiftPolicy instance. Use this to set the policy name, user's shift based presence (EnableShiftPresence) and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
+This cmdlet allows you to set or update properties of a TeamsShiftPolicy instance. Use this to set the policy name, and Teams off shift warning message-specific settings (ShiftNoticeMessageType, ShiftNoticeMessageCustom, ShiftNoticeFrequency, AccessGracePeriodMinutes).
 
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Set-CsTeamsShiftsPolicy -Identity OffShiftAccess_WarningMessage1_AlwaysShowMessage -EnableShiftPresence $true -ShiftNoticeMessageType Message1 -ShiftNoticeFrequency always -AccessGracePeriodMinutes 5
+PS C:\> Set-CsTeamsShiftsPolicy -Identity OffShiftAccess_WarningMessage1_AlwaysShowMessage -ShiftNoticeMessageType Message1 -ShiftNoticeFrequency always -AccessGracePeriodMinutes 5
 ```
-In this example, the policy instance is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage", Shift based presence is enabled (On Shift, Off Shift), a warning message (Message 1) will be always be displayed to the user on opening Teams during off shift hours.
+In this example, the policy instance is called "OffShiftAccess_WarningMessage1_AlwaysShowMessage", a warning message (Message 1) will be always be displayed to the user on opening Teams during off shift hours.
 
 ## PARAMETERS
 
@@ -60,21 +60,6 @@ Applicable: Microsoft Teams
 Required: False
 Position: Named
 Default value: UnrestrictedAccess_TeamsApp
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -EnableShiftPresence
-Indicates whether a user is given shift-based presence (On shift, Off shift, or Busy). This must be set in order to have any off shift warning message-specific settings.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
The Shifts Service team is no longer supporting _shifts based presence_ in their PS commands. You can contact the following MSFT alias for futher details:
- wblocker
- martinflores
- erkandurmaz
- andreagannon