### PR TITLE
Update Get-EXOMailboxFolderStatistics.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-EXOMailboxFolderStatistics.md
+++ b/exchange/exchange-ps/exchange/Get-EXOMailboxFolderStatistics.md
@@ -24,11 +24,9 @@ For information about the parameter sets in the Syntax section below, see [Excha
 ```
 Get-EXOMailboxFolderStatistics
  [-Archive]
- [-DiagnosticInfo <String>]
  [-ExternalDirectoryObjectId <Guid>]
  [-Folderscope <ElcFolderType>]
  [-Identity <String>]
- [-IncludeAnalysis]
  [-IncludeOldestAndNewestItems]
  [-IncludeSoftDeletedRecipients]
  [-PrimarySmtpAddress <String>]
@@ -73,22 +71,6 @@ If you use this switch on a mailbox that doesn't have archiving enabled, an erro
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DiagnosticInfo
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: String
 Parameter Sets: (All)
 Aliases:
 Applicable: Exchange Online
@@ -180,22 +162,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
-```
-
-### -IncludeAnalysis
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
The 2 parameters IncludeAnalysis and DiagnosticInfo is not supported for external customers in Get-EXOMailboxFolderStatistics