### PR TITLE
Update formatting of New-CsTeamsComplianceRecordingPolicy.md

### DIFF
--- a/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPolicy.md
+++ b/skype/skype-ps/skype/New-CsTeamsComplianceRecordingPolicy.md
@@ -20,7 +20,7 @@ Automatic policy-based recording is only applicable to Microsoft Teams users.
 
 ```
 New-CsTeamsComplianceRecordingPolicy [-Tenant <System.Guid>] [-Identity <XdsIdentity>]
- [-Enabled <Boolean>] [-WarnUserOnRemoval <Boolean>] [-DisableComplianceRecordingAudioNotificationForCalls <Boolean>] 
+ [-Enabled <Boolean>] [-WarnUserOnRemoval <Boolean>] [-DisableComplianceRecordingAudioNotificationForCalls <Boolean>]
  [-RecordReroutedCalls <Boolean>] [-Description <String>]
  [-ComplianceRecordingApplications <ComplianceRecordingApplication[]>]
  [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]


### PR DESCRIPTION
Because of the additional whitespace, formatting is broken for one of the parameters:
![image](https://github.com/robdy/office-docs-powershell/assets/15113729/0105c9d6-861c-443f-9e84-4d4194d2e541)

I fixed it by removing the space