### PR TITLE
[BULK] - DocuTune - Rebranding of Azure Active Directory to Microsoft Entra terminology (part 4)

### DIFF
--- a/skype/skype-ps/skype/New-CsVideoInteropServiceProvider.md
+++ b/skype/skype-ps/skype/New-CsVideoInteropServiceProvider.md
@@ -51,7 +51,7 @@ PS C:\> New-CsVideoInteropServiceProvider
 ## PARAMETERS
 
 ### -AadApplicationIds
-This is an optional parameter. A semicolon separated list of AAD AppIds of the CVI partner bots can be specified in this parameter. This parameter works in conjunction with AllowAppGuestJoinsAsAuthenticated. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of these bots, is shown in the meeting as an authenticated tenant entity.
+This is an optional parameter. A semicolon separated list of Microsoft Entra AppIds of the CVI partner bots can be specified in this parameter. This parameter works in conjunction with AllowAppGuestJoinsAsAuthenticated. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of these bots, is shown in the meeting as an authenticated tenant entity.
 
 ```yaml
 Type: String
@@ -67,7 +67,7 @@ Accept wildcard characters: False
 
 ### -AllowAppGuestJoinsAsAuthenticated
 This is an optional parameter. Default = false.
-This parameter works in conjunction with AadApplicationIds. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of the bots AAD application ids specified in AadApplicationIds, is shown in the meeting as an authenticated tenant entity.
+This parameter works in conjunction with AadApplicationIds. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of the bots Microsoft Entra application ids specified in AadApplicationIds, is shown in the meeting as an authenticated tenant entity.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Search-CsOnlineTelephoneNumberInventory.md
+++ b/skype/skype-ps/skype/Search-CsOnlineTelephoneNumberInventory.md
@@ -243,7 +243,7 @@ None
 ## OUTPUTS
 
 ###  
-This cmdlets returns an Microsoft.Rtc.Management.Hosted.Bvd.Types.NumberReservationResponse object.
+This cmdlets returns a Microsoft.Rtc.Management.Hosted.Bvd.Types.NumberReservationResponse object.
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Select-CsOnlineTelephoneNumberInventory.md
+++ b/skype/skype-ps/skype/Select-CsOnlineTelephoneNumberInventory.md
@@ -229,7 +229,7 @@ None
 ## OUTPUTS
 
 ###  
-This cmdlets returns an Microsoft.Rtc.Management.Hosted.Bvd.Types.NumberReservationResponse object.
+This cmdlets returns a Microsoft.Rtc.Management.Hosted.Bvd.Types.NumberReservationResponse object.
 
 ## NOTES
 

--- a/skype/skype-ps/skype/Set-CsOnlineApplicationInstance.md
+++ b/skype/skype-ps/skype/Set-CsOnlineApplicationInstance.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # Set-CsOnlineApplicationInstance
 
 ## SYNOPSIS
-Updates an application instance in Azure Active Directory. 
+Updates an application instance in Microsoft Entra ID. 
 
 **Note**: The use of this cmdlet for assigning phone numbers in commercial and GCC cloud instances has been deprecated. Use the new [Set-CsPhoneNumberAssignment](/powershell/module/teams/set-csphonenumberassignment) and [Remove-CsPhoneNumberAssignment](/powershell/module/teams/remove-csphonenumberassignment) cmdlets instead.
 
@@ -24,7 +24,7 @@ Set-CsOnlineApplicationInstance [-Identity] <string> [[-OnpremPhoneNumber] <stri
 ```
 
 ## DESCRIPTION
-This cmdlet is used to update an application instance in Azure Active Directory.
+This cmdlet is used to update an application instance in Microsoft Entra ID.
 
 ## EXAMPLES
 

--- a/skype/skype-ps/skype/Set-CsOnlineVoiceApplicationInstance.md
+++ b/skype/skype-ps/skype/Set-CsOnlineVoiceApplicationInstance.md
@@ -13,7 +13,7 @@ ms.author: jenstr
 # Set-CsOnlineVoiceApplicationInstance
 
 ## SYNOPSIS
