### PR TITLE
Update Set-CsTeamsChannelsPolicy.md

### DIFF
--- a/skype/skype-ps/skype/Set-CsTeamsChannelsPolicy.md
+++ b/skype/skype-ps/skype/Set-CsTeamsChannelsPolicy.md
@@ -29,7 +29,7 @@ Set-CsTeamsChannelsPolicy [-Tenant <Guid>] [-AllowOrgWideTeamCreation <Boolean>]
 ### Instance
 ```
 Set-CsTeamsChannelsPolicy [-Tenant <Guid>] [-AllowOrgWideTeamCreation <Boolean>]
- [-AllowPrivateTeamDiscovery <Boolean>] [-AllowPrivateChannelCreation <Boolean>]
+ [-EnablePrivateTeamDiscovery <Boolean>] [-AllowPrivateChannelCreation <Boolean>]
  [-AllowUserToParticipateInExternalSharedChannel <Boolean>] [-AllowChannelSharingToExternalUser <Boolean>] [-AllowSharedChannelCreation <Boolean>]
  [-Instance <PSObject>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
@@ -43,7 +43,7 @@ This cmdlet allows you to update existing policies of this type.
 
 ### Example 1
 ```powershell
-PS C:\> Set-CsTeamsChannelsPolicy -Identity StudentPolicy -AllowPrivateTeamDiscovery $true
+PS C:\> Set-CsTeamsChannelsPolicy -Identity StudentPolicy -EnablePrivateTeamDiscovery $true
 ```
 
 This example shows updating an existing policy with name "StudentPolicy" and enabling Private Team Discovery.


### PR DESCRIPTION
Updating the setting name for private team discovery as the old setting is deprecated. New setting : EnablePrivateTeamDiscovery
Old setting : AllowPrivateTeamDiscovery