### PR TITLE
Update Set-UnifiedGroup.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
+++ b/exchange/exchange-ps/exchange/Set-UnifiedGroup.md
@@ -643,6 +643,8 @@ Valid syntax for this parameter is `"Type:EmailAddress1","Type:EmailAddress2",..
 - X500: X.500 addresses in on-premises Exchange.
 
 If you don't include a Type value for an email address, the value smtp is assumed. Note that Exchange doesn't validate the syntax of custom address types (including X.400 addresses). Therefore, you need to verify that any custom addresses are formatted correctly.
+> [!NOTE]
+> When using ExchangeOnline powershell module, the Type value is NOT optional.
 
 To specify the primary SMTP email address, you can use any of the following methods:
 


### PR DESCRIPTION
Added a note to inform users that the type value is not optional in the -emailaddresses parameter when using exchangeonline (for clarification, it appears to work via CLI, but is not reflected in the GUI, and gui changes overwrite everything in the GUI unless you use the Type value).

Added a note because I'm not positive on whether this cmdlet is relevant to on premise exchange and perhaps the type value is still truly optional there.