### PR TITLE
Add TeamsWorkLocationDetectionPolicy cmdlets public docs

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
@@ -26,7 +26,8 @@ Get-CsTeamsWorkLocationDetectionPolicy [-Filter <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Fetches instances of TeamsWorkLocationDetectionPolicy. Each policy object contains a property called `EnableWorkLocationDetection`. This property lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios. This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
+Fetches instances of TeamsWorkLocationDetectionPolicy. Each policy object contains a property called `EnableWorkLocationDetection`. This setting allows your organization to collect the work location of users when they connect, interact, or are detected near your organization's networks and devices. It also captures the geographic location information users share from personal and mobile devices.
+This gives users the ability to consent to the use of this location data to set their current work location.Microsoft collects this information to provide users with a consistent location-based experience and to improve the hybrid work experience in Microsoft 365 according to the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839).
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,14 +1,17 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
-Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
-online version:
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/get-csteamsworklocationdetectionpolicy
 schema: 2.0.0
+ms.author: arkozlov
+manager: prashibadkur
+author: artemiykozlov
 ---
 
 # Get-CsTeamsWorkLocationDetectionPolicy
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+This cmdlet is used to fetch policy instances of TeamsWorkLocationDetectionPolicy.
 
 ## SYNTAX
 
@@ -23,21 +26,52 @@ Get-CsTeamsWorkLocationDetectionPolicy [-Filter <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Fetches instances of TeamsWorkLocationDetectionPolicy. Each policy object contains a property called `EnableWorkLocationDetection`. This property lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios. This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Get-CsTeamsWorkLocationDetectionPolicy
 ```
+```output
+Identity            EnableWorkLocationDetection                                                                          
+--------                 ----------------------                                                                          
+Global                                     False
+Tag:wld-enabled                            True
+Tag:wld-disabled                           False
+```
+Fetches all the policy instances currently available.
 
-{{ Add example description here }}
+### Example 2
+```powershell
+PS C:\> Get-CsTeamsWorkLocationDetectionPolicy -Identity wld-enabled
+```
+```output
+Identity            EnableWorkLocationDetection                                                                          
+--------                 ----------------------                                                                          
+Tag:wld-enabled                            True
+```
+Fetches an instance of a policy with a known identity.
+
+### Example 3
+```powershell
+PS C:\> Get-CsTeamsWorkLocationDetectionPolicy -Filter *wld*
+```
+```output
+Identity            EnableWorkLocationDetection                                                                          
+--------                 ----------------------                                                                          
+Tag:wld-enabled                            True
+Tag:wld-disabled                          False
+```
+The `Filter` parameter can be used to fetch policy instances based on partial matches on Identity.
+
+Note: _The "Tag:" prefix can be ignored when specifying the identity._
 
 ## PARAMETERS
 
 ### -Filter
-{{ Fill Filter Description }}
+This parameter can be used to fetch policy instances based on partial matches on the Identity field.
 
 ```yaml
 Type: String
@@ -52,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{ Fill Identity Description }}
+This parameter can be used to fetch a specific instance of the policy.
 
 ```yaml
 Type: String
@@ -71,7 +105,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.String
 
 ## OUTPUTS
 
@@ -80,3 +114,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+[New-CsTeamsWorkLocationDetectionPolicy](New-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Remove-CsTeamsWorkLocationDetectionPolicy](Remove-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Set-CsTeamsWorkLocationDetectionPolicy](Set-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Grant-CsTeamsWorkLocationDetectionPolicy](Grant-CsTeamsWorkLocationDetectionPolicy.md)

--- a/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,0 +1,82 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
+online version:
+schema: 2.0.0
+---
+
+# Get-CsTeamsWorkLocationDetectionPolicy
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsTeamsWorkLocationDetectionPolicy [[-Identity] <String>] [<CommonParameters>]
+```
+
+### Filter
+```
+Get-CsTeamsWorkLocationDetectionPolicy [-Filter <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Filter
+{{ Fill Filter Description }}
+
+```yaml
+Type: String
+Parameter Sets: Filter
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: String
+Parameter Sets: Identity
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### TeamsWorkLocationDetectionPolicy.Cmdlets.TeamsWorkLocationDetectionPolicy
+
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
 Module Name: MicrosoftTeams
-online version: https://learn.microsoft.com/powershell/module/skype/get-csteamsworklocationdetectionpolicy
+online version: https://learn.microsoft.com/powershell/module/teams/get-csteamsworklocationdetectionpolicy
 schema: 2.0.0
 ms.author: arkozlov
 manager: prashibadkur

