### PR TITLE
Updated Get-CsOnlineLisCivicAddress.md for NumberOfResultsToSkip parameter

### DIFF
--- a/skype/skype-ps/skype/Get-CsOnlineLisCivicAddress.md
+++ b/skype/skype-ps/skype/Get-CsOnlineLisCivicAddress.md
@@ -163,9 +163,6 @@ Accept wildcard characters: False
 ```
 
 ### -NumberOfResultsToSkip
-
-**Note:** This parameter has been deprecated from the Teams PowerShell Module version 3.0.0 or later.
-
 Specifies the number of results to skip.
 If there are a large number of civic addresses, you can limit the number of returns by using the ResultSize parameter.
 If you limited the first cmdlet execution to 25 results, and want to look at the next 25 locations, then you leave ResultSize at 25 and set NumberOfResultsToSkip to 25 to omit the first 25 you've reviewed.

--- a/skype/skype-ps/skype/Get-CsOnlineLisCivicAddress.md
+++ b/skype/skype-ps/skype/Get-CsOnlineLisCivicAddress.md
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 
 ### -NumberOfResultsToSkip
 Specifies the number of results to skip.
-If there are a large number of civic addresses, you can limit the number of returns by using the ResultSize parameter.
+If there are a large number of civic addresses, you can limit the number of results by using the ResultSize parameter.
 If you limited the first cmdlet execution to 25 results, and want to look at the next 25 locations, then you leave ResultSize at 25 and set NumberOfResultsToSkip to 25 to omit the first 25 you've reviewed.
 For example the command below will return civic addresses 26-50 for Seattle.
 


### PR DESCRIPTION
Removed deprecated message for NumberOfResultsToSkip parameter as it is added again. This change will be available in Teams Powershell Module Release 5.8.0-GA.