### PR TITLE
TeamsMeetingTemplatePermissionPolicy cmdlet docs

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -1,0 +1,64 @@
+# Get-CsTeamsFirstPartyMeetingTemplateConfiguration
+
+## SYNOPSIS
+This cmdlet fetches the first party meeting templates stored on the tenant.
+
+## SYNTAX
+
+```powershell
+Get-CsTeamsFirstPartyMeetingTemplateConfiguration [[-Identity] <string>]  [<CommonParameters>]
+```
+
+## DESCRIPTION
+Fetches the list of first party templates on the tenant. Each template object contains its list of meeting options, the name of the template and its ID.
+
+This is a readonly configuration.
+
+## EXAMPLES
+
+To fetch all the first party templates on the tenant just run the command without any parameters:
+
+```powershell
+PS C:\test> Get-CsTeamsFirstPartyMeetingTemplateConfiguration
+```
+```output
+Identity              : Global
+TeamsMeetingTemplates : {default, firstparty_30d773c0-1b4e-4bf6-970b-73f544c054bb,
+                        firstparty_399f69a3-c482-41bf-9cf7-fcdefe269ce6,
+                        firstparty_64c92390-c8a2-471e-96d9-4ee8f6080155...}
+Description           :
+```
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+A configuration object with the following structure:
+
+```output
+Identity              : Global
+TeamsMeetingTemplates : {default, firstparty_30d773c0-1b4e-4bf6-970b-73f544c054bb,
+                        firstparty_399f69a3-c482-41bf-9cf7-fcdefe269ce6,
+                        firstparty_64c92390-c8a2-471e-96d9-4ee8f6080155...}
+Description           :
+```
+
+The `TeamsMeetingTemplates` property contains the meeting template details:
+
+```output
+TeamsMeetingOptions : {SelectedSensitivityLabel, AutoAdmittedUsers, AllowPstnUsersToBypassLobby,
+                      EntryExitAnnouncementsEnabled...}
+Description         : Townhall
+Name                : firstparty_21f91ef7-6265-4064-b78b-41ab66889d90
+Category            :
+
+TeamsMeetingOptions : {AutoRecordingEnabled, AllowMeetingChat, PresenterOption}
+Description         : Virtual appointment
+Name                : firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
+Category            :
+```
+
+## RELATED LINKS
+[Get-CsTeamsMeetingTemplateConfiguration](Get-CsTeamsMeetingTemplateConfiguration.md)

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -25,11 +25,12 @@ This is a readonly configuration.
 
 ## EXAMPLES
 
-To fetch all the first party templates on the tenant just run the command without any parameters:
+### Example 1
 
 ```powershell
 PS> Get-CsTeamsFirstPartyMeetingTemplateConfiguration
 ```
+
 ```output
 Identity              : Global
 TeamsMeetingTemplates : {default, firstparty_30d773c0-1b4e-4bf6-970b-73f544c054bb,
@@ -52,6 +53,8 @@ Description         : Virtual appointment
 Name                : firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
 Category            :
 ```
+
+Fetches all the first party templates on the tenant.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: Get-CsTeamsFirstPartyMeetingTemplateConfiguration
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration
+schema: 2.0.0
+---
+
 # Get-CsTeamsFirstPartyMeetingTemplateConfiguration
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -54,7 +54,7 @@ Name                : firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
 Category            :
 ```
 
-Fetches all the first party templates on the tenant.
+Fetches all the first-party templates on the tenant.
 
 ## PARAMETERS
 
@@ -62,7 +62,7 @@ Fetches all the first party templates on the tenant.
 
 This parameter can be used to fetch a specific instance of the configuration.
 
-Note: This configuration is readonly and will only have the Global instance.
+Note: This configuration is read only and will only have the Global instance.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -15,7 +15,7 @@ This cmdlet fetches the first party meeting templates stored on the tenant.
 ## SYNTAX
 
 ```powershell
