### PR TITLE
Update Set-User.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-User.md
+++ b/exchange/exchange-ps/exchange/Set-User.md
@@ -917,7 +917,7 @@ The PermanentlyClearPreviousMailboxInfo switch specifies whether to clear the Ex
 
 Clearing these attributes might be required in mailbox move and re-licensing scenarios between on-premises Exchange and Microsoft 365. For more information, see [Permanently Clear Previous Mailbox Info](https://techcommunity.microsoft.com/t5/exchange-team-blog/permanently-clear-previous-mailbox-info/ba-p/607619).
 
-**Caution**: This switch will prevent you from reconnecting to the mailbox, and prevents you from recovering content from the mailbox.
+**Caution**: This switch prevents you from reconnecting to the mailbox and prevents you from recovering content from the mailbox.
 
 ```yaml
 Type: SwitchParameter

--- a/exchange/exchange-ps/exchange/Set-User.md
+++ b/exchange/exchange-ps/exchange/Set-User.md
@@ -917,7 +917,7 @@ The PermanentlyClearPreviousMailboxInfo switch specifies whether to clear the Ex
 
 Clearing these attributes might be required in mailbox move and re-licensing scenarios between on-premises Exchange and Microsoft 365. For more information, see [Permanently Clear Previous Mailbox Info](https://techcommunity.microsoft.com/t5/exchange-team-blog/permanently-clear-previous-mailbox-info/ba-p/607619).
 
-**Caution**: This switch permanently deletes the existing cloud mailbox and its associated archive, prevents you from reconnecting to the mailbox, and prevents you from recovering content from the mailbox.
+**Caution**: This switch will prevent you from reconnecting to the mailbox, and prevents you from recovering content from the mailbox.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
Removed extra info where the PermanentlyClearPreviousMailboxInfo would point to its old behavior which was to purge the disconnected mailbox, and this is not the case anymore since a long time already. This change will set the expectations around this parameter.