### PR TITLE
Create the doc for TeamsExternalAccessConfiguration

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsExternalAccessConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsExternalAccessConfiguration.md
@@ -8,7 +8,7 @@ schema: 1.0.0
 # Get-CsTeamsExternalAccessConfiguration
 
 ## SYNOPSIS
-TeamsExternalAccessConfiguration has all configs that can be used to improve entire org security like the blocked users in this case. This cmdlet returns your organization's current settings.
+The TeamsExternalAccessConfiguration contains all configurations that can be used to enhance the security of the entire organization, such as managing blocked users. This cmdlet returns the current settings of your organization.
 
 ## SYNTAX
 

--- a/teams/teams-ps/teams/Get-CsTeamsExternalAccessConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsExternalAccessConfiguration.md
@@ -1,0 +1,82 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version:
+schema: 1.0.0
+---
+
+# Get-CsTeamsExternalAccessConfiguration
+
+## SYNOPSIS
+TeamsExternalAccessConfiguration has all configs that can be used to improve entire org security like the blocked users in this case. This cmdlet returns your organization's current settings.
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsTeamsExternalAccessConfiguration [[-Identity] <XdsIdentity>] [<CommonParameters>]
+```
+
+### Filter
+```
+Get-CsTeamsExternalAccessConfiguration [-Filter <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves the current Teams External Access Configuration in the organization.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-CsTeamsExternalAccessConfiguration
+```
+
+In this example, we retrieve the Teams External Access Configuration in the organization.
+
+## PARAMETERS
+
+### -Filter
+Internal Microsoft use.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The only value accepted is Global
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### TeamsExternalAccessConfiguration.Cmdlets.TeamsExternalAccessConfiguration
+
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/teams/Set-CsTeamsExternalAccessConfiguration.md
+++ b/teams/teams-ps/teams/Set-CsTeamsExternalAccessConfiguration.md
@@ -7,15 +7,13 @@ schema: 1.0.0
 # Set-CsTeamsExternalAccessConfiguration
 
 ## SYNOPSIS
-Allows admins to set values in the TeamsExternalAccessConfiguration
-, which specifies configs that can be used to improve entire org security.
 
 
 ## SYNTAX
 
 ### Identity (Default)
 ```
-Set-CsTeamsExternalAccessConfiguration [-BlockedUsers <List>] [-BlockExternalUserAccess <Boolean>] [[-Identity] <XdsIdentity>]
+Set-CsTeamsExternalAccessConfiguration [-BlockedUsers <List>] [-BlockExternalUserAccess <Boolean>] [[-Identity] <XdsIdentity>] [-Force] [-WhatIf] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/teams/teams-ps/teams/Set-CsTeamsExternalAccessConfiguration.md
+++ b/teams/teams-ps/teams/Set-CsTeamsExternalAccessConfiguration.md
@@ -1,0 +1,130 @@
+---
+external help file: Microsoft.Teams.Policy.Administration.Cmdlets.Core.dll-Help.xml
+Module Name: MicrosoftTeams
+online version:
+schema: 1.0.0
+---
+# Set-CsTeamsExternalAccessConfiguration
+
+## SYNOPSIS
+Allows admins to set values in the TeamsExternalAccessConfiguration
+, which specifies configs that can be used to improve entire org security.
+
+
+## SYNTAX
+
+### Identity (Default)
+```
+Set-CsTeamsExternalAccessConfiguration [-BlockedUsers <List>] [-BlockExternalUserAccess <Boolean>] [[-Identity] <XdsIdentity>]
+```
+
+## DESCRIPTION
+Allows admins to set values in the TeamsExternalAccessConfiguration, which specifies configs that can be used to improve entire org security. This configuration primarily allows admins to block malicious external users from the organization.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-CsTeamsExternalAccessConfiguration -Identity Global -BlockExternalAccessUserAccess $true
+```
+
+In this example, the admin has enabled the BlockExternalUserAccess. The users in the BlockedUsers will be blocked from communicating with the internal users.
+
+### Example 2
+```powershell
+PS C:\> Set-CsTeamsExternalAccessConfiguration -Identity Global -BlockedUsers @("user1@malicious.com", "user2@malicious.com")
+```
+
+In this example, the admin has added two malicious users into the blocked list. These blocked users can't communicate with internal users anymore.
+
+## PARAMETERS
+
+### -BlockExternalAccessUserAccess
+Designates whether BlockedUsers list is taking effect or not. $true means BlockedUsers are blocked and can't communicate with internal users.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BlockedUsers
+You can specify blocked users using a List object that contains either the user email or the MRI from the external user you want to block. The user in the list will not able to communicate with the internal users in your organization.
+
+```yaml
+Type: List
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Bypass confirmation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+The only option is Global
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Management.Automation.PSObject
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
TeamsExternalAccessConfiguration is introduced to provide the configurations so that Teams Admin can have a better way to control the External Access within the organization. This is a tenant wise configuration, and Teams Admin and add external users into the BlockedUsers list so that all communication (chat/call/search) is blocked for these users