### PR TITLE
Update Set-CsExternalAccessPolicy.md from PR 12143

### DIFF
--- a/teams/teams-ps/teams/Set-CsExternalAccessPolicy.md
+++ b/teams/teams-ps/teams/Set-CsExternalAccessPolicy.md
@@ -213,7 +213,7 @@ Indicates how the users get assigned by this policy can communicate with the ext
 Type: String
 Parameter Sets: (All)
 Aliases:
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -228,7 +228,7 @@ Indicates the domains that are allowed to communicate with the users of this pol
 Type: List
 Parameter Sets: (All)
 Aliases:
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -243,7 +243,7 @@ Indicates the domains that are blocked from communicating with the users of this
 Type: List
 Parameter Sets: (All)
 Aliases:
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named


### PR DESCRIPTION
This PR cherry-picks commit https://github.com/MicrosoftDocs/office-docs-powershell/pull/12143/commits/879885eb3dc7aec6f11a154baccb925496335c69 from PR https://github.com/MicrosoftDocs/office-docs-powershell/pull/12143, because the history on GitHub.com for [Set-CsExternalAccessPolicy.md](https://github.com/krammerliu/office-docs-powershell/commits/main/skype/skype-ps/skype/Set-CsExternalAccessPolicy.md) did not show that the commit had been applied (unlike the history for the other file in the PR, [Set-CsTenantFederationConfiguration.md](https://github.com/MicrosoftDocs/office-docs-powershell/commits/main/teams/teams-ps/teams/Set-CsTenantFederationConfiguration.md), which does show changes from PR 12143).