### PR TITLE
Update Teams Calling Policy

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
@@ -20,14 +20,37 @@ Use this cmdlet to create a new instance of a Teams Calling Policy.
 
 ### Identity (Default)
 ```
-New-CsTeamsCallingPolicy [-Identity] <string> [-Description <string>] [-AllowPrivateCalling <boolean>] [-AllowWebPSTNCalling <boolean>]
- [-AllowSIPDevicesCalling <boolean>] [-AllowVoicemail <string>] [-AllowCallGroups <boolean>] [-AllowDelegation <boolean>]
- [-AllowCallForwardingToUser <boolean>] [-AllowCallForwardingToPhone <boolean>] [-PreventTollBypass <boolean>]
- [-BusyOnBusyEnabledType <string>] [-MusicOnHoldEnabledType <string>] [-AllowCloudRecordingForCalls <boolean>]
- [-AllowTranscriptionForCalling <boolean>] [-PopoutForIncomingPstnCalls <string>] [-PopoutAppPathForIncomingPstnCalls <string>]
- [-LiveCaptionsEnabledTypeForCalling <string>] [-AutoAnswerEnabledType <string>] [-SpamFilteringEnabledType <string>]
- [-CallRecordingExpirationDays <long>] [-AllowCallRedirect <string>] [-EnableWebPstnMediaBypass <Boolean>]
- [-InboundPstnCallRoutingTreatment <string>] [-InboundFederatedCallRoutingTreatment <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsTeamsCallingPolicy [-Identity] <string>
+ [-Description <string>]
+ [-AllowPrivateCalling <boolean>]
+ [-AllowWebPSTNCalling <boolean>]
+ [-AllowSIPDevicesCalling <boolean>]
+ [-AllowVoicemail <string>]
+ [-AllowCallGroups <boolean>]
+ [-AllowDelegation <boolean>]
+ [-AllowCallForwardingToUser <boolean>]
+ [-AllowCallForwardingToPhone <boolean>]
+ [-PreventTollBypass <boolean>]
+ [-BusyOnBusyEnabledType <string>]
+ [-MusicOnHoldEnabledType <string>]
+ [-AllowCloudRecordingForCalls <boolean>]
+ [-AllowTranscriptionForCalling <boolean>]
+ [-PopoutForIncomingPstnCalls <string>]
+ [-PopoutAppPathForIncomingPstnCalls <string>]
+ [-LiveCaptionsEnabledTypeForCalling <string>]
+ [-AutoAnswerEnabledType <string>]
+ [-SpamFilteringEnabledType <string>]
+ [-CallRecordingExpirationDays <long>]
+ [-AllowCallRedirect <string>]
+ [-EnableWebPstnMediaBypass <Boolean>]
+ [-InboundPstnCallRoutingTreatment <string>]
+ [-InboundFederatedCallRoutingTreatment <string>]
+ [-PayAsYouGoSpendingLimits <Boolean>] 
+ [-PayAsYouGoSpendingUserLimit <long>] 
+ [-Force]
+ [-WhatIf]
+ [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -489,6 +512,37 @@ Possible values:
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PayAsYouGoSpendingLimits
+Determines if spending limit is enabled for pay-as-you-go PSTN calls.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PayAsYouGoSpendingUserLimit
+Determines the value of spending limit for a user making pay-as-you-go PSTN calls.
+```yaml
+Type: Long
 Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams

--- a/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
@@ -541,6 +541,9 @@ Accept wildcard characters: False
 
 ### -PayAsYouGoSpendingUserLimit
 Determines the value of spending limit for a user making pay-as-you-go PSTN calls.
+
+Possible values are any positive integer.
+
 ```yaml
 Type: Long
 Parameter Sets: (All)

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -44,6 +44,8 @@ Set-CsTeamsCallingPolicy [-Identity] <string>
  [-PopoutForIncomingPstnCalls <string>]
  [-PreventTollBypass <boolean>]
  [-SpamFilteringEnabledType <string>]
+ [-PayAsYouGoSpendingLimits <Boolean>] 
+ [-PayAsYouGoSpendingUserLimit <long>] 
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -473,6 +475,38 @@ Possible values:
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PayAsYouGoSpendingLimits
+Determines if spending limit is enabled for pay-as-you-go PSTN calls.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PayAsYouGoSpendingUserLimit
+Determines the value of spending limit for a user making pay-as-you-go PSTN calls.
+
+```yaml
+Type: Long
 Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -505,6 +505,8 @@ Accept wildcard characters: False
 ### -PayAsYouGoSpendingUserLimit
 Determines the value of spending limit for a user making pay-as-you-go PSTN calls.
 
+Possible values are any positive integer.
+
 ```yaml
 Type: Long
 Parameter Sets: (All)

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -36,7 +36,7 @@ Set-CsTeamsCallingPolicy [-Identity] <string>
  [-CallRecordingExpirationDays <long>]
  [-Confirm]
  [-Force]
- [-Copilot] <string>]
+ [-Copilot <string>]
  [-InboundFederatedCallRoutingTreatment <string>]
  [-InboundPstnCallRoutingTreatment <string>]
  [-LiveCaptionsEnabledTypeForCalling <string>]


### PR DESCRIPTION
- Add new properties `PayAsYouGoSpendingLimits` and `PayAsYouGoSpendingUserLimit` for Pay-as-you-go calling spending limits feature.
- Split parameters on new lines in `New-CsTeamsCallingPolicy.md` for better readability in the same way as they are in `Set-CsTeamsCallingPolicy.md`.