### PR TITLE
Update Set-MailboxMessageConfiguration.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
+++ b/exchange/exchange-ps/exchange/Set-MailboxMessageConfiguration.md
@@ -91,7 +91,7 @@ Set-MailboxMessageConfiguration [-Identity] <MailboxIdParameter>
 ```
 
 ## DESCRIPTION
-The Set-MailboxMessageConfiguration cmdlet configures Outlook on the web settings for the specified mailbox. These settings include email signature, message format, message options, read receipts, reading pane, and conversations. These settings are not used in Outlook, Exchange ActiveSync, or other email clients. These settings are applied in Outlook on the web only. Settings that contain the word Mobile are applied in Outlook on the web for devices only.
+The Set-MailboxMessageConfiguration cmdlet configures Outlook on the web settings for the specified mailbox. These settings include email signature, message format, message options, read receipts, reading pane, and conversations. These settings are not used in Outlook, Exchange ActiveSync, or other email clients. These settings are applied in Outlook on the web only. Some settings also apply to the new Outlook client. Settings that contain the word Mobile are applied in Outlook on the web for devices only.
 
 You need to be assigned permissions before you can run this cmdlet. Although this topic lists all parameters for the cmdlet, you may not have access to some parameters if they're not included in the permissions assigned to you. To find the permissions required to run any cmdlet or parameter in your organization, see [Find the permissions required to run any Exchange cmdlet](https://learn.microsoft.com/powershell/exchange/find-exchange-cmdlet-permissions).
 


### PR DESCRIPTION
The description mentions that it only applies to Outlook on the web. This is not true. Some settings also apply to the new Outlook client.  This is not described so I've changed the documentation.