-Get-CsTeamsFirstPartyMeetingTemplateConfiguration [[-Identity] <string>]  [<CommonParameters>]
+Get-CsTeamsFirstPartyMeetingTemplateConfiguration [[-Identity] <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,20 +28,8 @@ This is a readonly configuration.
 To fetch all the first party templates on the tenant just run the command without any parameters:
 
 ```powershell
-PS C:\test> Get-CsTeamsFirstPartyMeetingTemplateConfiguration
+PS> Get-CsTeamsFirstPartyMeetingTemplateConfiguration
 ```
-```output
-Identity              : Global
-TeamsMeetingTemplates : {default, firstparty_30d773c0-1b4e-4bf6-970b-73f544c054bb,
-                        firstparty_399f69a3-c482-41bf-9cf7-fcdefe269ce6,
-                        firstparty_64c92390-c8a2-471e-96d9-4ee8f6080155...}
-Description           :
-```
-
-## OUTPUTS
-
-A configuration object with the following structure:
-
 ```output
 Identity              : Global
 TeamsMeetingTemplates : {default, firstparty_30d773c0-1b4e-4bf6-970b-73f544c054bb,
@@ -64,6 +52,29 @@ Description         : Virtual appointment
 Name                : firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
 Category            :
 ```
+
+## PARAMETERS
+
+### -Identity
+
+This parameter can be used to fetch a specific instance of the configuration.
+
+Note: This configuration is readonly and will only have the Global instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplateConfiguration](Get-CsTeamsMeetingTemplateConfiguration.md)

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -19,7 +19,7 @@ Get-CsTeamsFirstPartyMeetingTemplateConfiguration [[-Identity] <string>] [<Commo
 ```
 
 ## DESCRIPTION
-Fetches the list of first party templates on the tenant. Each template object contains its list of meeting options, the name of the template and its ID.
+Fetches the list of first-party templates on the tenant. Each template object contains its list of meeting options, the name of the template, and its ID.
 
 This is a read-only configuration.
 

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -21,7 +21,7 @@ Get-CsTeamsFirstPartyMeetingTemplateConfiguration [[-Identity] <string>] [<Commo
 ## DESCRIPTION
 Fetches the list of first party templates on the tenant. Each template object contains its list of meeting options, the name of the template and its ID.
 
-This is a readonly configuration.
+This is a read-only configuration.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -10,7 +10,7 @@ schema: 2.0.0
 # Get-CsTeamsFirstPartyMeetingTemplateConfiguration
 
 ## SYNOPSIS
-This cmdlet fetches the first party meeting templates stored on the tenant.
+This cmdlet fetches the first-party meeting templates stored on the tenant.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -38,10 +38,6 @@ TeamsMeetingTemplates : {default, firstparty_30d773c0-1b4e-4bf6-970b-73f544c054b
 Description           :
 ```
 
-## INPUTS
-
-### None
-
 ## OUTPUTS
 
 A configuration object with the following structure:

--- a/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md
@@ -28,7 +28,7 @@ This is a readonly configuration.
 ### Example 1
 
 ```powershell
-PS> Get-CsTeamsFirstPartyMeetingTemplateConfiguration
+Get-CsTeamsFirstPartyMeetingTemplateConfiguration
 ```
 
 ```output

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -26,7 +26,7 @@ Fetches the list of custom templates on the tenant. Each template object contain
 ### Example 1
 
 ```powershell
-PS> Get-CsTeamsMeetingTemplateConfiguration
+Get-CsTeamsMeetingTemplateConfiguration
 ```
 
 ```output

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -23,7 +23,7 @@ Fetches the list of custom templates on the tenant. Each template object contain
 
 ## EXAMPLES
 
-# Example 1
+### Example 1
 
 ```powershell
 PS> Get-CsTeamsMeetingTemplateConfiguration

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -23,11 +23,12 @@ Fetches the list of custom templates on the tenant. Each template object contain
 
 ## EXAMPLES
 
-To fetch all the custom templates on the tenant just run the command without any parameters:
+# Example 1
 
 ```powershell
 PS> Get-CsTeamsMeetingTemplateConfiguration
 ```
+
 ```output
 Identity              : Global
 TeamsMeetingTemplates : {default, customtemplate_1cb7073a-8b19-4b5d-a3a6-14737d006969,
@@ -50,6 +51,8 @@ Description         : Custom Template 2
 Name                : customtemplate_21ecf22c-eb1a-4f05-93e0-555b994ebeb5
 Category            :
 ```
+
+Fetches all the custom templates on the tenant.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -9,3 +9,59 @@ schema: 2.0.0
 
 # Get-CsTeamsMeetingTemplateConfiguration
 
+## SYNOPSIS
+This cmdlet fetches the custom meeting templates stored on the tenant.
+
+## SYNTAX
+
+```powershell
+Get-CsTeamsMeetingTemplateConfiguration [[-Identity] <string>]  [<CommonParameters>]
+```
+
+## DESCRIPTION
+Fetches the list of custom templates on the tenant. Each template object contains its list of meeting options, the name of the template and its ID.
+
+## EXAMPLES
+
+To fetch all the custom templates on the tenant just run the command without any parameters:
+
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplateConfiguration
+```
+```output
+Identity              : Global
+TeamsMeetingTemplates : {default, customtemplate_1cb7073a-8b19-4b5d-a3a6-14737d006969,
+                        customtemplate_21ecf22c-eb1a-4f05-93e0-555b994ebeb5,
+                        customtemplate_0b9c1f57-01ec-4b8a-b4c2-08bd1c01e6ba...}
+Description           :
+```
+
+## OUTPUTS
+
+A configuration object with the following structure:
+
+```output
+Identity              : Global
+TeamsMeetingTemplates : {default, customtemplate_1cb7073a-8b19-4b5d-a3a6-14737d006969,
+                        customtemplate_21ecf22c-eb1a-4f05-93e0-555b994ebeb5,
+                        customtemplate_0b9c1f57-01ec-4b8a-b4c2-08bd1c01e6ba...}
+Description           :
+```
+
+The `TeamsMeetingTemplates` property contains the meeting template details:
+
+```output
+TeamsMeetingOptions : {SelectedSensitivityLabel, AutoAdmittedUsers, AllowPstnUsersToBypassLobby,
+                      EntryExitAnnouncementsEnabled...}
+Description         : Custom Template 1
+Name                : customtemplate_1cb7073a-8b19-4b5d-a3a6-14737d006969
+Category            :
+
+TeamsMeetingOptions : {AutoRecordingEnabled, AllowMeetingChat, PresenterOption}
+Description         : Custom Template 2
+Name                : customtemplate_21ecf22c-eb1a-4f05-93e0-555b994ebeb5
+Category            :
+```
+
+## RELATED LINKS
+[Get-CsTeamsFirstPartyMeetingTemplateConfiguration](Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md)

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -15,7 +15,7 @@ This cmdlet fetches the custom meeting templates stored on the tenant.
 ## SYNTAX
 
 ```powershell
-Get-CsTeamsMeetingTemplateConfiguration [[-Identity] <string>]  [<CommonParameters>]
+Get-CsTeamsMeetingTemplateConfiguration [[-Identity] <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,20 +26,8 @@ Fetches the list of custom templates on the tenant. Each template object contain
 To fetch all the custom templates on the tenant just run the command without any parameters:
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplateConfiguration
+PS> Get-CsTeamsMeetingTemplateConfiguration
 ```
-```output
-Identity              : Global
-TeamsMeetingTemplates : {default, customtemplate_1cb7073a-8b19-4b5d-a3a6-14737d006969,
-                        customtemplate_21ecf22c-eb1a-4f05-93e0-555b994ebeb5,
-                        customtemplate_0b9c1f57-01ec-4b8a-b4c2-08bd1c01e6ba...}
-Description           :
-```
-
-## OUTPUTS
-
-A configuration object with the following structure:
-
 ```output
 Identity              : Global
 TeamsMeetingTemplates : {default, customtemplate_1cb7073a-8b19-4b5d-a3a6-14737d006969,
@@ -62,6 +50,30 @@ Description         : Custom Template 2
 Name                : customtemplate_21ecf22c-eb1a-4f05-93e0-555b994ebeb5
 Category            :
 ```
+
+## PARAMETERS
+
+### -Identity
+
+This parameter can be used to fetch a specific instance of the configuration.
+
+Note: This configuration is readonly and will only have the Global instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
 
 ## RELATED LINKS
 [Get-CsTeamsFirstPartyMeetingTemplateConfiguration](Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md)

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -1,2 +1,11 @@
+---
+Module Name: MicrosoftTeams
+title: Get-CsTeamsMeetingTemplateConfiguration
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/Get-CsTeamsMeetingTemplateConfiguration
+schema: 2.0.0
+---
+
 # Get-CsTeamsMeetingTemplateConfiguration
 

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -1,0 +1,2 @@
+# Get-CsTeamsMeetingTemplateConfiguration
+

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplateConfiguration.md
@@ -19,7 +19,7 @@ Get-CsTeamsMeetingTemplateConfiguration [[-Identity] <string>] [<CommonParameter
 ```
 
 ## DESCRIPTION
-Fetches the list of custom templates on the tenant. Each template object contains its list of meeting options, the name of the template and its ID.
+Fetches the list of custom templates on the tenant. Each template object contains its list of meeting options, the name of the template, and its ID.
 
 ## EXAMPLES
 
@@ -60,7 +60,7 @@ Fetches all the custom templates on the tenant.
 
 This parameter can be used to fetch a specific instance of the configuration.
 
-Note: This configuration is readonly and will only have the Global instance.
+Note: This configuration is read only and will only have the Global instance.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -78,7 +78,7 @@ HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
 Description            :
 ```
 
-`Filter` parameter can be used to fetch policy instances based on partial matches on Identity.
+The `Filter` parameter can be used to fetch policy instances based on partial matches on Identity.
 
 Note: _The "Tag:" prefix can be ignored when specifying the identity._
 

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -59,10 +59,6 @@ Description            :
 
 Note: _The "Tag:" prefix can be ignored when specifying the identity._
 
-## INPUTS
-
-## OUTPUTS
-
 ## RELATED LINKS
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
 [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -13,9 +13,14 @@ schema: 2.0.0
 Fetches the TeamsMeetingTemplatePermissionPolicy. This policy can be used to hide meeting templates from users and groups.
 
 ## SYNTAX
+
+### Identity
 ```powershell
 Get-CsTeamsMeetingTemplatePermissionPolicy [[-Identity] <string>]  [<CommonParameters>]
+```
 
+### Filter
+```powershell
 Get-CsTeamsMeetingTemplatePermissionPolicy [-Filter <string>]  [<CommonParameters>]
 ```
 
@@ -23,7 +28,8 @@ Get-CsTeamsMeetingTemplatePermissionPolicy [-Filter <string>]  [<CommonParameter
 Fetches the instances of the policy. Each policy object contains a property called `HiddenMeetingTemplates`.This array contains the list of meeting template IDs that will be hidden by that instance of the policy.
 
 ## EXAMPLES
-To fetch all the policy instances currently available run the command with any parameters;
+
+### Example 1
 
 ```powershell
 PS> Get-CsTeamsMeetingTemplatePermissionPolicy
@@ -46,7 +52,9 @@ HiddenMeetingTemplates : {}
 Description            :
 ```
 
-To fetch an instance of a policy with known identity, pass in the `Identity` parameter:
+Fetches all the policy instances currently available.
+
+### Example 2
 
 ```powershell
 PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
@@ -57,7 +65,9 @@ HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
 Description            :
 ```
 
-`Filter` parameter can be used to fetch policy instances based on partial matches on Identity:
+Fetches an instance of a policy with known identity.
+
+### Example 3
 
 ```powershell
 PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Filter *Foo*
@@ -67,6 +77,8 @@ Identity               : Tag:Foobar
 HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
 Description            :
 ```
+
+`Filter` parameter can be used to fetch policy instances based on partial matches on Identity.
 
 Note: _The "Tag:" prefix can be ignored when specifying the identity._
 

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: Get-CsTeamsMeetingTemplatePermissionPolicy
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/Get-CsTeamsMeetingTemplatePermissionPolicy
+schema: 2.0.0
+---
+
 # Get-CsTeamsMeetingTemplatePermissionPolicy
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -32,7 +32,7 @@ Fetches the instances of the policy. Each policy object contains a property call
 ### Example 1
 
 ```powershell
-PS> Get-CsTeamsMeetingTemplatePermissionPolicy
+Get-CsTeamsMeetingTemplatePermissionPolicy
 ```
 ```output
 Identity               : Global

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -109,6 +109,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,0 +1,61 @@
+# Get-CsTeamsMeetingTemplatePermissionPolicy
+
+## SYNOPSIS
+Fetches the TeamsMeetingTemplatePermissionPolicy. This policy can be used to hide meeting templates from users and groups.
+
+## SYNTAX
+```powershell
+Get-CsTeamsMeetingTemplatePermissionPolicy [[-Identity] <string>]  [<CommonParameters>]
+
+Get-CsTeamsMeetingTemplatePermissionPolicy [-Filter <string>]  [<CommonParameters>]
+```
+
+## DESCRIPTION
+Fetches the instances of the policy. Each policy object contains a property called `HiddenMeetingTemplates`.This array contains the list of meeting template IDs that will be hidden by that instance of the policy.
+
+## EXAMPLES
+To fetch all the policy instances currently available run the command with any parameters;
+
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy
+```
+```output
+Identity               : Global
+HiddenMeetingTemplates : {}
+Description            :
+
+Identity               : Tag:Foobar
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            :
+
+Identity               : Tag:dashbrd test
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            : test
+
+Identity               : Tag:Default
+HiddenMeetingTemplates : {}
+Description            :
+```
+
+To fetch an instance of a policy with known identity, pass in the `Identity` parameter:
+
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+```
+```output
+Identity               : Tag:Foobar
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            :
+```
+
+Note: _The "Tag:" prefix can be ignored when specifying the identity._
+
+## INPUTS
+
+## OUTPUTS
+
+## RELATED LINKS
+[Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+[New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -26,7 +26,7 @@ Fetches the instances of the policy. Each policy object contains a property call
 To fetch all the policy instances currently available run the command with any parameters;
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy
 ```
 ```output
 Identity               : Global
@@ -49,7 +49,18 @@ Description            :
 To fetch an instance of a policy with known identity, pass in the `Identity` parameter:
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+```
+```output
+Identity               : Tag:Foobar
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            :
+```
+
+`Filter` parameter can be used to fetch policy instances based on partial matches on Identity:
+
+```powershell
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Filter *Foo*
 ```
 ```output
 Identity               : Tag:Foobar
@@ -58,6 +69,43 @@ Description            :
 ```
 
 Note: _The "Tag:" prefix can be ignored when specifying the identity._
+
+## PARAMETERS
+
+### -Identity
+
+This parameter can be used to fetch a specific instance of the policy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Filter
+
+This parameter can be used to fetch policy instances based on partial matches on the `Identity` field.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## RELATED LINKS
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: Grant-CsTeamsMeetingTemplatePermissionPolicy
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy
+schema: 2.0.0
+---
+
 # Grant-CsTeamsMeetingTemplatePermissionPolicy
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -34,7 +34,7 @@ Grant-CsTeamsMeetingTemplatePermissionPolicy [-Group] <string> [[-PolicyName] <s
 
 This cmdlet applies an instance of the TeamsMeetingTemplatePermissionPolicy to users or groups in a tenant.
 
-Pass in the `Identity` of the policy instance in the `PolicyName` parameter and the user identifier in the `Identity` parameter or the group name in the `Group` parameter. One of `Identity` or `Group` needs to be passed.
+Pass in the `Identity` of the policy instance in the `PolicyName` parameter and the user identifier in the `Identity` parameter or the group name in the `Group` parameter. One of either `Identity` or `Group` needs to be passed.
 
 ## EXAMPLES
 
@@ -50,7 +50,7 @@ Assigns a given policy to a user.
 
 ### -PolicyName
 
-Specifies the Identity of the policy to assign to the user/group.
+Specifies the Identity of the policy to assign to the user or group.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -23,21 +23,21 @@ This cmdlet applies an instance of the TeamsMeetingTemplatePermissionPolicy to u
     Grant-CsTeamsMeetingTemplatePermissionPolicy [-Group] <string> [[-PolicyName] <string>] -Rank <int>
     [<CommonParameters>]
 
-    Grant-CsTeamsMeetingTemplatePermissionPolicy [-Global] [[-PolicyName] <string>] [-Force]  [<CommonParameters>]
+    Grant-CsTeamsMeetingTemplatePermissionPolicy [-Global] [[-PolicyName] <string>] [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 This cmdlet applies an instance of the TeamsMeetingTemplatePermissionPolicy to users or groups in a tenant.
 
-Pass in the `Identity` of the policy instance in the `PolicyName` parameter and the user identifier in the `Identity` parameter or the group name in the `Group` parameter.
+Pass in the `Identity` of the policy instance in the `PolicyName` parameter and the user identifier in the `Identity` parameter or the group name in the `Group` parameter. One of `Identity` or `Group` needs to be passed.
 
 ## EXAMPLES
 
 Lets attempt to assign the Foobar policy instance to the user testuser@test.onmicrosoft.com. The policy instance that we want to assign:
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
 ```
 ```output
 Identity               : Tag:Foobar
@@ -48,8 +48,93 @@ Description            : updated description
 Command to assign the policy to the user:
 
 ```powershell
-PS C:\test> Grant-CsTeamsMeetingTemplatePermissionPolicy -PolicyName Foobar -Identity testuser@test.onmicrosoft.com
+PS> Grant-CsTeamsMeetingTemplatePermissionPolicy -PolicyName Foobar -Identity testuser@test.onmicrosoft.com
 ```
+
+## PARAMETERS
+
+### -PolicyName
+
+Specifies the Identity of the policy to assign to the user/group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+
+This is the identifier of the user that the policy should be assigned to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Group
+
+This is the identifier of the group that the policy should be assigned to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Global
+
+This is the equivalent to `-Identity Global`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+Forces the policy assignment.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -15,14 +15,18 @@ This cmdlet applies an instance of the TeamsMeetingTemplatePermissionPolicy to u
 
 ## SYNTAX
 
+### Identity
 ```powershell
-    Grant-CsTeamsMeetingTemplatePermissionPolicy  [<CommonParameters>]
+Grant-CsTeamsMeetingTemplatePermissionPolicy [[-PolicyName] <string>] -Identity <string> [<CommonParameters>]
+```
 
-    Grant-CsTeamsMeetingTemplatePermissionPolicy [[-PolicyName] <string>] -Identity <string>  [<CommonParameters>]
+### Group
+```powershell
+Grant-CsTeamsMeetingTemplatePermissionPolicy [-Group] <string> [[-PolicyName] <string>] [<CommonParameters>]
+```
 
-    Grant-CsTeamsMeetingTemplatePermissionPolicy [-Group] <string> [[-PolicyName] <string>] -Rank <int>
-    [<CommonParameters>]
-
+### Global
+```powershell
     Grant-CsTeamsMeetingTemplatePermissionPolicy [-Global] [[-PolicyName] <string>] [-Force] [<CommonParameters>]
 ```
 
@@ -34,22 +38,13 @@ Pass in the `Identity` of the policy instance in the `PolicyName` parameter and 
 
 ## EXAMPLES
 
-Lets attempt to assign the Foobar policy instance to the user testuser@test.onmicrosoft.com. The policy instance that we want to assign:
-
-```powershell
-PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
-```
-```output
-Identity               : Tag:Foobar
-HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
-Description            : updated description
-```
-
-Command to assign the policy to the user:
+### Example 1
 
 ```powershell
 PS> Grant-CsTeamsMeetingTemplatePermissionPolicy -PolicyName Foobar -Identity testuser@test.onmicrosoft.com
 ```
+
+Assigns a given policy to a user.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,0 +1,19 @@
+# Grant-CsTeamsMeetingTemplatePermissionPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+## DESCRIPTION
+
+## EXAMPLES
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -11,18 +11,48 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
+This cmdlet applies an instance of the TeamsMeetingTemplatePermissionPolicy to users or groups in a tenant.
+
 ## SYNTAX
+
+```powershell
+    Grant-CsTeamsMeetingTemplatePermissionPolicy  [<CommonParameters>]
+
+    Grant-CsTeamsMeetingTemplatePermissionPolicy [[-PolicyName] <string>] -Identity <string>  [<CommonParameters>]
+
+    Grant-CsTeamsMeetingTemplatePermissionPolicy [-Group] <string> [[-PolicyName] <string>] -Rank <int>
+    [<CommonParameters>]
+
+    Grant-CsTeamsMeetingTemplatePermissionPolicy [-Global] [[-PolicyName] <string>] [-Force]  [<CommonParameters>]
+```
 
 ## DESCRIPTION
 
+This cmdlet applies an instance of the TeamsMeetingTemplatePermissionPolicy to users or groups in a tenant.
+
+Pass in the `Identity` of the policy instance in the `PolicyName` parameter and the user identifier in the `Identity` parameter or the group name in the `Group` parameter.
+
 ## EXAMPLES
 
-## INPUTS
+Lets attempt to assign the Foobar policy instance to the user testuser@test.onmicrosoft.com. The policy instance that we want to assign:
 
-### None
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+```
+```output
+Identity               : Tag:Foobar
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            : updated description
+```
 
-## OUTPUTS
+Command to assign the policy to the user:
 
-### None
+```powershell
+PS C:\test> Grant-CsTeamsMeetingTemplatePermissionPolicy -PolicyName Foobar -Identity testuser@test.onmicrosoft.com
+```
 
-## NOTES
+## RELATED LINKS
+[Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+[New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -138,6 +138,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: New-CsTeamsHiddenMeetingTemplate
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/New-CsTeamsHiddenMeetingTemplate
+schema: 2.0.0
+---
+
 # New-CsTeamsHiddenMeetingTemplate
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -25,9 +25,14 @@ Creates an object that can be supplied as `HiddenMeetingTemplate` to [New-CsTeam
 
 ## EXAMPLES
 
+### Example 1
+
+Create a new hidden meeting template object:
 ```powershell
 PS> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
 ```
+
+Creates a new HiddenMeetingTemplate object with the given template id.
 
 For more examples on how this can be used, please check the examples at [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
 

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -54,5 +54,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -1,0 +1,19 @@
+# New-CsTeamsHiddenMeetingTemplate
+
+## SYNOPSIS
+
+## SYNTAX
+
+## DESCRIPTION
+
+## EXAMPLES
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -21,20 +21,21 @@ New-CsTeamsHiddenMeetingTemplate -Id <string>  [<CommonParameters>]
 
 ## DESCRIPTION
 
-Creates an object that can be supplied as `HiddenMeetingTemplate` to [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md) and [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md) cmdlets.
+Creates an object that can be supplied as `HiddenMeetingTemplate` to the [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md) and [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md) cmdlets.
 
 ## EXAMPLES
 
 ### Example 1
 
-Create a new hidden meeting template object:
+Creates a new hidden meeting template object:
+
 ```powershell
 PS> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
 ```
 
-Creates a new HiddenMeetingTemplate object with the given template id.
+Creates a new HiddenMeetingTemplate object with the given template ID.
 
-For more examples on how this can be used, please check the examples at [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+For more examples of how this can be used, see the examples for [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md).
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -26,14 +26,31 @@ Creates an object that can be supplied as `HiddenMeetingTemplate` to [New-CsTeam
 ## EXAMPLES
 
 ```powershell
-PS C:\test> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
+PS> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
 ```
 
 For more examples on how this can be used, please check the examples at [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
 
-## INPUTS
+## PARAMETERS
 
-## OUTPUTS
+### -Id
+
+ID of the meeting template to hide.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamsHiddenMeetingTemplate.md
@@ -11,18 +11,31 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
+This cmdlet is used to create a `HiddenMeetingTemplate` object for use with the [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md) and [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md) cmdlets.
+
 ## SYNTAX
+
+```powershell
+New-CsTeamsHiddenMeetingTemplate -Id <string>  [<CommonParameters>]
+```
 
 ## DESCRIPTION
 
+Creates an object that can be supplied as `HiddenMeetingTemplate` to [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md) and [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md) cmdlets.
+
 ## EXAMPLES
+
+```powershell
+PS C:\test> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
+```
+
+For more examples on how this can be used, please check the examples at [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
 
 ## INPUTS
 
-### None
-
 ## OUTPUTS
 
-### None
-
-## NOTES
+## RELATED LINKS
+[Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+[New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -15,15 +15,15 @@ Creates a new instance of the TeamsMeetingTemplatePermissionPolicy.
 ## SYNTAX
 
 ```powershell
-    New-CsTeamsMeetingTemplatePermissionPolicy [-Identity] <string> [-HiddenMeetingTemplates
-    <PSListModifier[HiddenMeetingTemplate]>] [-Description <string>] [-Force] [-WhatIf] [-Confirm]
-    [<CommonParameters>]
+    New-CsTeamsMeetingTemplatePermissionPolicy [-Identity] <string> [-HiddenMeetingTemplates<PSListModifier[HiddenMeetingTemplate]>] [-Description <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 Creates a new instance of the policy with a name and a list of hidden meeting template IDs. The templates IDs passed in to the `HiddenMeetingTemplates` object must be valid existing template IDs. The current custom and first party templates on a tenant can be fetched by [Get-CsTeamsMeetingTemplateConfiguration](Get-CsTeamsMeetingTemplateConfiguration.md) and [Get-CsTeamsFirstPartyMeetingTemplateConfiguration](Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md) respectively.
 
 ## EXAMPLES
+
+### Example 1
 
 Assuming there are two valid templates with IDs `firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748` and `customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056`, we will first create the `HiddenMeetingTemplate` objects
 

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,0 +1,49 @@
+# New-CsTeamsMeetingTemplatePermissionPolicy
+
+## SYNOPSIS
+Creates a new instance of the TeamsMeetingTemplatePermissionPolicy.
+
+## SYNTAX
+
+```powershell
+    New-CsTeamsMeetingTemplatePermissionPolicy [-Identity] <string> [-HiddenMeetingTemplates
+    <PSListModifier[HiddenMeetingTemplate]>] [-Description <string>] [-Force] [-WhatIf] [-Confirm]
+    [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a new instance of the policy with a name and a list of hidden meeting template IDs. The templates IDs passed in to the `HiddenMeetingTemplates` object must be valid existing template IDs. The current custom and first party templates on a tenant can be fetched by [Get-CsTeamsMeetingTemplateConfiguration](Get-CsTeamsMeetingTemplateConfiguration.md) and [Get-CsTeamsFirstPartyMeetingTemplateConfiguration](Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md) respectively.
+
+## EXAMPLES
+
+Assuming there are two valid templates with IDs `firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748` and `customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056`, we will first create the `HiddenMeetingTemplate` objects
+
+```powershell
+PS C:\test> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
+PS C:\test> $hiddentemplate_2 = New-CsTeamsHiddenMeetingTemplate -Id firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
+```
+
+The next step would be to create the policy instance
+
+```powershell
+PS C:\test> New-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy -HiddenMeetingTemplates @($hiddentemplate_1, $hiddentemplate_2) -Description "This is a test policy"
+
+Identity               : Tag:Test_Policy
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056, firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748}
+Description            : This is a test policy
+```
+
+## INPUTS
+
+The property `HiddenMeetingTemplates` is an array of type 
+
+## OUTPUTS
+
+The created policy object.
+
+## RELATED LINKS
+[New-CsTeamsHiddenMeetingTemplate](New-CsTeamsHiddenMeetingTemplate.md)
+[Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -32,7 +32,7 @@ PS> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0
 PS> $hiddentemplate_2 = New-CsTeamsHiddenMeetingTemplate -Id firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
 ```
 
-The next step would be to create the policy instance
+The next step would be to create the policy instance.
 
 ```powershell
 PS> New-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy -HiddenMeetingTemplates @($hiddentemplate_1, $hiddentemplate_2) -Description "This is a test policy"

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -28,27 +28,73 @@ Creates a new instance of the policy with a name and a list of hidden meeting te
 Assuming there are two valid templates with IDs `firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748` and `customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056`, we will first create the `HiddenMeetingTemplate` objects
 
 ```powershell
-PS C:\test> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
-PS C:\test> $hiddentemplate_2 = New-CsTeamsHiddenMeetingTemplate -Id firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
+PS> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056
+PS> $hiddentemplate_2 = New-CsTeamsHiddenMeetingTemplate -Id firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748
 ```
 
 The next step would be to create the policy instance
 
 ```powershell
-PS C:\test> New-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy -HiddenMeetingTemplates @($hiddentemplate_1, $hiddentemplate_2) -Description "This is a test policy"
+PS> New-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy -HiddenMeetingTemplates @($hiddentemplate_1, $hiddentemplate_2) -Description "This is a test policy"
 
 Identity               : Tag:Test_Policy
 HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056, firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748}
 Description            : This is a test policy
 ```
 
-## INPUTS
+## PARAMETERS
 
-The property `HiddenMeetingTemplates` is an array of type 
+### -Identity
 
-## OUTPUTS
+Name of the new policy instance to be created.
 
-The created policy object.
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HiddenMeetingTemplates
+
+The list of meeting template IDs to hide.
+The HiddenMeetingTemplate objects are created with [New-CsTeamsHiddenMeetingTemplate](New-CsTeamsHiddenMeetingTemplate.md).
+
+```yaml
+Type: HiddenMeetingTemplate[]
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Description of the new policy instance to be created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## RELATED LINKS
 [New-CsTeamsHiddenMeetingTemplate](New-CsTeamsHiddenMeetingTemplate.md)

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -25,7 +25,7 @@ Creates a new instance of the policy with a name and a list of hidden meeting te
 
 ### Example 1
 
-Assuming there are two valid templates with IDs `firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748` and `customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056`, we will first create the `HiddenMeetingTemplate` objects
+Assuming there are two valid templates with IDs `firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748` and `customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056`, we will first create the `HiddenMeetingTemplate` objects.
 
 ```powershell
 PS> $hiddentemplate_1 = New-CsTeamsHiddenMeetingTemplate -Id customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: New-CsTeamsMeetingTemplatePermissionPolicy
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/New-CsTeamsMeetingTemplatePermissionPolicy
+schema: 2.0.0
+---
+
 # New-CsTeamsMeetingTemplatePermissionPolicy
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -98,7 +98,11 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 [New-CsTeamsHiddenMeetingTemplate](New-CsTeamsHiddenMeetingTemplate.md)
+
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -19,7 +19,7 @@ Creates a new instance of the TeamsMeetingTemplatePermissionPolicy.
 ```
 
 ## DESCRIPTION
-Creates a new instance of the policy with a name and a list of hidden meeting template IDs. The templates IDs passed in to the `HiddenMeetingTemplates` object must be valid existing template IDs. The current custom and first party templates on a tenant can be fetched by [Get-CsTeamsMeetingTemplateConfiguration](Get-CsTeamsMeetingTemplateConfiguration.md) and [Get-CsTeamsFirstPartyMeetingTemplateConfiguration](Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md) respectively.
+Creates a new instance of the policy with a name and a list of hidden meeting template IDs. The template IDs passed into the `HiddenMeetingTemplates` object must be valid existing template IDs. The current custom and first-party templates on a tenant can be fetched by [Get-CsTeamsMeetingTemplateConfiguration](Get-CsTeamsMeetingTemplateConfiguration.md) and [Get-CsTeamsFirstPartyMeetingTemplateConfiguration](Get-CsTeamsFirstPartyMeetingTemplateConfiguration.md) respectively.
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -22,25 +22,14 @@ Remove-CsTeamsMeetingTemplatePermissionPolicy [-Identity] <string> [-Force] [-Wh
 Deletes an instance of TeamsMeetingTemplatePermissionPolicy. The `Identity` parameter accepts the identity of the policy instance to delete.
 
 ## EXAMPLES
-We'll first find a policy to delete, delete the policy and then confirm that it has been deleted by trying to fetch it again.
+
+### Example 1
 
 ```powershell
-PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
-
-Identity               : Tag:Test_Policy
-HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056, firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748}
-Description            : This is a test policy
-
 PS> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
-PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
-
-Get-CsTeamsMeetingTemplatePermissionPolicy : "Test_Policy" not found Please check your request parameters. CorrelationId: c2738e06-0171-4da2-a0ae-e7e99b7c70e3
-At line:1 char:1
-+ Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
-+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    + CategoryInfo          : NotSpecified: (:) [Get-CsTeamsMeet...ermissionPolicy], PolicyRpException
-    + FullyQualifiedErrorId : ClientError,Microsoft.Teams.Policy.Administration.Cmdlets.Core.GetTeamsMeetingTemplatePermissionPolicyCmdlet
 ```
+
+Delete a policy instance with the Identity *Test_Policy*.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -29,7 +29,7 @@ Deletes an instance of TeamsMeetingTemplatePermissionPolicy. The `Identity` para
 PS> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
 ```
 
-Delete a policy instance with the Identity *Test_Policy*.
+Deletes a policy instance with the Identity *Test_Policy*.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: Remove-CsTeamsMeetingTemplatePermissionPolicy
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy
+schema: 2.0.0
+---
+
 # Remove-CsTeamsMeetingTemplatePermissionPolicy
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -83,6 +83,9 @@ At line:1 char:1
 
 ## RELATED LINKS
 [Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -10,7 +10,7 @@ schema: 2.0.0
 # Remove-CsTeamsMeetingTemplatePermissionPolicy
 
 ## SYNOPSIS
-Deletes an instance of TeamsMeetingTemplatePermissionPolicy
+Deletes an instance of TeamsMeetingTemplatePermissionPolicy.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -54,7 +54,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Attempting to delete a policy instance that is currently assigned to users will result in an error. Please remove the assignment before attempting to delete it.
+Attempting to delete a policy instance that is currently assigned to users will result in an error. Remove the assignment before attempting to delete it.
 
 ```powershell
 PS> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,0 +1,62 @@
+# Remove-CsTeamsMeetingTemplatePermissionPolicy
+
+## SYNOPSIS
+Deletes an instance of TeamsMeetingTemplatePermissionPolicy
+
+## SYNTAX
+
+```powershell
+Remove-CsTeamsMeetingTemplatePermissionPolicy [-Identity] <string> [-Force] [-WhatIf] [-Confirm]  [<CommonParameters>]
+```
+
+## DESCRIPTION
+Deletes an instance of TeamsMeetingTemplatePermissionPolicy. The `Identity` parameter accepts the identity of the policy instance to delete.
+
+## EXAMPLES
+We'll first find a policy to delete, delete the policy and then confirm that it has been deleted by trying to fetch it again.
+
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
+
+Identity               : Tag:Test_Policy
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056, firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748}
+Description            : This is a test policy
+
+PS C:\test> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
+
+Get-CsTeamsMeetingTemplatePermissionPolicy : "Test_Policy" not found Please check your request parameters. CorrelationId: c2738e06-0171-4da2-a0ae-e7e99b7c70e3
+At line:1 char:1
++ Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:) [Get-CsTeamsMeet...ermissionPolicy], PolicyRpException
+    + FullyQualifiedErrorId : ClientError,Microsoft.Teams.Policy.Administration.Cmdlets.Core.GetTeamsMeetingTemplatePermissionPolicyCmdlet
+```
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+Attempting to delete a policy instance that is currently assigned to users will result in an error. Please remove the assignment before attempting to delete it.
+
+```powershell
+PS C:\test> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+```
+
+```output
+Remove-CsTeamsMeetingTemplatePermissionPolicy : The policy "Foobar" is currently assigned to one or more users. Assign a different policy to the users before removing
+this one. Please refer to documentation. CorrelationId: 8698472b-f441-423b-8ee3-0469c7e07528
+At line:1 char:1
++ Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:) [Remove-CsTeamsM...ermissionPolicy], PolicyRpException
+    + FullyQualifiedErrorId : ClientError,Microsoft.Teams.Policy.Administration.Cmdlets.Core.RemoveTeamsMeetingTemplatePermissionPolicyCmdlet
+```
+
+## RELATED LINKS
+[Set-CsTeamsMeetingTemplatePermissionPolicy](Set-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+[New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -25,14 +25,14 @@ Deletes an instance of TeamsMeetingTemplatePermissionPolicy. The `Identity` para
 We'll first find a policy to delete, delete the policy and then confirm that it has been deleted by trying to fetch it again.
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
 
 Identity               : Tag:Test_Policy
 HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056, firstparty_e514e598-fba6-4e1f-b8b3-138dd3bca748}
 Description            : This is a test policy
 
-PS C:\test> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
+PS> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Test_Policy
 
 Get-CsTeamsMeetingTemplatePermissionPolicy : "Test_Policy" not found Please check your request parameters. CorrelationId: c2738e06-0171-4da2-a0ae-e7e99b7c70e3
 At line:1 char:1
@@ -42,16 +42,33 @@ At line:1 char:1
     + FullyQualifiedErrorId : ClientError,Microsoft.Teams.Policy.Administration.Cmdlets.Core.GetTeamsMeetingTemplatePermissionPolicyCmdlet
 ```
 
-## INPUTS
+## PARAMETERS
 
-## OUTPUTS
+### -Identity
+
+Identity of the policy instance to be deleted.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## NOTES
 
 Attempting to delete a policy instance that is currently assigned to users will result in an error. Please remove the assignment before attempting to delete it.
 
 ```powershell
-PS C:\test> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+PS> Remove-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
 ```
 
 ```output

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -11,18 +11,58 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
+This cmdlet updates an existing TeamsMeetingTemplatePermissionPolicy.
+
 ## SYNTAX
+
+```powershell
+    Set-CsTeamsMeetingTemplatePermissionPolicy 
+        [-Identity] <string> 
+        [-HiddenMeetingTemplates <PSListModifier[HiddenMeetingTemplate]>] 
+        [-Description <string>] [-Force]
+        [-WhatIf]
+        [-Confirm]
+        [<CommonParameters>]
+```
 
 ## DESCRIPTION
 
+Update any of the properties of an existing instance of the TeamsMeetingTemplatePermissionPolicy.
+
 ## EXAMPLES
 
-## INPUTS
+The below snippets illustrates a typical update operation where we fetch an existing policy instance and then update one of its properties and then fetch it again to confirm that the update was applied.
 
-### None
+Lets update a policy instance with Identity=Foobar:
 
-## OUTPUTS
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+```
+```output
+Identity               : Tag:Foobar
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            :
+```
 
-### None
+Nows lets try to update its description:
 
-## NOTES
+```powershell
+PS C:\test> Set-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar -Description "updated description"
+```
+
+Fetch it again to confirm that the update was saved:
+
+```powershell
+PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+```
+```output
+Identity               : Tag:Foobar
+HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
+Description            : updated description
+```
+
+## RELATED LINKS
+[Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+[New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)
+[Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,3 +1,12 @@
+---
+Module Name: MicrosoftTeams
+title: Set-CsTeamsMeetingTemplatePermissionPolicy
+author: boboPD
+ms.author: pradas
+online version: https://learn.microsoft.com/powershell/module/teams/Set-CsTeamsMeetingTemplatePermissionPolicy
+schema: 2.0.0
+---
+
 # Set-CsTeamsMeetingTemplatePermissionPolicy
 
 ## SYNOPSIS

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -1,0 +1,19 @@
+# Set-CsTeamsMeetingTemplatePermissionPolicy
+
+## SYNOPSIS
+
+## SYNTAX
+
+## DESCRIPTION
+
+## EXAMPLES
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -36,7 +36,7 @@ The below snippets illustrates a typical update operation where we fetch an exis
 Lets update a policy instance with Identity=Foobar:
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
 ```
 ```output
 Identity               : Tag:Foobar
@@ -47,19 +47,73 @@ Description            :
 Nows lets try to update its description:
 
 ```powershell
-PS C:\test> Set-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar -Description "updated description"
+PS> Set-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar -Description "updated description"
 ```
 
 Fetch it again to confirm that the update was saved:
 
 ```powershell
-PS C:\test> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
 ```
 ```output
 Identity               : Tag:Foobar
 HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
 Description            : updated description
 ```
+
+## PARAMETERS
+
+### -Identity
+
+Name of the policy instance to be updated.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HiddenMeetingTemplates
+
+The updated list of meeting template IDs to hide.
+The HiddenMeetingTemplate objects are created with [New-CsTeamsHiddenMeetingTemplate](New-CsTeamsHiddenMeetingTemplate.md).
+
+```yaml
+Type: HiddenMeetingTemplate[]
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+Pass in a new description if that field needs to be updated.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -31,35 +31,21 @@ Update any of the properties of an existing instance of the TeamsMeetingTemplate
 
 ## EXAMPLES
 
-The below snippets illustrates a typical update operation where we fetch an existing policy instance and then update one of its properties and then fetch it again to confirm that the update was applied.
-
-Lets update a policy instance with Identity=Foobar:
-
-```powershell
-PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
-```
-```output
-Identity               : Tag:Foobar
-HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
-Description            :
-```
-
-Nows lets try to update its description:
+### Example 1
 
 ```powershell
 PS> Set-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar -Description "updated description"
 ```
 
-Fetch it again to confirm that the update was saved:
+Updates the description field of a policy.
+
+### Example 2
 
 ```powershell
-PS> Get-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar
+PS> Set-CsTeamsMeetingTemplatePermissionPolicy -Identity Foobar -HiddenMeetingTemplates @($hiddentemplate_1, $hiddentemplate_2)
 ```
-```output
-Identity               : Tag:Foobar
-HiddenMeetingTemplates : {customtemplate_9ab0014a-bba4-4ad6-b816-0b42104b5056}
-Description            : updated description
-```
+
+Updates the hidden meeting templates array.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingTemplatePermissionPolicy.md
@@ -117,6 +117,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 [Get-CsTeamsMeetingTemplatePermissionPolicy](Get-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [New-CsTeamsMeetingTemplatePermissionPolicy](New-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Remove-CsTeamsMeetingTemplatePermissionPolicy](Remove-CsTeamsMeetingTemplatePermissionPolicy.md)
+
 [Grant-CsTeamsMeetingTemplatePermissionPolicy](Grant-CsTeamsMeetingTemplatePermissionPolicy.md)


### PR DESCRIPTION
We are releasing the cmdlets to manage the TeamsMeetingTemplatePermissionPolicy. As a part of this release, we are adding documentation for the following cmdlets we are releasing:

Get-CsTeamsMeetingTemplatePermissionPolicy
Grant-CsTeamsMeetingTemplatePermissionPolicy
New-CsTeamsMeetingTemplatePermissionPolicy
Remove-CsTeamsMeetingTemplatePermissionPolicy
Set-CsTeamsMeetingTemplatePermissionPolicy

New-CsTeamsHiddenMeetingTemplate

Get-CsTeamsMeetingTemplateConfiguration
Get-CsTeamsFirstPartyMeetingTemplateConfiguration