### PR TITLE
Update Teams Events Policy to include the AllowEmailEditing policy

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsEventsPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsEventsPolicy.md
@@ -14,7 +14,7 @@ This cmdlet allows you to create a new TeamsEventsPolicy instance and set its pr
 ## SYNTAX
 
 ```
-New-CsTeamsEventsPolicy [-Identity] <String> [-AllowWebinars <String>] [-AllowTownhalls <String>] [-Description <String>]
+New-CsTeamsEventsPolicy [-Identity] <String> [-AllowWebinars <String>] [-AllowTownhalls <String>] [-AllowEmailEditing <String>] [-Description <String>]
  [-EventAccessType <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 

--- a/teams/teams-ps/teams/New-CsTeamsEventsPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsEventsPolicy.md
@@ -79,6 +79,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -AllowEmailEditing
+This setting governs if a user is allowed to edit the communication emails in Teams Town hall or Webinar Events. 
+Possible values are:
+ - **Enabled**: Enables editing of communication emails.
+ - **Disabled**: Disables editing of communication emails.
+
+
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: Enabled
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -EventAccessType
 This setting governs which users can access the event registration page or the event site to register. It also governs which user type is allowed to join the session/s in the event. 
 Possible values are:

--- a/teams/teams-ps/teams/New-CsTeamsEventsPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsEventsPolicy.md
@@ -80,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowEmailEditing
-This setting governs if a user is allowed to edit the communication emails in Teams Town hall or Webinar Events. 
+This setting governs if a user is allowed to edit the communication emails in Teams Town Hall or Teams Webinar events. 
 Possible values are:
  - **Enabled**: Enables editing of communication emails.
  - **Disabled**: Disables editing of communication emails.

--- a/teams/teams-ps/teams/Set-CsTeamsEventsPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsEventsPolicy.md
@@ -13,7 +13,7 @@ This cmdlet allows you to configure options for customizing Teams events experie
 ## SYNTAX
 
 ```
-Set-CsTeamsEventsPolicy [-AllowWebinars <String>] [-AllowTownhalls <String>] [-Description <String>] [-EventAccessType <String>]
+Set-CsTeamsEventsPolicy [-AllowWebinars <String>] [-AllowTownhalls <String>] [-AllowEmailEditing <String>] [-Description <String>] [-EventAccessType <String>]
  [[-Identity] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -86,6 +86,56 @@ This setting governs if a user can create town halls using Teams Events.
 Possible values are:
  - **Enabled**: Enables creating town halls.
  - **Disabled**: Disables creating town halls.
+
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+The Confirm switch does not work with this cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Enables administrators to provide explanatory text to accompany a Teams Events policy.
+
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowEmailEditing
+This setting governs if a user is allowed to edit the communication emails in Teams Town hall or Webinar Events.
+Possible values are:
+ - **Enabled**: Enables editing of communication emails.
+ - **Disabled**: Disables editing of communication emails.
 
 
 ```yaml

--- a/teams/teams-ps/teams/Set-CsTeamsEventsPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsEventsPolicy.md
@@ -132,7 +132,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowEmailEditing
-This setting governs if a user is allowed to edit the communication emails in Teams Town hall or Webinar Events.
+This setting governs if a user is allowed to edit the communication emails in Teams Town Hall or Teams Webinar events.
 Possible values are:
  - **Enabled**: Enables editing of communication emails.
  - **Disabled**: Disables editing of communication emails.


### PR DESCRIPTION
Updated Teams Events Policy to include the AllowEmailEditing policy as well.