### PR TITLE
Update Set-OwaMailboxPolicy.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
@@ -561,7 +561,6 @@ Accept wildcard characters: False
 ```
 
 ### -CalendarEnabled
-
 The CalendarEnabled parameter specifies whether to enable or disable the calendar in Outlook Web App. Valid values are:
 
 - $true: The Calendar is available in Outlook Web App. This is the default value.

--- a/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
+++ b/exchange/exchange-ps/exchange/Set-OwaMailboxPolicy.md
@@ -561,7 +561,6 @@ Accept wildcard characters: False
 ```
 
 ### -CalendarEnabled
-This parameter is functional only in on-premises Exchange.
 
 The CalendarEnabled parameter specifies whether to enable or disable the calendar in Outlook Web App. Valid values are:
 


### PR DESCRIPTION
Confirmed with Engineering team and in lab, CalendarEnabled parameter is valid for Exchange Online OWA as well and is not Exchange OnPremise only. Updating doc