### PR TITLE
Update Set-MailboxCalendarFolder.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-MailboxCalendarFolder.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxCalendarFolder.md
@@ -118,12 +118,9 @@ Accept wildcard characters: False
 ### -DetailLevel
 The DetailLevel parameter specifies the level of calendar detail that's published and available to anonymous users. Valid values are:
 
-- AvailabilityOnly (This is the default value)
+- AvailabilityOnly (default)
 - LimitedDetails
 - FullDetails
-
-**Note** Editor permission should be removed as it doesnt work irrespective if Anonymous is there or not in sharing Policy under Domain parameter.
-It always throws error "The policy doesn't allow anonymous sharing with Editor." . ALso even if we PublishEnabled Parameter is true still we are not allowed to give Editor permission. Reproduced in both Office 365 and Onpremises behavior. 
 
 This parameter is meaningful only when the PublishEnabled parameter value is $true.
 

--- a/exchange/exchange-ps/exchange/Set-MailboxCalendarFolder.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxCalendarFolder.md
@@ -121,7 +121,9 @@ The DetailLevel parameter specifies the level of calendar detail that's publishe
 - AvailabilityOnly (This is the default value)
 - LimitedDetails
 - FullDetails
-- Editor
+
+**Note** Editor permission should be removed as it doesnt work irrespective if Anonymous is there or not in sharing Policy under Domain parameter.
+It always throws error "The policy doesn't allow anonymous sharing with Editor." . ALso even if we PublishEnabled Parameter is true still we are not allowed to give Editor permission. Reproduced in both Office 365 and Onpremises behavior. 
 
 This parameter is meaningful only when the PublishEnabled parameter value is $true.
 


### PR DESCRIPTION
Editor permission should be removed as it doesn't work irrespective if Anonymous is there or not in sharing Policy under Domain parameter. It always throws error "The policy doesn't allow anonymous sharing with Editor." . Aso even if we PublishEnabled Parameter is true still we are not allowed to give Editor permission. Reproduced in both Office 365 and Onpremises behavior. I have reproduced in my test lab. 

Please feel free to remove Note section from the main page I modified..