### PR TITLE
Updated deprecated usage and params for New-CsOnlineLisLocation.md

### DIFF
--- a/teams/teams-ps/teams/New-CsOnlineLisLocation.md
+++ b/teams/teams-ps/teams/New-CsOnlineLisLocation.md
@@ -17,18 +17,8 @@ Use the New-CsOnlineLisLocation cmdlet to create a new emergency dispatch locati
 
 ## SYNTAX
 
-### ExistingCivicAddress (Default)
 ```
-New-CsOnlineLisLocation -Location <string> -CivicAddressId <guid> [-CityAlias <string>] [-CompanyName <string>] [-CompanyTaxId <string>] [-Confidence <string>]
-[-Elin <string>] [-Force] [-HouseNumberSuffix <string>] [-Latitude <string>] [-Longitude <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
-```
-
-### CreateCivicAddress
-```
-New-CsOnlineLisLocation -Location <string> -CountryOrRegion <string> [-CityAlias <string>] [-CompanyName <string>] [-CompanyTaxId <string>] [-Confidence <string>]
-[-Elin <string>] [-Force] [-HouseNumberSuffix <string>] [-Latitude <string>] [-Longitude <string>] [-City <string>] [-Description <string>] [-HouseNumber <string>]
-[-PostalCode <string>] [-PostDirectional <string>] [-PreDirectional <string>] [-StateOrProvince <string>] [-StreetName <string>] [-StreetSuffix <string>]
-[-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsOnlineLisLocation -Location <string> -CivicAddressId <guid> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,7 +39,7 @@ Specifies the unique identifier of the civic address that will contain the new l
 
 ```yaml
 Type: Guid
-Parameter Sets: ExistingCivicAddress
+Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams
 
@@ -65,20 +55,7 @@ Specifies an administrator-defined description of the new location. For example,
 
 ```yaml
 Type: String
-Parameter Sets: ExistingCivicAddress
-Aliases:
-Applicable: Microsoft Teams
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True
-Accept wildcard characters: False
-```
-
-```yaml
-Type: String
-Parameter Sets: CreateCivicAddress
+Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams
 
@@ -92,7 +69,7 @@ Accept wildcard characters: False
 ### -CountryOrRegion
 Specifies the country or region of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -110,7 +87,7 @@ Accept wildcard characters: False
 ### -City
 Specifies the city of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -128,7 +105,7 @@ Accept wildcard characters: False
 ### -CityAlias
 Specifies the city alias.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -146,7 +123,7 @@ Accept wildcard characters: False
 ### -CompanyName
 Specifies the name of your organization.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -164,7 +141,7 @@ Accept wildcard characters: False
 ### -CompanyTaxId
 The company tax ID.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -198,7 +175,7 @@ Accept wildcard characters: False
 ### -Description
 Specifies an administrator defined description of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -232,7 +209,7 @@ Accept wildcard characters: False
 ### -HouseNumber
 Specifies the numeric portion of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -251,7 +228,7 @@ Accept wildcard characters: False
 Specifies the numeric suffix of the civic address.
 For example, if the property was multiplexed, the HouseNumberSuffix parameter would be the multiplex specifier: "425A Smith Avenue", or "425B Smith Avenue".
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -269,7 +246,7 @@ Accept wildcard characters: False
 ### -Latitude
 Specifies the angular distance of a place north or south of the earth's equator using the decimal degrees format.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -287,7 +264,7 @@ Accept wildcard characters: False
 ### -Longitude
 Specifies the angular distance of a place east or west of the meridian at Greenwich, England, using the decimal degrees format.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -305,7 +282,7 @@ Accept wildcard characters: False
 ### -PostalCode
 Specifies the postal code of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -323,7 +300,7 @@ Accept wildcard characters: False
 ### -PostDirectional
 Specifies the directional attribute of the civic address which follows the street name. For example, "425 Smith Avenue NE".
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -341,7 +318,7 @@ Accept wildcard characters: False
 ### -PreDirectional
 Specifies the directional attribute of the civic address which precedes the street name. For example, "425 NE Smith Avenue".
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -359,7 +336,7 @@ Accept wildcard characters: False
 ### -StateOrProvince
 Specifies the state or province of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -377,7 +354,7 @@ Accept wildcard characters: False
 ### -StreetName
 Specifies the street name of the civic address.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String
@@ -395,7 +372,7 @@ Accept wildcard characters: False
 ### -StreetSuffix
 Specifies the modifier of the street name. The street suffix will typically be something like street, avenue, way, or boulevard.
 
-**Note:** This parameter is not supported and will be deprecated.
+**Note:** This parameter is not supported and is deprecated.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/New-CsOnlineLisLocation.md
+++ b/teams/teams-ps/teams/New-CsOnlineLisLocation.md
@@ -18,7 +18,7 @@ Use the New-CsOnlineLisLocation cmdlet to create a new emergency dispatch locati
 ## SYNTAX
 
 ```
-New-CsOnlineLisLocation -Location <string> -CivicAddressId <guid> [-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsOnlineLisLocation -Location <string> -CivicAddressId <guid> [-Elin <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
Removed second usage of New-CsOnlineLisLocation which creates the civic address also. Now creating location with only existing civic address id is supported. Also, updated description of parameters from "will be deprecated" to "is deprecated".