### PR TITLE
Update Get-Mailbox.md to remove obsolete parameter

### DIFF
--- a/exchange/exchange-ps/exchange/Get-Mailbox.md
+++ b/exchange/exchange-ps/exchange/Get-Mailbox.md
@@ -48,7 +48,6 @@ Get-Mailbox [-Anr <String>]
  [-RecipientTypeDetails <RecipientTypeDetails[]>]
  [-RemoteArchive]
  [-ResultSize <Unlimited>]
- [-ServiceSafetyConfiguration]
  [-SoftDeletedMailbox]
  [-SortBy <String>]
  [-SupervisoryReviewPolicy]
@@ -106,7 +105,6 @@ Get-Mailbox [[-Identity] <MailboxIdParameter>]
  [-RecipientTypeDetails <RecipientTypeDetails[]>]
  [-RemoteArchive]
  [-ResultSize <Unlimited>]
- [-ServiceSafetyConfiguration]
  [-SoftDeletedMailbox]
  [-SortBy <String>]
  [-SupervisoryReviewPolicy]
@@ -155,7 +153,6 @@ Get-Mailbox [-MailboxPlan <MailboxPlanIdParameter>]
  [-PublicFolder]
  [-RecipientTypeDetails <RecipientTypeDetails[]>]
  [-ResultSize <Unlimited>]
- [-ServiceSafetyConfiguration]
  [-SoftDeletedMailbox]
  [-SortBy <String>]
  [<CommonParameters>]
@@ -799,24 +796,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True
-Accept wildcard characters: False
-```
-
-### -ServiceSafetyConfiguration
-This parameter is available only in the cloud-based service.
-
-This parameter is reserved for internal Microsoft use.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: Identity, AnrSet, MailboxPlanSet
-Aliases:
-Applicable: Exchange Online
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
The parameter -ServiceSafetyConfiguration no longer exists and should not be added to the docs.