### PR TITLE
Update Search-UnifiedAuditLog.md

### DIFF
--- a/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
+++ b/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
@@ -193,7 +193,9 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectIds
-The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event. For example, for SharePoint operations, the object ID is the URL path to a file, folder, or site. For Azure Active Directory operations, the object ID is the account name or GUID value of the account.
+The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event. For example, for SharePoint operations, the object ID is the URL path to a file, folder, or site. For searching logs in a site you should add a wildcard * in from of the URL of the site. e.g. "https://contoso.sharepoint.com/sites/test/*".
+
+For Azure Active Directory operations, the object ID is the account name or GUID value of the account.
 
 The ObjectId value appears in the AuditData (also known as Details) property of the event.
 

--- a/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
+++ b/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
@@ -193,7 +193,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectIds
-The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event. For example, for SharePoint operations, the object ID is the URL path to a file, folder, or site. For searching logs in a site you should add a wildcard * in from of the URL of the site. e.g. "https://contoso.sharepoint.com/sites/test/*".
+The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event. For example, for SharePoint operations, the object ID is the URL path to a file, folder, or site. For searching logs in a site you should add a wildcard (*) in from of the URL of the site, for example, "https://contoso.sharepoint.com/sites/test/*".
 
 For Azure Active Directory operations, the object ID is the account name or GUID value of the account.
 

--- a/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
+++ b/exchange/exchange-ps/exchange/Search-UnifiedAuditLog.md
@@ -193,7 +193,9 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectIds
-The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event. For example, for SharePoint operations, the object ID is the URL path to a file, folder, or site. For searching logs in a site you should add a wildcard (*) in from of the URL of the site, for example, "https://contoso.sharepoint.com/sites/test/*".
+The ObjectIds parameter filters the log entries by object ID. The object ID is the target object that was acted upon, and depends on the RecordType and Operations values of the event.
+
+For example, for SharePoint operations, the object ID is the URL path to a file, folder, or site. To search logs in a site, add a wildcard (\*) in front of the site URL (for example, `"https://contoso.sharepoint.com/sites/test/*"`).
 
 For Azure Active Directory operations, the object ID is the account name or GUID value of the account.
 


### PR DESCRIPTION
We need to clarify customers that a wildcard * is required as we are having a few cases where customer complain they don't get any logs, the solution is to use the wildcard in front of the site URL