### PR TITLE
Update Set-MailboxMessageConfiguration.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
@@ -72,9 +72,13 @@ Set-MailboxMessageConfiguration [-Identity] <MailboxIdParameter>
  [-ShowReadingPaneOnFirstLoad <Boolean>]
  [-ShowSenderOnTopInListView <Boolean>]
  [-ShowUpNext <Boolean>]
+
+Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
  [-SignatureHtml <String>]
  [-SignatureText <String>]
  [-SignatureTextOnMobile <String>]
+Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
+
  [-SigningCertificateId <String>]
  [-SigningCertificateSubject <String>]
  [-SmimeEncrypt <Boolean>]
@@ -1122,6 +1126,8 @@ Accept wildcard characters: False
 ### -SignatureHtml
 **Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your organization. Currently, the only way to make this parameter work again is to open a support ticket and ask to have Outlook roaming signatures disabled in your organization.
 
+Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
+
 The SignatureHtml parameter specifies the email signature that's available to the user in HTML-formatted messages in Outlook on the web. You can use plain text or text with HTML tags. However, any JavaScript code is removed.
 
 To automatically add this email signature to HTML-formatted messages created by the user in Outlook on the web, the AutoAddSignature parameter must be set to $true.
@@ -1142,6 +1148,8 @@ Accept wildcard characters: False
 ### -SignatureText
 The SignatureText parameter specifies the email signature that's available to the user in plain text messages in Outlook on the web. This parameter supports all Unicode characters.
 
+Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
+
 To automatically add the email signature to plain text messages created by the user in Outlook on the web, the AutoAddSignature parameter must be set to the value $true.
 
 ```yaml
@@ -1159,6 +1167,8 @@ Accept wildcard characters: False
 
 ### -SignatureTextOnMobile
 The SignatureTextOnMobile parameter specifies the email signature that's available in messages created by the user in Outlook on the web for devices. This parameter supports all Unicode characters.
+
+Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
 
 To automatically add the email signature to messages created by the user in Outlook on the web for devices, the AutoAddSignatureOnMobile parameter must be set to the value $true.
 

--- a/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
@@ -194,6 +194,8 @@ Accept wildcard characters: False
 ```
 
 ### -AutoAddSignature
+**Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your could-based organization. Admins can now temporarily disable roaming signatures without opening a support ticket by using the PostponeRoamingSignaturesUntilLater parameter on the Set-OrganizationConfig cmdlet.
+
 The AutoAddSignature parameter specifies whether to automatically add signatures to new email messages created in Outlook on the web. Valid values are:
 
 - $true: Email signatures are automatically added to new messages.
@@ -215,6 +217,8 @@ Accept wildcard characters: False
 ```
 
 ### -AutoAddSignatureOnMobile
+**Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your could-based organization. Admins can now temporarily disable roaming signatures without opening a support ticket by using the PostponeRoamingSignaturesUntilLater parameter on the Set-OrganizationConfig cmdlet.
+
 The AutoAddSignatureOnMobile parameter automatically adds the signature specified by the SignatureTextOnMobile parameter to messages when the user creates messages in Outlook on the web for devices.
 
 Valid input for this parameter is $true or $false. The default value is $false.

--- a/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
@@ -72,13 +72,9 @@ Set-MailboxMessageConfiguration [-Identity] <MailboxIdParameter>
  [-ShowReadingPaneOnFirstLoad <Boolean>]
  [-ShowSenderOnTopInListView <Boolean>]
  [-ShowUpNext <Boolean>]
-
-Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
  [-SignatureHtml <String>]
  [-SignatureText <String>]
  [-SignatureTextOnMobile <String>]
-Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
-
  [-SigningCertificateId <String>]
  [-SigningCertificateSubject <String>]
  [-SmimeEncrypt <Boolean>]

--- a/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
@@ -1120,9 +1120,7 @@ Accept wildcard characters: False
 ```
 
 ### -SignatureHtml
-**Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your organization. Currently, the only way to make this parameter work again is to open a support ticket and ask to have Outlook roaming signatures disabled in your organization.
-
-Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
+**Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your could-based organization. Admins can now temporarily disable roaming signatures without opening a support ticket by using the PostponeRoamingSignaturesUntilLater parameter on the Set-OrganizationConfig cmdlet.
 
 The SignatureHtml parameter specifies the email signature that's available to the user in HTML-formatted messages in Outlook on the web. You can use plain text or text with HTML tags. However, any JavaScript code is removed.
 
@@ -1142,9 +1140,9 @@ Accept wildcard characters: False
 ```
 
 ### -SignatureText
-The SignatureText parameter specifies the email signature that's available to the user in plain text messages in Outlook on the web. This parameter supports all Unicode characters.
+**Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your could-based organization. Admins can now temporarily disable roaming signatures without opening a support ticket by using the PostponeRoamingSignaturesUntilLater parameter on the Set-OrganizationConfig cmdlet.
 
-Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
+The SignatureText parameter specifies the email signature that's available to the user in plain text messages in Outlook on the web. This parameter supports all Unicode characters.
 
 To automatically add the email signature to plain text messages created by the user in Outlook on the web, the AutoAddSignature parameter must be set to the value $true.
 
@@ -1162,9 +1160,9 @@ Accept wildcard characters: False
 ```
 
 ### -SignatureTextOnMobile
-The SignatureTextOnMobile parameter specifies the email signature that's available in messages created by the user in Outlook on the web for devices. This parameter supports all Unicode characters.
+**Note**: This parameter doesn't work if the Outlook roaming signatures feature is enabled in your could-based organization. Admins can now temporarily disable roaming signatures without opening a support ticket by using the PostponeRoamingSignaturesUntilLater parameter on the Set-OrganizationConfig cmdlet.
 
-Only avaiable for exchange on prem users who don't have any signature, depreciated for Office 365
+The SignatureTextOnMobile parameter specifies the email signature that's available in messages created by the user in Outlook on the web for devices. This parameter supports all Unicode characters.
 
 To automatically add the email signature to messages created by the user in Outlook on the web for devices, the AutoAddSignatureOnMobile parameter must be set to the value $true.
 


### PR DESCRIPTION
As per a case with MS TrackingID#2308240030000032, below switch doesn't work now and they are deprecated for Office 365. If they are deprecated, they should be removed from the article or should mention it only works for users with no signature and will only work for On prem exchange servers
 [-SignatureHtml <String>]
   [-SignatureText <String>]
   [-SignatureTextOnMobile <String>]