### PR TITLE
Updated PublicFolderClientAccess parameter

### DIFF
--- a/exchange/exchange-ps/exchange/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/Set-CASMailbox.md
@@ -1156,7 +1156,7 @@ Accept wildcard characters: False
 The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to $true. Valid values are:
 
 - $true: The user can access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true (the default value is $false).
-- $false: The user can't access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true. This is the default value.
+- $false: The user can't access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to $true. This is the default value.
 
 ```yaml
 Type: Boolean

--- a/exchange/exchange-ps/exchange/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/Set-CASMailbox.md
@@ -1153,10 +1153,10 @@ Accept wildcard characters: False
 ```
 
 ### -PublicFolderClientAccess
-The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to $true. Valid values are:
+The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook. Valid values are:
 
-- $true: The user can access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true (the default value is $false).
-- $false: The user can't access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to $true. This is the default value.
+- $true: The user can access public folders in Outlook if the value of the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is $true (the default value is $false).
+- $false: The user can't access public folders in Outlook if the value of the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is $true. This is the default value.
 
 ```yaml
 Type: Boolean

--- a/exchange/exchange-ps/exchange/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/Set-CASMailbox.md
@@ -1153,10 +1153,10 @@ Accept wildcard characters: False
 ```
 
 ### -PublicFolderClientAccess
-The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook. Valid values are:
+The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true. Valid values are:
 
 - $true: The user can access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true (the default value is $false).
-- $false: The user can't access public folders in Outlook. This is the default value.
+- $false: The user can't access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true. This is the default value.
 
 ```yaml
 Type: Boolean

--- a/exchange/exchange-ps/exchange/Set-CASMailbox.md
+++ b/exchange/exchange-ps/exchange/Set-CASMailbox.md
@@ -1153,7 +1153,7 @@ Accept wildcard characters: False
 ```
 
 ### -PublicFolderClientAccess
-The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true. Valid values are:
+The PublicFolderClientAccess parameter enables or disables access to public folders in Microsoft Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to $true. Valid values are:
 
 - $true: The user can access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true (the default value is $false).
 - $false: The user can't access public folders in Outlook if the PublicFolderShowClientControl parameter on the Set-OrganizationConfig cmdlet is set to the $true. This is the default value.


### PR DESCRIPTION
According to 
https://techcommunity.microsoft.com/t5/exchange-team-blog/announcing-support-for-controlled-connections-to-public-folders/ba-p/608591 it only apply if PublicFolderShowClientControl at organization level and with the current description looks it is not involve if you use false. Needs clarification to confirma that only apply if PublicFolderShowClientControl is set to $true.