### PR TITLE
Correct metadata: Presence of "Module Name" and capitalization of its value, "MicrosoftTeams"

### DIFF
--- a/teams/teams-ps/teams/Get-CsCloudCallDataConnection.md
+++ b/teams/teams-ps/teams/Get-CsCloudCallDataConnection.md
@@ -1,6 +1,6 @@
 ---
 external help file: MicrosoftTeams-help.xml
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Get-CsCloudCallDataConnection
 online version: https://learn.microsoft.com/powershell/module/teams/get-cscloudcalldataconnection

--- a/teams/teams-ps/teams/Get-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMediaConnectivityPolicy.md
@@ -1,5 +1,5 @@
 ---
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Get-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Get-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Get-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMediaConnectivityPolicy.md
@@ -5,7 +5,7 @@ applicable: Microsoft Teams
 title: Get-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Get-CsTeamsMediaConnectivityPolicy
 schema: 2.0.0
-author: lirunping_MSFT
+author: lirunping-MSFT
 ms.author: runli
 ---
 

--- a/teams/teams-ps/teams/Get-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMediaConnectivityPolicy.md
@@ -1,4 +1,5 @@
 ---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
 Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Get-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Grant-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMediaConnectivityPolicy.md
@@ -1,5 +1,5 @@
 ---
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Grant-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Grant-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Grant-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMediaConnectivityPolicy.md
@@ -1,4 +1,5 @@
 ---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
 Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Grant-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Grant-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsMediaConnectivityPolicy.md
@@ -5,7 +5,7 @@ applicable: Microsoft Teams
 title: Grant-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Grant-CsTeamsMediaConnectivityPolicy
 schema: 2.0.0
-author: lirunping_MSFT
+author: lirunping-MSFT
 ms.author: runli
 ---
 

--- a/teams/teams-ps/teams/New-CsCloudCallDataConnection.md
+++ b/teams/teams-ps/teams/New-CsCloudCallDataConnection.md
@@ -1,6 +1,6 @@
 ---
 external help file: MicrosoftTeams-help.xml
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: New-CsCloudCallDataConnection
 online version: https://learn.microsoft.com/powershell/module/teams/new-cscloudcalldataconnection

--- a/teams/teams-ps/teams/New-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMediaConnectivityPolicy.md
@@ -1,5 +1,5 @@
 ---
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: New-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/New-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/New-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMediaConnectivityPolicy.md
@@ -1,4 +1,5 @@
 ---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
 Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: New-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/New-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMediaConnectivityPolicy.md
@@ -5,7 +5,7 @@ applicable: Microsoft Teams
 title: New-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/New-CsTeamsMediaConnectivityPolicy
 schema: 2.0.0
-author: lirunping_MSFT
+author: lirunping-MSFT
 ms.author: runli
 ---
 

--- a/teams/teams-ps/teams/New-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingPolicy.md
@@ -1,6 +1,7 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml 
 online version: https://learn.microsoft.com/powershell/module/teams/new-csteamsmeetingpolicy
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: New-CsTeamsMeetingPolicy
 schema: 2.0.0

--- a/teams/teams-ps/teams/Remove-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMediaConnectivityPolicy.md
@@ -1,4 +1,5 @@
 ---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
 Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Remove-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Remove-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMediaConnectivityPolicy.md
@@ -5,7 +5,7 @@ applicable: Microsoft Teams
 title: Remove-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Remove-CsTeamsMediaConnectivityPolicy
 schema: 2.0.0
-author: lirunping_MSFT
+author: lirunping-MSFT
 ms.author: runli
 ---
 

--- a/teams/teams-ps/teams/Remove-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsMediaConnectivityPolicy.md
@@ -1,5 +1,5 @@
 ---
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Remove-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Remove-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Set-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMediaConnectivityPolicy.md
@@ -1,5 +1,5 @@
 ---
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Set-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Set-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Set-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMediaConnectivityPolicy.md
@@ -5,7 +5,7 @@ applicable: Microsoft Teams
 title: Set-CsTeamsMediaConnectivityPolicy
 online version: https://learn.microsoft.com/powershell/module/teams/Set-CsTeamsMediaConnectivityPolicy
 schema: 2.0.0
-author: lirunping_MSFT
+author: lirunping-MSFT
 ms.author: runli
 ---
 

--- a/teams/teams-ps/teams/Set-CsTeamsMediaConnectivityPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMediaConnectivityPolicy.md
@@ -1,4 +1,5 @@
 ---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
 Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Set-CsTeamsMediaConnectivityPolicy

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
@@ -1,6 +1,7 @@
 ---
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml 
 online version: https://learn.microsoft.com/powershell/module/teams/set-csteamsmeetingpolicy
+Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Set-CsTeamsMeetingPolicy
 schema: 2.0.0

--- a/teams/teams-ps/teams/Set-TeamArchivedState.md
+++ b/teams/teams-ps/teams/Set-TeamArchivedState.md
@@ -1,6 +1,6 @@
 ---
 external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
-Module Name: microsoftteams
+Module Name: MicrosoftTeams
 online version: https://learn.microsoft.com/powershell/module/teams/set-teamarchivedstate
 schema: 2.0.0
 author: serdarsoysal


### PR DESCRIPTION
This correction is based on PR https://github.com/MicrosoftDocs/office-docs-powershell/pull/11739/files, which demonstrates correct metadata for content to be published on learn.microsoft.com. This is related to [Incident-490271299 Details - IcM (microsofticm.com)](https://portal.microsofticm.com/imp/v3/incidents/incident/490271299/summary), which describes how articles that are in main and live are not on learn.microsoft.com.

@lirunping-MSFT, @boboPD, @2012ucp1544, @tomkau, @SerdarSoysal 