--- a/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
 Module Name: MicrosoftTeams
-online version: https://learn.microsoft.com/powershell/module/skype/grant-csteamsworklocationdetectionpolicy
+online version: https://learn.microsoft.com/powershell/module/teams/grant-csteamsworklocationdetectionpolicy
 schema: 2.0.0
 ms.author: arkozlov
 manager: prashibadkur

--- a/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,0 +1,75 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
+online version:
+schema: 2.0.0
+---
+
+# Grant-CsTeamsWorkLocationDetectionPolicy
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Grant-CsTeamsWorkLocationDetectionPolicy -Identity <String> -PolicyName <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyName
+{{ Fill PolicyName Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,41 +1,137 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
-Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
-online version:
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/grant-csteamsworklocationdetectionpolicy
 schema: 2.0.0
+ms.author: arkozlov
+manager: prashibadkur
+author: artemiykozlov
 ---
 
 # Grant-CsTeamsWorkLocationDetectionPolicy
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+This cmdlet applies an instance of the TeamsWorkLocationDetectionPolicy to users or groups in a tenant.
 
 ## SYNTAX
 
+### Identity (Default)
 ```
-Grant-CsTeamsWorkLocationDetectionPolicy -Identity <String> -PolicyName <String> [<CommonParameters>]
+Grant-CsTeamsWorkLocationDetectionPolicy [<CommonParameters>]
+```
+
+### GrantToUser
+```
+Grant-CsTeamsWorkLocationDetectionPolicy -Identity <String> [[-PolicyName] <String>] [<CommonParameters>]
+```
+
+### GrantToGroup
+```
+Grant-CsTeamsWorkLocationDetectionPolicy [[-PolicyName] <String>] [-Group] <String> -Rank <Int32>
+ [<CommonParameters>]
+```
+
+### GrantToTenant
+```
+Grant-CsTeamsWorkLocationDetectionPolicy [[-PolicyName] <String>] [-Global] [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+
+This cmdlet applies an instance of the TeamsWorkLocationDetectionPolicy to users or groups in a tenant.
+
+Passes in the `Identity` of the policy instance in the `PolicyName` parameter and the user identifier in the `Identity` parameter or the group name in the `Group` parameter. One of either `Identity` or `Group` needs to be passed.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -PolicyName sms-enabled -Identity testuser@test.onmicrosoft.com
 ```
 
-{{ Add example description here }}
+Assigns a given policy to a user.
+
+### Example 2
+```powershell
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Group f13d6c9d-ce76-422c-af78-b6018b4d9c80 -PolicyName wld-enabled
+```
+
+Assigns a given policy to a group.
+
+
+### Example 3
+```powershell
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Global -PolicyName wld-enabled
+```
+
+Assigns a given policy to the tenant.
+
+### Example 3
+```powershell
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Global -PolicyName wld-enabled
+```
+
+Note: _Using $null in place of a policy name can be used to unassigned a policy instance._
 
 ## PARAMETERS
 
-### -Identity
-{{ Fill Identity Description }}
+### -Force
+Suppresses the display of any non-fatal error message that might arise when running the command.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GrantToTenant
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Global
+This is the equivalent to `-Identity Global`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: GrantToTenant
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Group
+This is the identifier of the group that the policy should be assigned to.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: GrantToGroup
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Specifies the identity of the target user.
+
+Example: testuser@test.onmicrosoft.com
+
+Example: 98403f08-577c-46dd-851a-f0460a13b03d
+
+Use the "Global" Identity if you wish to set the policy for the entire tenant.
+
+```yaml
+Type: String
+Parameter Sets: GrantToUser
 Aliases:
 
 Required: True
@@ -46,11 +142,26 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyName
-{{ Fill PolicyName Description }}
+Specifies the name of the policy to be assigned. The PolicyName is the policy identity minus the policy scope ("tag:"), for example, a policy that has an identity of "Tag:Enabled" has a PolicyName of "Enabled".
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: GrantToUser, GrantToGroup, GrantToTenant
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Rank
+The rank of the policy assignment, relative to other group policy assignments for the same policy type.
+
+```yaml
+Type: Int32
+Parameter Sets: GrantToGroup
 Aliases:
 
 Required: True
@@ -65,11 +176,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.String
 
 ## OUTPUTS
 
-### System.Object
+### System.Void
+
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsTeamsWorkLocationDetectionPolicy](Get-CsTeamsWorkLocationDetectionPolicy.md)
+
+[New-CsTeamsWorkLocationDetectionPolicy](New-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Set-CsTeamsWorkLocationDetectionPolicy](Set-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Remove-CsTeamsWorkLocationDetectionPolicy](Remove-CsTeamsWorkLocationDetectionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
 Module Name: MicrosoftTeams
-online version: https://learn.microsoft.com/powershell/module/skype/new-csteamsworklocationdetectionpolicy
+online version: https://learn.microsoft.com/powershell/module/teams/new-csteamsworklocationdetectionpolicy
 schema: 2.0.0
 ms.author: arkozlov
 manager: prashibadkur

--- a/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,14 +1,17 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
-Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
-online version:
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/new-csteamsworklocationdetectionpolicy
 schema: 2.0.0
+ms.author: arkozlov
+manager: prashibadkur
+author: artemiykozlov
 ---
 
 # New-CsTeamsWorkLocationDetectionPolicy
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+This cmdlet is used to create a new instance of the TeamsWorkLocationDetectionPolicy.
 
 ## SYNTAX
 
@@ -18,16 +21,31 @@ New-CsTeamsWorkLocationDetectionPolicy [-EnableWorkLocationDetection <Boolean>] 
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Creates a new instance of the TeamsWorkLocationDetectionPolicy. This policy can be used to tailor the work location detection experience. The parameter `EnableWorkLocationDetection` lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios. This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> New-CsTeamsWorkLocationDetectionPolicy -Identity wld-enabled -EnableWorkLocationDetection $true
 ```
+```output
+Identity                 EnableWorkLocationDetection                                                                          
+--------                 ----------------------                                                                          
+Tag:wld-enabled                            True
+```
+Creates a new policy instance with the identity wld-enabled. `EnableWorkLocationDetection` is set to the value specified in the command.
 
-{{ Add example description here }}
+### Example 2
+```powershell
+PS C:\> New-CsTeamsWorkLocationDetectionPolicy -Identity wld-disable
+```
+```output
+Identity                 EnableWorkLocationDetection                                                                          
+--------                 ----------------------                                                                          
+Tag:wld-disable                            False
+```
+Creates a new policy instance with the identity wld-disable. `EnableWorkLocationDetection` will default to false if it is not specified.
 
 ## PARAMETERS
 
@@ -47,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableWorkLocationDetection
-{{ Fill EnableWorkLocationDetection Description }}
+This property lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios. This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
 
 ```yaml
 Type: Boolean
@@ -62,7 +80,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{ Fill Force Description }}
+Suppresses the display of any non-fatal error message that might arise when running the command.
 
 ```yaml
 Type: SwitchParameter
@@ -77,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{ Fill Identity Description }}
+Name of the new policy instance to be created.
 
 ```yaml
 Type: String
@@ -112,7 +130,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.String
 
 ## OUTPUTS
 
@@ -121,3 +139,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsTeamsWorkLocationDetectionPolicy](Get-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Remove-CsTeamsWorkLocationDetectionPolicy](Remove-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Set-CsTeamsWorkLocationDetectionPolicy](Set-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Grant-CsTeamsWorkLocationDetectionPolicy](Grant-CsTeamsWorkLocationDetectionPolicy.md)

