### PR TITLE
Update Set-RetentionCompliancePolicy.md

### DIFF
--- a/exchange/exchange-ps/exchange/Set-RetentionCompliancePolicy.md
+++ b/exchange/exchange-ps/exchange/Set-RetentionCompliancePolicy.md
@@ -759,12 +759,9 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveExchangeLocation
-The RemoveExchangeLocation parameter specifies the mailboxes to remove from the list of included mailboxes when you aren't using the value All for the ExchangeLocation parameter. Valid values are:
+The RemoveExchangeLocation parameter specifies the mailboxes to remove from the list of included mailboxes when you aren't using the value All for the ExchangeLocation parameter. Valid values are mailboxes.
 
-- A mailbox
-- A distribution group or mail-enabled security group
-
-To specify a mailbox or distribution group, you can use any value that uniquely identifies it. For example:
+To specify a mailbox, you can use any value that uniquely identifies it. For example:
 
 - Name
 - Distinguished name (DN)
@@ -787,12 +784,9 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveExchangeLocationException
-The RemoveExchangeLocationException parameter specifies the mailboxes to remove from the list of excluded mailboxes when you use the value All for the ExchangeLocation parameter. Valid values are:
+The RemoveExchangeLocationException parameter specifies the mailboxes to remove from the list of excluded mailboxes when you use the value All for the ExchangeLocation parameter. Valid values are mailboxes.
 
-- A mailbox
-- A distribution group or mail-enabled security group
-
-To specify a mailbox or distribution group, you can use any value that uniquely identifies it. For example:
+To specify a mailbox, you can use any value that uniquely identifies it. For example:
 
 - Name
 - Distinguished name (DN)

--- a/exchange/exchange-ps/exchange/Set-RetentionCompliancePolicy.md
+++ b/exchange/exchange-ps/exchange/Set-RetentionCompliancePolicy.md
@@ -759,9 +759,9 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveExchangeLocation
-The RemoveExchangeLocation parameter specifies the mailboxes to remove from the list of included mailboxes when you aren't using the value All for the ExchangeLocation parameter. Valid values are mailboxes.
+The RemoveExchangeLocation parameter specifies the mailboxes to remove from the list of included mailboxes when you aren't using the value All for the ExchangeLocation parameter.
 
-To specify a mailbox, you can use any value that uniquely identifies it. For example:
+You can use any value that uniquely identifies the mailbox. For example:
 
 - Name
 - Distinguished name (DN)
@@ -784,9 +784,9 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveExchangeLocationException
-The RemoveExchangeLocationException parameter specifies the mailboxes to remove from the list of excluded mailboxes when you use the value All for the ExchangeLocation parameter. Valid values are mailboxes.
+The RemoveExchangeLocationException parameter specifies the mailboxes to remove from the list of excluded mailboxes when you use the value All for the ExchangeLocation parameter.
 
-To specify a mailbox, you can use any value that uniquely identifies it. For example:
+You can use any value that uniquely identifies the mailbox. For example:
 
 - Name
 - Distinguished name (DN)


### PR DESCRIPTION
As confirmed in this bug https://o365exchange.visualstudio.com/IP%20Engineering/_workitems/edit/169228/?view=edit, groups are not supported for attributes -RemoveExchangeLocation and -RemoveExchangeLocationException, only mailboxes