### PR TITLE
Update Location Cmdlets description with missing parameters

### DIFF
--- a/teams/teams-ps/teams/New-CsOnlineLisCivicAddress.md
+++ b/teams/teams-ps/teams/New-CsOnlineLisCivicAddress.md
@@ -21,7 +21,8 @@ Use the New-CsOnlineLisCivicAddress cmdlet to create a civic address in the Loca
 New-CsOnlineLisCivicAddress -CompanyName <string> -CountryOrRegion <string> [-City <string>] [-CityAlias <string>] [-CompanyTaxId <string>]
 [-Description <string>] [-Elin <string>] [-Force] [-HouseNumber <string>] [-HouseNumberSuffix <string>]
 [-Latitude <string>] [-Longitude <string>] [-PostalCode <string>] [-PostDirectional <string>] [-PreDirectional <string>]
-[-StateOrProvince <string>] [-StreetName <string>] [-StreetSuffix <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-StateOrProvince <string>] [-StreetName <string>] [-StreetSuffix <string>] [-Confidence <String>] [-IsAzureMapValidationRequired <String>] [-ValidationStatus <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -368,6 +369,52 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -Confidence
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsAzureMapValidationRequired
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ValidationStatus
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 
 ### -WhatIf
 The WhatIf switch causes the command to simulate its results.

--- a/teams/teams-ps/teams/Set-CsOnlineLisCivicAddress.md
+++ b/teams/teams-ps/teams/Set-CsOnlineLisCivicAddress.md
@@ -26,7 +26,7 @@ Set-CsOnlineLisCivicAddress -CivicAddressId <Guid> [-CompanyName <String>] [-Com
  [-PreDirectional <String>] [-PostDirectional <String>] [-City <String>] [-CityAlias <String>]
  [-StateOrProvince <String>] [-CountryOrRegion <String>] [-PostalCode <String>] [-Description <String>]
  [-ValidationStatus <String>] [-Latitude <String>] [-Longitude <String>] [-Confidence <String>]
- [-Elin <String>] [-Force] [-WhatIf] [-Confirm]
+ [-Elin <String>] [-IsAzureMapValidationRequired <String>] [-Force] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -418,6 +418,21 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsAzureMapValidationRequired
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/teams/teams-ps/teams/Set-CsOnlineLisLocation.md
+++ b/teams/teams-ps/teams/Set-CsOnlineLisLocation.md
@@ -23,7 +23,7 @@ Typically the civic address designates the building, and locations are specific 
 Set-CsOnlineLisLocation -CivicAddressId <guid> [-City <string>] [-CityAlias <string>] [-CompanyName <string>] [-CompanyTaxId <string>]
  [-Confidence <string>] [-CountryOrRegion <string>] [-Description <string>] [-Elin <string>] [-Force] [-HouseNumber <string>] [-HouseNumberSuffix <string>]
  [-Latitude <string>] [-Longitude <string>] [-PostalCode <string>] [-PostDirectional <string>] [-PreDirectional <string>]
- [-StateOrProvince <string>] [-StreetName <string>] [-StreetSuffix <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-StateOrProvince <string>] [-StreetName <string>] [-StreetSuffix <string>] [-IsAzureMapValidationRequired <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### UseLocationId
@@ -418,6 +418,23 @@ Default value: None
 Accept pipeline input: True
 Accept wildcard characters: False
 ```
+
+### -IsAzureMapValidationRequired
+This parameter is reserved for internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: UseCivicAddressId
+Aliases:
+Applicable: Microsoft Teans
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 
 ### -Force
 The Force switch specifies whether to suppress warning and confirmation messages.


### PR DESCRIPTION


<html>
<body>
Following cmdlets have been updated <br>
<!--StartFragment--><span><span class="ui-provider a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ae af ag ah ai aj ak" dir="ltr">
Cmdlet | Parameter
-- | --
Set-CsOnlineLisCivicAddress | IsAzureMapValidationRequired
<br> New-CsOnlineLisCivicAddress | "Confidence", "IsAzureMapValidationRequired", "ValidationStatus"
<br> Set-CsOnlineLisLocation | IsAzureMapValidationRequired

</span></span><!--EndFragment-->
</body>
</html>