--- a/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,0 +1,123 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
+online version:
+schema: 2.0.0
+---
+
+# New-CsTeamsWorkLocationDetectionPolicy
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+New-CsTeamsWorkLocationDetectionPolicy [-EnableWorkLocationDetection <Boolean>] [-Identity] <String> [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableWorkLocationDetection
+{{ Fill EnableWorkLocationDetection Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{ Fill Force Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### TeamsWorkLocationDetectionPolicy.Cmdlets.TeamsWorkLocationDetectionPolicy
+
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
@@ -21,7 +21,8 @@ New-CsTeamsWorkLocationDetectionPolicy [-EnableWorkLocationDetection <Boolean>] 
 ```
 
 ## DESCRIPTION
-Creates a new instance of the TeamsWorkLocationDetectionPolicy. This policy can be used to tailor the work location detection experience. The parameter `EnableWorkLocationDetection` lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios. This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
+Creates a new instance of the TeamsWorkLocationDetectionPolicy. This policy can be used to tailor the work location detection experience. The parameter `EnableWorkLocationDetection` allows your organization to collect the work location of users when they connect, interact, or are detected near your organization's networks and devices. It also captures the geographic location information users share from personal and mobile devices.
+This gives users the ability to consent to the use of this location data to set their current work location.Microsoft collects this information to provide users with a consistent location-based experience and to improve the hybrid work experience in Microsoft 365 according to the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839).
 
 ## EXAMPLES
 
@@ -65,7 +66,8 @@ Accept wildcard characters: False
 ```
 
 ### -EnableWorkLocationDetection
-This property lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios. This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
+This setting allows your organization to collect the work location of users when they connect, interact, or are detected near your organization's networks and devices. It also captures the geographic location information users share from personal and mobile devices.
+This gives users the ability to consent to the use of this location data to set their current work location.Microsoft collects this information to provide users with a consistent location-based experience and to improve the hybrid work experience in Microsoft 365 according to the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839).
 
 ```yaml
 Type: Boolean

--- a/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,0 +1,108 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
+online version:
+schema: 2.0.0
+---
+
+# Remove-CsTeamsWorkLocationDetectionPolicy
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Remove-CsTeamsWorkLocationDetectionPolicy [-Identity] <String> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{ Fill Force Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
 Module Name: MicrosoftTeams
-online version: https://learn.microsoft.com/powershell/module/skype/remove-csteamsworklocationdetectionpolicy
+online version: https://learn.microsoft.com/powershell/module/teams/remove-csteamsworklocationdetectionpolicy
 schema: 2.0.0
 ms.author: arkozlov
 manager: prashibadkur

--- a/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,14 +1,17 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
-Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
-online version:
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/remove-csteamsworklocationdetectionpolicy
 schema: 2.0.0
+ms.author: arkozlov
+manager: prashibadkur
+author: artemiykozlov
 ---
 
 # Remove-CsTeamsWorkLocationDetectionPolicy
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+This cmdlet is used to delete an instance of TeamsWorkLocationDetectionPolicy.
 
 ## SYNTAX
 
@@ -18,16 +21,18 @@ Remove-CsTeamsWorkLocationDetectionPolicy [-Identity] <String> [-Force] [-WhatIf
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Deletes an instance of TeamsWorkLocationDetectionPolicy. The `Identity` parameter accepts the identity of the policy instance to delete.
+
+## EXAMPLES
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\>Remove-CsTeamsWorkLocationDetectionPolicy -Identity Foobar
 ```
 
-{{ Add example description here }}
+Deletes a given policy instance with the Identity Foobar.
 
 ## PARAMETERS
 
@@ -47,7 +52,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{ Fill Force Description }}
+Suppresses the display of any non-fatal error message that might arise when running the command.
 
 ```yaml
 Type: SwitchParameter
@@ -62,7 +67,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{ Fill Identity Description }}
+Name of the new policy instance to be created.
 
 ```yaml
 Type: String
@@ -106,3 +111,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsTeamsWorkLocationDetectionPolicy](Get-CsTeamsWorkLocationDetectionPolicy.md)
+
+[New-CsTeamsWorkLocationDetectionPolicy](New-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Set-CsTeamsWorkLocationDetectionPolicy](Set-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Grant-CsTeamsWorkLocationDetectionPolicy](Grant-CsTeamsWorkLocationDetectionPolicy.md)

--- a/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
@@ -51,7 +51,8 @@ Accept wildcard characters: False
 ```
 
 ### -EnableWorkLocationDetection
-This property lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios.  This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
+This setting allows your organization to collect the work location of users when they connect, interact, or are detected near your organization's networks and devices. It also captures the geographic location information users share from personal and mobile devices.
+This gives users the ability to consent to the use of this location data to set their current work location.Microsoft collects this information to provide users with a consistent location-based experience and to improve the hybrid work experience in Microsoft 365 according to the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839).
 
 ```yaml
 Type: Boolean

--- a/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,0 +1,123 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
+online version:
+schema: 2.0.0
+---
+
+# Set-CsTeamsWorkLocationDetectionPolicy
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Set-CsTeamsWorkLocationDetectionPolicy [-EnableWorkLocationDetection <Boolean>] [-Identity] <String> [-Force]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableWorkLocationDetection
+{{ Fill EnableWorkLocationDetection Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+{{ Fill Force Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,7 +1,7 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
 Module Name: MicrosoftTeams
-online version: https://learn.microsoft.com/powershell/module/skype/set-csteamsworklocationdetectionpolicy
+online version: https://learn.microsoft.com/powershell/module/teams/set-csteamsworklocationdetectionpolicy
 schema: 2.0.0
 ms.author: arkozlov
 manager: prashibadkur

--- a/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsWorkLocationDetectionPolicy.md
@@ -1,14 +1,17 @@
 ---
 external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
-Module Name: Microsoft.Teams.Policy.Administration.Cmdlets.Core
-online version:
+Module Name: MicrosoftTeams
+online version: https://learn.microsoft.com/powershell/module/skype/set-csteamsworklocationdetectionpolicy
 schema: 2.0.0
+ms.author: arkozlov
+manager: prashibadkur
+author: artemiykozlov
 ---
 
 # Set-CsTeamsWorkLocationDetectionPolicy
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+This cmdlet is used to update an instance of TeamsWorkLocationDetectionPolicy.
 
 ## SYNTAX
 
@@ -18,16 +21,17 @@ Set-CsTeamsWorkLocationDetectionPolicy [-EnableWorkLocationDetection <Boolean>] 
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Updates any of the properties of an existing instance of TeamsWorkLocationDetectionPolicy.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> {{ Add example code here }}
+PS> Set-CsTeamsWorkLocationDetectionPolicy -Identity ExistingPolicyInstance -EnableWorkLocationDetection $true
 ```
 
-{{ Add example description here }}
+Updates the `EnableWorkLocationDetection` field of a given policy.
 
 ## PARAMETERS
 
@@ -47,7 +51,7 @@ Accept wildcard characters: False
 ```
 
 ### -EnableWorkLocationDetection
-{{ Fill EnableWorkLocationDetection Description }}
+This property lets organizations collect the work location information of users using users plugging into hotdesks (unassigned desks) or rooms using tenant admin managed devices, using M365 in proximity of tenant managed device as MTRs, and sharing geographic geo location of mobile phone. The users can consent to use this information to set their workplace location.  The location information will be stored in the cloud and will be used for M365 hybrid work location scenarios.  This information will also be used by M365 to drive analytics on workplace utilization and enhance the hybrid work experience.
 
 ```yaml
 Type: Boolean
@@ -62,7 +66,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
-{{ Fill Force Description }}
+Suppresses the display of any non-fatal error message that might arise when running the command.
 
 ```yaml
 Type: SwitchParameter
@@ -77,7 +81,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{ Fill Identity Description }}
+Name of the new policy instance to be updated.
 
 ```yaml
 Type: String
@@ -112,7 +116,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.String
 
 ## OUTPUTS
 
@@ -121,3 +125,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+[Get-CsTeamsWorkLocationDetectionPolicy](Get-CsTeamsWorkLocationDetectionPolicy.md)
+
+[New-CsTeamsWorkLocationDetectionPolicy](New-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Remove-CsTeamsWorkLocationDetectionPolicy](Remove-CsTeamsWorkLocationDetectionPolicy.md)
+
+[Grant-CsTeamsWorkLocationDetectionPolicy](Grant-CsTeamsWorkLocationDetectionPolicy.md)


### PR DESCRIPTION
[PubOps PR review feedback](https://github.com/MicrosoftDocs/office-docs-powershell/pull/11616#issuecomment-1948867285)
***

This pull request includes changes to the `teams/teams-ps/teams` directory, specifically for the TeamsWorkLocationDetectionPolicy. The changes include the addition of new cmdlets. The cmdlets are used to manage the TeamsWorkLocationDetectionPolicy, which allows organizations to collect work location information of users.

Addition of new cmdlets:

* [`Get-CsTeamsWorkLocationDetectionPolicy`](diffhunk://#diff-b02b543870975c28a5ee3e5215f3a92bab42ae0b82060bd8864203ad6aa3220bR1-R123): Fetches instances of TeamsWorkLocationDetectionPolicy.
* [`Grant-CsTeamsWorkLocationDetectionPolicy`](diffhunk://#diff-130af06eb9f5d39faca61ae72fa06168317c432a990d52d2da7052e39863d0e9R1-R194): Applies an instance of the TeamsWorkLocationDetectionPolicy to users or groups in a tenant.
* [`New-CsTeamsWorkLocationDetectionPolicy`](diffhunk://#diff-1a50b08b55f38aac56641cd554fff2f7e2ed308affc2310dbc1fed3f2e2f9113R1-R148): Creates a new instance of the TeamsWorkLocationDetectionPolicy.
* [`Remove-CsTeamsWorkLocationDetectionPolicy`](diffhunk://#diff-027ee08e4fa1aa8544237b4bb0d225de9c8509dbf5fdb0a61aefd0f6371c9c1dR1-R120): Deletes an instance of TeamsWorkLocationDetectionPolicy.
* [`Set-CsTeamsWorkLocationDetectionPolicy`](diffhunk://#diff-2b989fcc3b44a71f65f276b09abcb4fea0b39cdd29e5488ee930bd28fa67acc1R1-R134): Updates any of the properties of an existing instance of TeamsWorkLocationDetectionPolicy.