### PR TITLE
Update Set-MailboxJunkEmailConfiguration.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-MailboxJunkEmailConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxJunkEmailConfiguration.md
@@ -16,8 +16,6 @@ This cmdlet is available in on-premises Exchange and in the cloud-based service.
 
 Use the Set-MailboxJunkEmailConfiguration cmdlet to configure the junk email settings on mailboxes.
 
-You can only use this cmdlet on a mailbox that's been opened in Outlook (in Cached Exchange mode) or Outlook on the web. If the mailbox hasn't been opened, you'll receive the error: "The Junk Email configuration couldn't be set. The user needs to sign in to Outlook Web App before they can modify their Safe Senders and Recipients or Blocked Senders lists." If you want to suppress this error for bulk operations, you can add `-ErrorAction SilentlyContinue` to the end of the command.
-
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://learn.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 
 ## SYNTAX


### PR DESCRIPTION
Removed below old lines which is no more the case.

You can only use this cmdlet on a mailbox that's been opened in Outlook (in Cached Exchange mode) or Outlook on the web. If the mailbox hasn't been opened, you'll receive the error: "The Junk Email configuration couldn't be set. The user needs to sign in to Outlook Web App before they can modify their Safe Senders and Recipients or Blocked Senders lists." If you want to suppress this error for bulk operations, you can add -ErrorAction SilentlyContinue to the end of the command.

