### PR TITLE
Dial Plan Cmdlets: Removing external access dialing parameters.

### DIFF
--- a/skype/skype-ps/skype/Get-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Get-CsTenantDialPlan.md
@@ -93,6 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
+The ExternalAccessPrefix and OptimizeDeviceDialing parameters have been removed from New-CsTenantDialPlan and Set-CsTenantDialPlan cmdlet since they are no longer used. External access dialing is now handled implicitly using normalization rules of the dial plans.
+The Get-CsTenantDialPlan will still show the external access prefix in the form of a normalization rule of the dial plan.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/Get-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Get-CsTenantDialPlan.md
@@ -31,7 +31,7 @@ Get-CsTenantDialPlan [-Filter <String>] [<CommonParameters>]
 The Get-CsTenantDialPlan cmdlet returns information about one or more tenant dial plans (also known as a location profiles) in an organization.
 Tenant dial plans provide required information to let Enterprise Voice users make telephone calls.
 The Conferencing Attendant application also uses tenant dial plans for dial-in conferencing.
-A tenant dial plan determines such things as which normalization rules are applied, and whether a prefix must be dialed for external calls.
+A tenant dial plan determines such things as which normalization rules are applied.
 
 You can use the Get-CsTenantDialPlan cmdlet to retrieve specific information about the normalization rules of a tenant dial plan.
 

