### PR TITLE
Update Set-TransportRule.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-TransportRule.md
+++ b/exchange/exchange-ps/exchange/Set-TransportRule.md
@@ -4304,7 +4304,7 @@ Accept wildcard characters: False
 ```
 
 ### -SCLOver
-This parameter is functional only in on-premises Exchange.
+**Note**: This parameter is functional only in on-premises Exchange.
 
 This parameter specifies a condition or part of a condition for the rule. The name of the corresponding exception parameter starts with ExceptIf.
 
@@ -4321,7 +4321,7 @@ The rule looks for messages with an SCL value that's greater than or equal to th
 Type: SclValue
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
+Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019, Exchange Online, Exchange Online Protection
 
 Required: False
 Position: Named

--- a/exchange/exchange-ps/exchange/Set-TransportRule.md
+++ b/exchange/exchange-ps/exchange/Set-TransportRule.md
@@ -4321,7 +4321,7 @@ The rule looks for messages with an SCL value that's greater than or equal to th
 Type: SclValue
 Parameter Sets: (All)
 Aliases:
-Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019, Exchange Online, Exchange Online Protection
+Applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
 
 Required: False
 Position: Named


### PR DESCRIPTION
“Applies to:” with ExO and ExO Online Protection
is misleading/confusing because it’s the opposite message than the statement at the beginning that SCL-Exceptions DO NOT apply in ExO.