### PR TITLE
Revert Meeting Policy setting - CaptchaVerificationForMeetingJoin

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingPolicy.md
@@ -57,7 +57,6 @@ New-CsTeamsMeetingPolicy [-Identity] <XdsIdentity>
  [-AutoAdmittedUsers <String>]
  [-AutomaticallyStartCopilot <String>]
  [-BlockedAnonymousJoinClientTypes <List>]
- [-CaptchaVerificationForMeetingJoin <String>]
  [-Confirm]
  [-ContentSharingInExternalMeetings <String>]
  [-Copilot <String>]
@@ -735,41 +734,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: Empty List
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CaptchaVerificationForMeetingJoin
-Check that everyone joining from outside the company is a real person. This will prevent unwanted guests.
-
-Possible values are:
-
-- **NotRequired**, Captcha not required
-- **AnonymousUsersAndUntrustedOrganizations**, Anonymous users and people from untrusted organizations
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: NotRequired
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
@@ -61,7 +61,6 @@ Set-CsTeamsMeetingPolicy [[-Identity] <XdsIdentity>]
  [-AutoAdmittedUsers <String>]
  [-AutomaticallyStartCopilot <String>]
  [-BlockedAnonymousJoinClientTypes <List>]
- [-CaptchaVerificationForMeetingJoin <String>]
  [-ChannelRecordingDownload <String>]
  [-Confirm]
  [-ConnectToMeetingControls <String>]
@@ -765,26 +764,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: Empty List
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CaptchaVerificationForMeetingJoin
-Check that everyone joining from outside the company is a real person. This will prevent unwanted guests.
-
-Possible values:
-
-- **NotRequired**, Captcha not required
-- **AnonymousUsersAndUntrustedOrganizations**, Anonymous users and people from untrusted organizations
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: NotRequired
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Revert this PR https://github.com/MicrosoftDocs/office-docs-powershell/pull/11927
Will be added after necessary signoff done.

>>>>>>>>>>>>>>>>>>>>>>>>>>>
-> Added a new meeting policy setting - CaptchaVerificationForMeetingJoin

This setting enforce captcha for anonymous user while meeting join.

NotRequired (Default)
AnonymousUsersAndUntrustedOrganizations

Type: String
Default value: NotRequired