### PR TITLE
Update Set-CalendarProcessing.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-CalendarProcessing.md
+++ b/exchange/exchange-ps/exchange/Set-CalendarProcessing.md
@@ -414,6 +414,8 @@ Query-based groups (for example, dynamic distribution groups) aren't supported.
 
 You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
 
+In a Delegate and Principal scenario, if either the delegate or the principal is listed in the BookInPolicy, their in-policy meeting requests to the resource mailbox will be automatically approved.
+
 ```yaml
 Type: RecipientIdParameter[]
 Parameter Sets: (All)

--- a/exchange/exchange-ps/exchange/Set-CalendarProcessing.md
+++ b/exchange/exchange-ps/exchange/Set-CalendarProcessing.md
@@ -412,9 +412,9 @@ The BookInPolicy parameter specifies users or groups who are allowed to submit i
 
 Query-based groups (for example, dynamic distribution groups) aren't supported.
 
-You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
+In delegate and principal scenarios, if the delegate or principal is specified by the BookInPolicy parameter, in-policy meeting requests to the resource mailbox are automatically approved.
 
-In a Delegate and Principal scenario, if either the delegate or the principal is listed in the BookInPolicy, their in-policy meeting requests to the resource mailbox will be automatically approved.
+You can enter multiple values separated by commas. If the values contain spaces or otherwise require quotation marks, use the following syntax: `"Value1","Value2",..."ValueN"`.
 
 ```yaml
 Type: RecipientIdParameter[]


### PR DESCRIPTION
We need to add this in the -BookInPolicy section because customers are confused about how a delegate and principal work with booking resources: " In a Delegate and Principal scenario, if either the delegate or the principal is listed in the BookInPolicy, their in-policy meeting requests to the resource mailbox will be automatically approved. " PG confirmed this is by design here:
https://o365exchange.visualstudio.com/Outlook%20Services/_workitems/edit/4459608 @chrisda