### PR TITLE
Update Set-CsTeamsMeetingPolicy.md

### DIFF
--- a/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
@@ -1202,10 +1202,14 @@ Accept wildcard characters: False
 ```
 
 ### -SpeakerAttributionMode
+Determines if users are identified in transcriptions and if they can change the value of the _Automatically identify me in meeting captions and transcripts_ setting.
+
 Possible values:
 
-- EnabledUserOverride
-- Disabled
+- **Enabled**: Speakers are identified in transcription.
+- **EnabledUserOverride**: Speakers are identified in transcription. If enabled, users can override this setting and choose not to be identified in their Teams profile settings.
+- **DisabledUserOverride**: Speakers are not identified in transcription. If enabled, users can override this setting and choose to be identified in their Teams profile settings.
+- **Disabled**: Speakers are not identified in transcription.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Updated the -SpeakerAttributionMode setting.
2 more possible values were added back in 2023, but not documented.

https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/2650773

@michbrown-png could you please review? Tianran Wu might be able to check the validity.