### PR TITLE
Re-remove Skype for Business Online

### DIFF
--- a/teams/teams-ps/teams/Set-CsExternalAccessPolicy.md
+++ b/teams/teams-ps/teams/Set-CsExternalAccessPolicy.md
@@ -213,7 +213,7 @@ Indicates how the users get assigned by this policy can communicate with the ext
 Type: String
 Parameter Sets: (All)
 Aliases:
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -228,7 +228,7 @@ Indicates the domains that are allowed to communicate with the users of this pol
 Type: List
 Parameter Sets: (All)
 Aliases:
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named
@@ -243,7 +243,7 @@ Indicates the domains that are blocked from communicating with the users of this
 Type: List
 Parameter Sets: (All)
 Aliases:
-Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Online, Skype for Business Server 2015, Skype for Business Server 2019
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
 
 Required: False
 Position: Named


### PR DESCRIPTION
Since my previous re-application of a commit to _Set-CsExternalAccessPolicy.md_ restored "Skype for Business Online", which was later removed, I'm re-applying the removal, too.