### PR TITLE
Please add parameter help to Set-CsTeamsUpdateManagementPolicy

### DIFF
--- a/teams/teams-ps/teams/Set-CsTeamsUpdateManagementPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsUpdateManagementPolicy.md
@@ -105,6 +105,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -BlockLegacyAuthorization
+
+### -AllowManagedUpdates
+
+### -AllowPreview
+
+### -UpdateDayOfWeek
+
+### -UpdateTime
+
+### -UpdateTimeOfDay
+
+### -AllowPublicPreview
+
+### -UseNewTeamsClient
+
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.


### PR DESCRIPTION
Please add (help) documentation for the missing parameters, stated in the syntax of Set-CsTeamsUpdateManagementPolicy.

PowerShell module: MicrosoftTeams 6.4.0

I received no error message. However, there is also no documentation available.
```powershell
Set-CsTeamsUpdateManagementPolicy -Identity Global -BlockLegacyAuthorization $true
```