### PR TITLE
Update app-only-auth-powershell-v2.md

### DIFF
--- a/exchange/docs-conceptual/app-only-auth-powershell-v2.md
+++ b/exchange/docs-conceptual/app-only-auth-powershell-v2.md
@@ -245,7 +245,7 @@ Choose **one** of the following methods in this section to assign API permission
 #### Modify the app manifest to assign API permissions
 
 > [!NOTE]
-> The procedures in this section _append_ the existing default permissions on the app (delegated **User.Read** permissions in **Microsoft Graph**) with the required application **Exchange.Manage.AsApp** permissions in **Office 365 Exchange Online**.
+> The procedures in this section _append_ the existing default permissions on the app (delegated **User.Read** permissions in **Microsoft Graph**) with the required application **Exchange.ManageAsApp** permissions in **Office 365 Exchange Online**.
 
 1. On the app **Overview** page, select **Manifest** from the **Manage** section.
 


### PR DESCRIPTION
corrected a typo - replacing the API permission Exchange.Manage.AsApp with Exchange.ManageAsApp

(It seems like a minimal and insignificant change, but I was working on implementing app-only auth and reading this documentation and could not ignore the typo. Thanks)