### PR TITLE
Updated Get-CsOnlineLisLocation.md for NumberOfResultsToSkip parameter

### DIFF
--- a/skype/skype-ps/skype/Get-CsOnlineLisLocation.md
+++ b/skype/skype-ps/skype/Get-CsOnlineLisLocation.md
@@ -216,7 +216,7 @@ Accept wildcard characters: False
 
 ### -NumberOfResultsToSkip
 Specifies the number of results to skip.
-If there are a large number of locations, you can limit the number of returns by using the ResultSize parameter.
+If there are a large number of locations, you can limit the number of results by using the ResultSize parameter.
 If you limited the first cmdlet execution to 25 results, and want to look at the next 25 locations, then you leave ResultSize at 25 and set NumberOfResultsToSkip to 25 to omit the first 25 you've reviewed.
 For example the command below will return locations 26-50 for Seattle.
 

--- a/skype/skype-ps/skype/Get-CsOnlineLisLocation.md
+++ b/skype/skype-ps/skype/Get-CsOnlineLisLocation.md
@@ -215,9 +215,6 @@ Accept wildcard characters: False
 ```
 
 ### -NumberOfResultsToSkip
-
-**Note:** This parameter has been deprecated from the Teams PowerShell Module version 3.0.0 or later.
-
 Specifies the number of results to skip.
 If there are a large number of locations, you can limit the number of returns by using the ResultSize parameter.
 If you limited the first cmdlet execution to 25 results, and want to look at the next 25 locations, then you leave ResultSize at 25 and set NumberOfResultsToSkip to 25 to omit the first 25 you've reviewed.


### PR DESCRIPTION
Removed deprecated message for NumberOfResultsToSkip parameter as it is added again.
This change will be available in Teams Powershell Release 5.8.0-GA.