-The `Set-CsOnlineVoiceApplicationInstance` modifies an application instance in Azure Active Directory.
+The `Set-CsOnlineVoiceApplicationInstance` modifies an application instance in Microsoft Entra ID.
 
 **Note**: This cmdlet has been deprecated. Use the new [Set-CsPhoneNumberAssignment](/powershell/module/teams/set-csphonenumberassignment) and 
 [Remove-CsPhoneNumberAssignment](/powershell/module/teams/remove-csphonenumberassignment) cmdlets instead.
@@ -25,7 +25,7 @@ Set-CsOnlineVoiceApplicationInstance [-WhatIf] [-Confirm] [-TelephoneNumber <Str
 ```
 
 ## DESCRIPTION
-This cmdlet is used to modify an application instance in Azure Active Directory.
+This cmdlet is used to modify an application instance in Microsoft Entra ID.
 
 ## EXAMPLES
 
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-The user principal name (UPN) of the resource account in Azure Active Directory.
+The user principal name (UPN) of the resource account in Microsoft Entra ID.
 
 ```yaml
 Type: Object

--- a/skype/skype-ps/skype/Set-CsTeamsChannelsPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsChannelsPolicy.md
@@ -186,7 +186,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowChannelSharingToExternalUser
-Owners of a shared channel can invite external users to join the channel if Azure AD external sharing policies are configured. If the channel has been shared with an external member or team, they will continue to have access to the channel even if this parameter is set to FALSE. For more information, see [Manage channel policies in Microsoft Teams](/microsoftteams/teams-policies).
+Owners of a shared channel can invite external users to join the channel if Microsoft Entra external sharing policies are configured. If the channel has been shared with an external member or team, they will continue to have access to the channel even if this parameter is set to FALSE. For more information, see [Manage channel policies in Microsoft Teams](/microsoftteams/teams-policies).
 
 ```yaml
 Type: Boolean
@@ -214,7 +214,7 @@ Accept wildcard characters: False
 ```
 
 ### -AllowUserToParticipateInExternalSharedChannel
-Users and teams can be invited to external shared channels if Azure AD external sharing policies are configured. If a team in your organization is part of an external shared channel, new team members will have access to the channel even if this parameter is set to FALSE. For more information, see [Manage channel policies in Microsoft Teams](/microsoftteams/teams-policies).
+Users and teams can be invited to external shared channels if Microsoft Entra external sharing policies are configured. If a team in your organization is part of an external shared channel, new team members will have access to the channel even if this parameter is set to FALSE. For more information, see [Manage channel policies in Microsoft Teams](/microsoftteams/teams-policies).
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Set-CsUser.md
+++ b/skype/skype-ps/skype/Set-CsUser.md
@@ -31,7 +31,7 @@ Set-CsUser [-DomainController <Fqdn>] [-Identity] <UserIdParameter> [-PassThru] 
 ```
 
 ## DESCRIPTION
-The `Set-CsUser` cmdlet enables you to modify the Skype for Business related user account attributes that are stored in Active Directory Domain Services or modify a subset of Skype for Business online user attributes that are stored in Azure Active Directory.
+The `Set-CsUser` cmdlet enables you to modify the Skype for Business related user account attributes that are stored in Active Directory Domain Services or modify a subset of Skype for Business online user attributes that are stored in Microsoft Entra ID.
 For example, you can disable or re-enable a user for Skype for Business Server; enable or disable a user for audio/video (A/V) communications; or modify a user's private line and line URI numbers. For Skype for Business online enable or disable a user for enterprise voice, hosted voicemail, or modify the user's on premise line uri.
 The `Set-CsUser` cmdlet can be used only for users who have been enabled for Skype for Business.
 

--- a/skype/skype-ps/skype/Set-CsVideoInteropServiceProvider.md
+++ b/skype/skype-ps/skype/Set-CsVideoInteropServiceProvider.md
@@ -49,7 +49,7 @@ This example enables a VTC device joining anonymously to shown in the meeting as
 ## PARAMETERS
 
 ### -AadApplicationIds
-This is an optional parameter. A semicolon separated list of AAD AppIds of the CVI partner bots can be specified in this parameter. This parameter works in conjunction with AllowAppGuestJoinsAsAuthenticated. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of these bots, is shown in the meeting as an authenticated tenant entity.
+This is an optional parameter. A semicolon separated list of Microsoft Entra AppIds of the CVI partner bots can be specified in this parameter. This parameter works in conjunction with AllowAppGuestJoinsAsAuthenticated. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of these bots, is shown in the meeting as an authenticated tenant entity.
 
 ```yaml
 Type: String
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 
 ### -AllowAppGuestJoinsAsAuthenticated
 This is an optional parameter. Default = false.
-This parameter works in conjunction with AadApplicationIds. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of the bots AAD application ids specified in AadApplicationIds, is shown in the meeting as an authenticated tenant entity.
+This parameter works in conjunction with AadApplicationIds. When AllowAppGuestJoinsAsAuthenticated is set to true, a VTC device joining anonymously using any of the bots Microsoft Entra application ids specified in AadApplicationIds, is shown in the meeting as an authenticated tenant entity.
 
 ```yaml
 Type: Boolean

--- a/skype/skype-ps/skype/Sync-CsOnlineApplicationInstance.md
+++ b/skype/skype-ps/skype/Sync-CsOnlineApplicationInstance.md
@@ -13,7 +13,7 @@ ms.reviewer:
 # Sync-CsOnlineApplicationInstance
 
 ## SYNOPSIS
-Use the Sync-CsOnlineApplicationInstance cmdlet to sync the application instance from Azure Active Directory into Agent Provisioning Service. This is needed because the mapping between application instance and application needs to be stored in Agent Provisioning Service. If an application ID was provided at the creation of the application instance, you need not run this cmdlet. 
+Use the Sync-CsOnlineApplicationInstance cmdlet to sync the application instance from Microsoft Entra ID into Agent Provisioning Service. This is needed because the mapping between application instance and application needs to be stored in Agent Provisioning Service. If an application ID was provided at the creation of the application instance, you need not run this cmdlet. 
 
 ## SYNTAX
 
@@ -22,7 +22,7 @@ Sync-CsOnlineApplicationInstance -ObjectId <guid> [-CallbackUri <string>] [-Forc
 ```
 
 ## DESCRIPTION
-Use the Sync-CsOnlineApplicationInstance cmdlet to sync application instances from Azure Active Directory into Agent Provisioning Service.
+Use the Sync-CsOnlineApplicationInstance cmdlet to sync application instances from Microsoft Entra ID into Agent Provisioning Service.
 
 ## EXAMPLES
 

--- a/spmt/spmt-ps/spmt/Register-SPMTMigration.md
+++ b/spmt/spmt-ps/spmt/Register-SPMTMigration.md
@@ -49,7 +49,7 @@ This example registers a migration session.
 
 ### -AzureActiveDirectoryLookup
 By default, this is set to On. 
-If no user mapping file is provided by the user, then Azure Active Directory is used as the default for user mapping.
+If no user mapping file is provided by the user, then Microsoft Entra ID is used as the default for user mapping.
 
 ```yaml
 Type: Boolean
@@ -449,8 +449,8 @@ Accept wildcard characters: False
 ```
 
 ### -UserMappingFile
-By default, Azure AD lookup is used to map users when submitting migration jobs.
-If you choose to use a custom user mapping file and you want to preserve user permissions, turn off Azure Active Directory lookup.By doing so, if a user isn't found in the mapping file, the tool won't look it up in AAD.
+By default, Microsoft Entra lookup is used to map users when submitting migration jobs.
+If you choose to use a custom user mapping file and you want to preserve user permissions, turn off Microsoft Entra lookup.By doing so, if a user isn't found in the mapping file, the tool won't look it up in Microsoft Entra ID.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Connect-MicrosoftTeams.md
+++ b/teams/teams-ps/teams/Connect-MicrosoftTeams.md
@@ -202,7 +202,7 @@ Specifies access tokens for "MS Graph" and "Skype and Teams Tenant Admin API" re
 
 - Delegated flow - The following steps must be performed by Tenant Admin in the Azure portal when using your own application. 
 
-   Steps to configure the AAD application. 
+   Steps to configure the Microsoft Entra application. 
    1. Go to Azure portal and go to App Registrations. 
    2. Create or select the existing application.
    3. Add the following permission to this Application. 

--- a/teams/teams-ps/teams/Get-CsUserPolicyAssignment.md
+++ b/teams/teams-ps/teams/Get-CsUserPolicyAssignment.md
@@ -91,7 +91,7 @@ d8ebfa45-0f28-4d2d-9bcc-b158a49e2d17 TeamsMeetingPolicy AllOn      1    10/29/20
 ### -Identity
 The identify of the user whose policy assignments will be returned.
 
-The -Identity parameter can be in the form of the users ObjectID (taken from Azure AD) or in the form of the UPN (a.smith@example.com)
+The -Identity parameter can be in the form of the users ObjectID (taken from Microsoft Entra ID) or in the form of the UPN (a.smith@example.com)
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Get-TeamsApp.md
+++ b/teams/teams-ps/teams/Get-TeamsApp.md
@@ -75,7 +75,7 @@ Accept wildcard characters: False
 ```
 
 ### -ExternalId
-The external ID of the app, provided by the app developer and used by Azure Active Directory
+The external ID of the app, provided by the app developer and used by Microsoft Entra ID
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/New-CsBatchPolicyAssignmentOperation.md
+++ b/teams/teams-ps/teams/New-CsBatchPolicyAssignmentOperation.md
@@ -68,7 +68,7 @@ $users = Get-AzureADUser
 New-CsBatchPolicyAssignmentOperation -PolicyType TeamsMeetingPolicy -PolicyName Kiosk -Identity $users.SipProxyAddress -OperationName "batch assign kiosk"
 ```
 
-In this example, the batch of users is obtained by connecting to Azure AD and retrieving a collection of users and then referencing the SipProxyAddress property.
+In this example, the batch of users is obtained by connecting to Microsoft Entra ID and retrieving a collection of users and then referencing the SipProxyAddress property.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/New-CsTeamTemplate.md
+++ b/teams/teams-ps/teams/New-CsTeamTemplate.md
@@ -199,7 +199,7 @@ Accept wildcard characters: False
 
 ### -Classification
 
-Gets or sets the team's classification.Tenant admins configure AAD with the set of possible values.
+Gets or sets the team's classification.Tenant admins configure Microsoft Entra ID with the set of possible values.
 
 ```yaml
 Type: System.String
@@ -331,7 +331,7 @@ Accept wildcard characters: False
 
 ### -IsMembershipLimitedToOwner
 
-Gets or sets whether to limit the membership of the team to owners in the AAD group until an owner "activates" the team.
+Gets or sets whether to limit the membership of the team to owners in the Microsoft Entra group until an owner "activates" the team.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -395,7 +395,7 @@ Accept wildcard characters: False
 
 ### -OwnerUserObjectId
 
-Gets or sets the AAD user object id of the user who should be set as the owner of the new team.Only to be used when an application or administrative user is making the request on behalf of the specified user.
+Gets or sets the Microsoft Entra user object id of the user who should be set as the owner of the new team.Only to be used when an application or administrative user is making the request on behalf of the specified user.
 
 ```yaml
 Type: System.String
@@ -687,7 +687,7 @@ BODY \<ITeamTemplate\>: The client input for a request to create a template.    
     - `[SortOrderIndex <String>]`: Gets or sets index of the order used for sorting tabs.
     - `[TeamsAppId <String>]`: Gets or sets the app's id in the global apps catalog.
     - `[WebUrl <String>]`: Gets or sets the deep link url of the tab instance.
-- `[Classification <String>]`: Gets or sets the team's classification.         Tenant admins configure AAD with the set of possible values.
+- `[Classification <String>]`: Gets or sets the team's classification.         Tenant admins configure Microsoft Entra ID with the set of possible values.
 - `[Description <String>]`: Gets or sets the team's Description.
 - `[DiscoverySetting <ITeamDiscoverySettings>]`: Governs discoverability of a team.
   - `ShowInTeamsSearchAndSuggestion <Boolean>`: Gets or sets value indicating if team is visible within search and suggestions in Teams clients.
@@ -700,7 +700,7 @@ BODY \<ITeamTemplate\>: The client input for a request to create a template.    
   - `AllowCreateUpdateChannel <Boolean>`: Gets or sets a value indicating whether guests can create or edit channels in the team.
   - `AllowDeleteChannel <Boolean>`: Gets or sets a value indicating whether guests can delete team channels.
 - `[Icon <String>]`: Gets or sets template icon.
-- `[IsMembershipLimitedToOwner <Boolean?>]`: Gets or sets whether to limit the membership of the team to owners in the AAD group until an owner "activates" the team.
+- `[IsMembershipLimitedToOwner <Boolean?>]`: Gets or sets whether to limit the membership of the team to owners in the Microsoft Entra group until an owner "activates" the team.
 - `[MemberSetting <ITeamMemberSettings>]`: Member role settings for the team.
   - `AllowAddRemoveApp <Boolean>`: Gets or sets a value indicating whether members can add or remove apps in the team.
   - `AllowCreatePrivateChannel <Boolean>`: Gets or Sets a value indicating whether members can create Private channels.
@@ -715,7 +715,7 @@ BODY \<ITeamTemplate\>: The client input for a request to create a template.    
   - `AllowTeamMention <Boolean>`: Gets or sets a value indicating whether team members can at-mention the entire team in team conversations.
   - `AllowUserDeleteMessage <Boolean>`: Gets or sets a value indicating whether team members can delete their own messages in team conversations.
   - `AllowUserEditMessage <Boolean>`: Gets or sets a value indicating whether team members can edit their own messages in team conversations.
-- `[OwnerUserObjectId <String>]`: Gets or sets the AAD user object id of the user who should be set as the owner of the new team.         Only to be used when an application or administrative user is making the request on behalf of the specified user.
+- `[OwnerUserObjectId <String>]`: Gets or sets the Microsoft Entra user object id of the user who should be set as the owner of the new team.         Only to be used when an application or administrative user is making the request on behalf of the specified user.
 - `[PublishedBy <String>]`: Gets or sets published name.
 - `[Specialization <String>]`: The specialization or use case describing the team.         Used for telemetry/BI, part of the team context exposed to app developers, and for legacy implementations of differentiated features for education.
 - `[TemplateId <String>]`: Gets or sets the id of the base template for the team.         Either a Microsoft base template or a custom template.

--- a/teams/teams-ps/teams/Set-TeamsEnvironmentConfig.md
+++ b/teams/teams-ps/teams/Set-TeamsEnvironmentConfig.md
@@ -23,7 +23,7 @@ Set-TeamsEnvironmentConfig [-EndpointUris <Hashtable>] [-TeamsEnvironmentName <S
 ```
 
 ## DESCRIPTION
-This cmdlet sets environment-specific configurations like endpoint URIs(such as Azure AD and Microsoft Graph) and Teams environment (such as GCCH and DOD) on the local machine.
+This cmdlet sets environment-specific configurations like endpoint URIs(such as Microsoft Entra ID and Microsoft Graph) and Teams environment (such as GCCH and DOD) on the local machine.
   
 When running Connect-MicrosoftTeams, environment-specific information set in this cmdlet will be considered unless overridden by Connect-MicrosoftTeams parameters.
 

--- a/teams/teams-ps/teams/Update-CsTeamTemplate.md
+++ b/teams/teams-ps/teams/Update-CsTeamTemplate.md
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 
 ### -Classification
 
-Gets or sets the team's classification.Tenant admins configure AAD with the set of possible values.
+Gets or sets the team's classification.Tenant admins configure Microsoft Entra ID with the set of possible values.
 
 ```yaml
 Type: System.String
@@ -328,7 +328,7 @@ Accept wildcard characters: False
 
 ### -IsMembershipLimitedToOwner
 
-Gets or sets whether to limit the membership of the team to owners in the AAD group until an owner "activates" the team.
+Gets or sets whether to limit the membership of the team to owners in the Microsoft Entra group until an owner "activates" the team.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
@@ -394,7 +394,7 @@ Accept wildcard characters: False
 
 ### -OwnerUserObjectId
 
-Gets or sets the AAD user object id of the user who should be set as the owner of the new team.Only to be used when an application or administrative user is making the request on behalf of the specified user.
+Gets or sets the Microsoft Entra user object id of the user who should be set as the owner of the new team.Only to be used when an application or administrative user is making the request on behalf of the specified user.
 
 ```yaml
 Type: System.String
@@ -686,7 +686,7 @@ BODY \<ITeamTemplate\>: The client input for a request to create a template.    
     - `[SortOrderIndex <String>]`: Gets or sets index of the order used for sorting tabs.
     - `[TeamsAppId <String>]`: Gets or sets the app's id in the global apps catalog.
     - `[WebUrl <String>]`: Gets or sets the deep link url of the tab instance.
-- `[Classification <String>]`: Gets or sets the team's classification.         Tenant admins configure AAD with the set of possible values.
+- `[Classification <String>]`: Gets or sets the team's classification.         Tenant admins configure Microsoft Entra ID with the set of possible values.
 - `[Description <String>]`: Gets or sets the team's Description.
 - `[DiscoverySetting <ITeamDiscoverySettings>]`: Governs discoverability of a team.
   - `ShowInTeamsSearchAndSuggestion <Boolean>`: Gets or sets value indicating if team is visible within search and suggestions in Teams clients.
@@ -699,7 +699,7 @@ BODY \<ITeamTemplate\>: The client input for a request to create a template.    
   - `AllowCreateUpdateChannel <Boolean>`: Gets or sets a value indicating whether guests can create or edit channels in the team.
   - `AllowDeleteChannel <Boolean>`: Gets or sets a value indicating whether guests can delete team channels.
 - `[Icon <String>]`: Gets or sets template icon.
-- `[IsMembershipLimitedToOwner <Boolean?>]`: Gets or sets whether to limit the membership of the team to owners in the AAD group until an owner "activates" the team.
+- `[IsMembershipLimitedToOwner <Boolean?>]`: Gets or sets whether to limit the membership of the team to owners in the Microsoft Entra group until an owner "activates" the team.
 - `[MemberSetting <ITeamMemberSettings>]`: Member role settings for the team.
   - `AllowAddRemoveApp <Boolean>`: Gets or sets a value indicating whether members can add or remove apps in the team.
   - `AllowCreatePrivateChannel <Boolean>`: Gets or Sets a value indicating whether members can create Private channels.
@@ -714,7 +714,7 @@ BODY \<ITeamTemplate\>: The client input for a request to create a template.    
   - `AllowTeamMention <Boolean>`: Gets or sets a value indicating whether team members can at-mention the entire team in team conversations.
   - `AllowUserDeleteMessage <Boolean>`: Gets or sets a value indicating whether team members can delete their own messages in team conversations.
   - `AllowUserEditMessage <Boolean>`: Gets or sets a value indicating whether team members can edit their own messages in team conversations.
-- `[OwnerUserObjectId <String>]`: Gets or sets the AAD user object id of the user who should be set as the owner of the new team.         Only to be used when an application or administrative user is making the request on behalf of the specified user.
+- `[OwnerUserObjectId <String>]`: Gets or sets the Microsoft Entra user object id of the user who should be set as the owner of the new team.         Only to be used when an application or administrative user is making the request on behalf of the specified user.
 - `[PublishedBy <String>]`: Gets or sets published name.
 - `[Specialization <String>]`: The specialization or use case describing the team.         Used for telemetry/BI, part of the team context exposed to app developers, and for legacy implementations of differentiated features for education.
 - `[TemplateId <String>]`: Gets or sets the id of the base template for the team.         Either a Microsoft base template or a custom template.

--- a/whiteboard/docs-conceptual/overview.md
+++ b/whiteboard/docs-conceptual/overview.md
@@ -41,7 +41,7 @@ Note: For more information on Execution_Policies, go to <https://go.microsoft.co
 
 ## User IDs
 
-Cmdlets taking user IDs use the ID from Azure Active Directory. To get a user ID, you can use the Microsoft Graph Explorer. For more information, go to <https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/user_get>.
+Cmdlets taking user IDs use the ID from Microsoft Entra ID. To get a user ID, you can use the Microsoft Graph Explorer. For more information, go to <https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/user_get>.
 
 ## Exporting Whiteboard Content
 


### PR DESCRIPTION
Applying Azure AD rebranding changes as announced on July 11, 2023 and outlined in https://aka.ms/AzureADNewName. Changes are part of the Microsoft-wide rebranding effort.

CorrelationId: 2520d58e-25ff-469e-af14-2834d2a1505e
PointOfContact: @CelesteDG

#docutune
