### PR TITLE
Update Set-InboundConnector.md

### DIFF
--- a/exchange/exchange-ps/exchange/New-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/New-InboundConnector.md
@@ -472,7 +472,9 @@ Accept wildcard characters: False
 ```
 
 ### -TrustedOrganizations
-{{ Fill TrustedOrganizations Description }}
+The TrustedOrganizations parameter specifies other Microsoft 365 organizations that are trusted mail sources (for example, after acquisitions and mergers). You can specify multiple Microsoft 365 organizations separated by commas.
+
+This parameter works only for mail flow between two Microsoft 365 organizations, so no other parameters are used.
 
 ```yaml
 Type: MultiValuedProperty

--- a/exchange/exchange-ps/exchange/Set-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/Set-InboundConnector.md
@@ -482,7 +482,7 @@ Accept wildcard characters: False
 ```
 
 ### -TrustedOrganizations
-"TrustedOrganizations" identifies other Office 365 organizations as trusted mail sources for your organization (for example, after acquisitions and mergers). This connector will only work for mail flow between two O365 organizations, so no other parameters will be used.
+The TrustedOrganizations parameter identifies other Office 365 organizations as trusted mail sources for your organization (for example, after acquisitions and mergers). This parameter only works for mail flow between two Office 365 organizations, so no other parameters are used.
 
 ```yaml
 Type: MultiValuedProperty

--- a/exchange/exchange-ps/exchange/Set-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/Set-InboundConnector.md
@@ -482,7 +482,7 @@ Accept wildcard characters: False
 ```
 
 ### -TrustedOrganizations
-{{ Fill TrustedOrganizations Description }}
+"TrustedOrganizations" identifies other Office 365 organizations as trusted mail sources for your organization (for example, after acquisitions and mergers). This connector will only work for mail flow between two O365 organizations, so no other parameters will be used.
 
 ```yaml
 Type: MultiValuedProperty

--- a/exchange/exchange-ps/exchange/Set-InboundConnector.md
+++ b/exchange/exchange-ps/exchange/Set-InboundConnector.md
@@ -482,7 +482,11 @@ Accept wildcard characters: False
 ```
 
 ### -TrustedOrganizations
-The TrustedOrganizations parameter identifies other Office 365 organizations as trusted mail sources for your organization (for example, after acquisitions and mergers). This parameter only works for mail flow between two Office 365 organizations, so no other parameters are used.
+The TrustedOrganizations parameter specifies other Microsoft 365 organizations that are trusted mail sources (for example, after acquisitions and mergers). This parameter works only for mail flow between two Microsoft 365 organizations, so no other parameters are used.
+
+To enter multiple values and overwrite any existing entries, use the following syntax: `Value1,Value2,...ValueN`. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
+
+To add or remove one or more values without affecting any existing entries, use the following syntax: `@{Add="Value1","Value2"...; Remove="Value3","Value4"...}`.
 
 ```yaml
 Type: MultiValuedProperty


### PR DESCRIPTION
Add a description for Trusted Organizations:

"TrustedOrganizations" identifies other Office 365 organizations as trusted mail sources for your organization (for example, after acquisitions and mergers). This connector will only work for mail flow between two O365 organizations, so no other parameters will be used.