### PR TITLE
Update Set-OwaMailboxPolicy.md for PersonalAccountsEnabled

### DIFF
--- a/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
@@ -1669,7 +1669,10 @@ Accept wildcard characters: False
 ### -PersonalAccountsEnabled
 This parameter is available only in the cloud-based service.
 
-{{ Fill PersonalAccountsEnabled Description }}
+The PersonalAccountsEnabled parameter specifies whether to allow users to add their personal accounts (for example, Outlook.com, Gmail, or Yahoo) in the new Outlook for Windows. Valid values are:
+
+- $true: Users can add their personal accounts in the new Outlook for Windows. This is the default value.
+- $false: Users can't add their personal accounts in the new Outlook for Windows.
 
 ```yaml
 Type: System.Boolean

--- a/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
@@ -1669,7 +1669,7 @@ Accept wildcard characters: False
 ### -PersonalAccountsEnabled
 This parameter is available only in the cloud-based service.
 
-The PersonalAccountsEnabled parameter specifies whether to allow users to add their personal accounts (for example, Outlook.com, Gmail, or Yahoo) in the new Outlook for Windows. Valid values are:
+The PersonalAccountsEnabled parameter specifies whether to allow users to add their personal accounts (for example, Outlook.com, Gmail, or Yahoo!) in the new Outlook for Windows. Valid values are:
 
 - $true: Users can add their personal accounts in the new Outlook for Windows. This is the default value.
 - $false: Users can't add their personal accounts in the new Outlook for Windows.


### PR DESCRIPTION
Add description for PersonalAccountsEnabled parameter, now available to manage adding of personal accounts for the new Outlook for Windows.