### PR TITLE
Mandated latitude & longitude params for New-CsOnlineLisCivicAddress

### DIFF
--- a/teams/teams-ps/teams/New-CsOnlineLisCivicAddress.md
+++ b/teams/teams-ps/teams/New-CsOnlineLisCivicAddress.md
@@ -248,7 +248,7 @@ Parameter Sets: (All)
 Aliases:
 applicable: Microsoft Teams
 
-Required: True (Required for all countries except Australia and Japan)
+Required: True (Required for all countries except Australia and Japan where it's optional)
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -264,7 +264,7 @@ Parameter Sets: (All)
 Aliases:
 applicable: Microsoft Teams
 
-Required: True (Required for all countries except Australia and Japan)
+Required: True (Required for all countries except Australia and Japan where it's optional)
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/teams/teams-ps/teams/New-CsOnlineLisCivicAddress.md
+++ b/teams/teams-ps/teams/New-CsOnlineLisCivicAddress.md
@@ -248,7 +248,7 @@ Parameter Sets: (All)
 Aliases:
 applicable: Microsoft Teams
 
-Required: False
+Required: True (Required for all countries except Australia and Japan)
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -264,7 +264,7 @@ Parameter Sets: (All)
 Aliases:
 applicable: Microsoft Teams
 
-Required: False
+Required: True (Required for all countries except Australia and Japan)
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Latitude and longitude are made mandatory parameters for New-CsOnlineLisCivicAddress cmdlet for all countries except Australia and Japan. This was a bug and was fixed in March on urgent basis. Modified documentation to reflect the same.