--- a/skype/skype-ps/skype/Grant-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Grant-CsTenantDialPlan.md
@@ -203,6 +203,8 @@ This cmdlet supports the common parameters: `-Debug, -ErrorAction, -ErrorVariabl
 ## OUTPUTS
 
 ## NOTES
+The ExternalAccessPrefix and OptimizeDeviceDialing parameters have been removed from New-CsTenantDialPlan and Set-CsTenantDialPlan cmdlet since they are no longer used. External access dialing is now handled implicitly using normalization rules of the dial plans.
+The Get-CsTenantDialPlan will still show the external access prefix in the form of a normalization rule of the dial plan.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/Grant-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Grant-CsTenantDialPlan.md
@@ -36,7 +36,7 @@ Grant-CsTenantDialPlan [[-Identity] <string>] [[-PolicyName] <string>] [-PassThr
 The Grant-CsTenantDialPlan cmdlet assigns an existing tenant dial plan to a user, a group of users, or sets the Global policy instance.
 Tenant dial plans provide information that is required for Enterprise Voice users to make telephone calls.
 Users who do not have a valid tenant dial plan cannot make calls by using Enterprise Voice.
-A tenant dial plan determines such things as how normalization rules are applied, and whether a prefix must be dialed for external calls.
+A tenant dial plan determines such things as how normalization rules are applied.
 
 You can check whether a user has been granted a per-user tenant dial plan by calling a command in this format: `Get-CsUserPolicyAssignment -Identity "<user name>" -PolicyType TenantDialPlan.`
 

--- a/skype/skype-ps/skype/New-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/New-CsTenantDialPlan.md
@@ -101,26 +101,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ExternalAccessPrefix
-The ExternalAccessPrefix parameter is a number (or set of numbers) that designates the call as external to the organization.
-(For example, to tenant-dial an outside line, first press 9.) This prefix is ignored by the normalization rules, although these rules are applied to the remainder of the number.
-
-The OptimizeDeviceDialing parameter must be set to True for this value to take effect.
-The value of this parameter must be no longer than 4 characters long and can contain only digits, "#" or a "*".
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -NormalizationRules
 The NormalizationRules parameter is a list of normalization rules that are applied to this dial plan.
 Although this list and these rules can be created directly by using this cmdlet, we recommend that you create the normalization rules by the [New-CsVoiceNormalizationRule](New-CsVoiceNormalizationRule.md) cmdlet, which creates the rule and then assign it to the specified tenant dial plan using [Set-CsTenantDialPlan](Set-CsTenantDialPlan.md) cmdlet.

--- a/skype/skype-ps/skype/New-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/New-CsTenantDialPlan.md
@@ -172,6 +172,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
+The ExternalAccessPrefix and OptimizeDeviceDialing parameters have been removed from New-CsTenantDialPlan and Set-CsTenantDialPlan cmdlet since they are no longer used. External access dialing is now handled implicitly using normalization rules of the dial plans.
+The Get-CsTenantDialPlan will still show the external access prefix in the form of a normalization rule of the dial plan.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/New-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/New-CsTenantDialPlan.md
@@ -124,23 +124,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OptimizeDeviceDialing
-Use this parameter to determine the effect of ExternalAccessPrefix parameter.
-If set to True, the ExternalAccessPrefix parameter takes effect.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases: 
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SimpleName
 The SimpleName parameter is a display name for the tenant dial plan.
 This name must be unique among all tenant dial plans.

--- a/skype/skype-ps/skype/Remove-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Remove-CsTenantDialPlan.md
@@ -25,7 +25,7 @@ Remove-CsTenantDialPlan [-Identity] <string> [-WhatIf] [-Confirm] [<CommonParame
 The `Remove-CsTenantDialPlan` cmdlet removes an existing tenant dial plan (also known as a location profile).
 Tenant dial plans provide required information to allow Enterprise Voice users to make telephone calls.
 The Conferencing Attendant application also uses tenant dial plans for dial-in conferencing.
-A tenant dial plan determines such things as which normalization rules are applied and whether a prefix must be dialed for external calls.
+A tenant dial plan determines such things as which normalization rules are applied.
 
 Removing a tenant dial plan also removes any associated normalization rules.
 If no tenant dial plan is assigned to an organization, the Global dial plan is used.

--- a/skype/skype-ps/skype/Remove-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Remove-CsTenantDialPlan.md
@@ -98,6 +98,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
+The ExternalAccessPrefix and OptimizeDeviceDialing parameters have been removed from New-CsTenantDialPlan and Set-CsTenantDialPlan cmdlet since they are no longer used. External access dialing is now handled implicitly using normalization rules of the dial plans.
+The Get-CsTenantDialPlan will still show the external access prefix in the form of a normalization rule of the dial plan.
 
 ## RELATED LINKS
 

--- a/skype/skype-ps/skype/Set-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Set-CsTenantDialPlan.md
@@ -143,23 +143,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OptimizeDeviceDialing
-Use this parameter to determine the effect of ExternalAccessPrefix parameter.
-If set to True, the ExternalAccessPrefix parameter takes effect.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases: 
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SimpleName
 The SimpleName parameter is a display name for the tenant dial plan. This name must be unique among all tenant dial plans.
 

--- a/skype/skype-ps/skype/Set-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Set-CsTenantDialPlan.md
@@ -108,26 +108,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ExternalAccessPrefix
-The ExternalAccessPrefix parameter is a number (or set of numbers) that designates the call as external to the organization.
-(For example, to tenant-dial an outside line, first dial 9). This prefix is ignored by the normalization rules, although these rules will be applied to the rest of the number.
-The OptimizeDeviceDialing parameter must be set to True for this value to take effect.
-
-The value of this parameter must be no longer than 4 characters long and can contain only digits, "#" or a "*".
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
 The Identity parameter is a unique identifier that designates the name of the tenant dial plan to modify.
 

--- a/skype/skype-ps/skype/Set-CsTenantDialPlan.md
+++ b/skype/skype-ps/skype/Set-CsTenantDialPlan.md
@@ -185,6 +185,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
+The ExternalAccessPrefix and OptimizeDeviceDialing parameters have been removed from New-CsTenantDialPlan and Set-CsTenantDialPlan cmdlet since they are no longer used. External access dialing is now handled implicitly using normalization rules of the dial plans.
+The Get-CsTenantDialPlan will still show the external access prefix in the form of a normalization rule of the dial plan.
 
 ## RELATED LINKS
 


### PR DESCRIPTION
Dial Plan Cmdlets no longer use parameters for external access dialing, since external access prefixes are now handled implicitly by normalization rules.
Removing all documentation references to external access dialing and 2 parameters used for the same -
- externalAccessPrefix
- optimizeDeviceDialing