### PR TITLE
Change Applicable Product list in Get-CalendarDiagnosticLog.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-CalendarDiagnosticLog.md
+++ b/exchange/exchange-ps/exchange/Get-CalendarDiagnosticLog.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Exchange.CalendarsAndGroups-Help.xml
 online version: https://learn.microsoft.com/powershell/module/exchange/get-calendardiagnosticlog
-applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019, Exchange Online
+applicable: Exchange Server 2010, Exchange Server 2013, Exchange Server 2016, Exchange Server 2019
 title: Get-CalendarDiagnosticLog
 schema: 2.0.0
 author: chrisda


### PR DESCRIPTION
Changing the applicable products due to the synopsis: 
`Although this cmdlet is available in on-premises Exchange and in the cloud-based service, it only works in on-premises Exchange. In cloud-based service, use the Get-CalendarDiagnosticObjects cmdlet instead.`