### PR TITLE
Update Set-CsTeamsEventsPolicy.md

### DIFF
--- a/teams/teams-ps/teams/Set-CsTeamsEventsPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsEventsPolicy.md
@@ -10,8 +10,6 @@ schema: 2.0.0
 ## SYNOPSIS
 This cmdlet allows you to configure options for customizing Teams events experiences. Note that this policy is currently still in preview.
 
-> [!NOTE]
-> Webinar and town hall policies must be managed separately.
 
 ## SYNTAX
 
@@ -174,6 +172,10 @@ Accept wildcard characters: False
 ```
 
 ### -EventAccessType
+
+> [!NOTE]
+> Currently, webinar and town hall event access is managed together via EventAccessType.
+
 This setting governs which users can access the event registration page or the event site to register. It also governs which user type is allowed to join the session/s in the event. 
 Possible values are:
  - **Everyone**: Enables creating events to allow in-tenant, guests, federated, and anonymous (external to the tenant) users to register and join the event.


### PR DESCRIPTION
Updated Policy note for EventAccessType to inform admins that currently event access policy controls both webinar and townhall.

Removed previous note indicating policies are controlled separately (this is an update that has not pushed out yet and will be updated at a later time)