### PR TITLE
Update recipient-filters.md

### DIFF
--- a/exchange/docs-conceptual/recipient-filters.md
+++ b/exchange/docs-conceptual/recipient-filters.md
@@ -196,9 +196,8 @@ When creating your own custom OPATH filters, consider the following items:
 
   - **Variables**: Enclose the whole OPATH filter in double quotation marks (for example, `"Name -eq '$User'"`).
 
-  - **Integer values**: Depends on how you enclosed (or didn't enclose) the integer to search for:
+  - **Integer values**: To ensure they work in all cases; enclose them in one  of the following ways.
 
-    - **Integer not enclosed**: Enclose the whole OPATH filter in double quotation marks, single quotation marks, or braces (for example `"CountryCode -eq 840"`).
     - **Integer enclosed in single quotation marks**: Enclose the whole OPATH filter in double quotation marks or braces `"CountryCode -eq '840'"`.
     - **Integer enclosed in double quotation marks**: Enclose the whole OPATH filter in braces (for example `{CountryCode -eq "840"}`).
 

--- a/exchange/docs-conceptual/recipient-filters.md
+++ b/exchange/docs-conceptual/recipient-filters.md
@@ -190,14 +190,12 @@ When creating your own custom OPATH filters, consider the following items:
 - You need to enclose the whole OPATH filter in double quotation marks " " or single quotation marks ' '. Although any OPATH filter object is technically a string and not a script block, you can still use braces { }, but only if the filter doesn't contain variables that require expansion. The characters that you can use to enclose the whole OPATH filter depend on types of values that you're searching for and the characters you used (or didn't use) to enclose those values:
 
   - **Text values**: Depends on how you enclosed the text to search for:
-
     - **Text enclosed in single quotation marks**: Enclose the whole OPATH filter in double quotation marks or braces.
     - **Text enclosed in double quotation marks**: Enclose the whole OPATH filter in braces.
 
   - **Variables**: Enclose the whole OPATH filter in double quotation marks (for example, `"Name -eq '$User'"`).
 
-  - **Integer values**: To ensure they work in all cases; enclose them in one  of the following ways.
-
+  - **Integer values**: To ensure they work in all cases, enclose them in one of the following ways:
     - **Integer enclosed in single quotation marks**: Enclose the whole OPATH filter in double quotation marks or braces `"CountryCode -eq '840'"`.
     - **Integer enclosed in double quotation marks**: Enclose the whole OPATH filter in braces (for example `{CountryCode -eq "840"}`).
 


### PR DESCRIPTION
Integer values will NOT work in OPATH filters if they are not enclosed in cases where there is an -and in the filter.  Enclosing integers will work in ALL cases therefore we should simply provide the "working" methods and not the conditionally working methods.