### PR TITLE
Update New-CsExternalAccessPolicy.md for granular federation control

### DIFF
--- a/teams/teams-ps/teams/New-CsExternalAccessPolicy.md
+++ b/teams/teams-ps/teams/New-CsExternalAccessPolicy.md
@@ -113,6 +113,14 @@ Finally, the last command uses the Set-CsExternalAccessPolicy cmdlet to create a
 If you do not call the Set-CsExternalAccessPolicy cmdlet, then the virtual policy will disappear as soon as you end your Windows PowerShell session or delete the variable $x.
 Should that happen, an external access policy with the Identity RedmondAccessPolicy will never be created.
 
+### -------------------------- Example 5 ------------------------
+```
+New-CsExternalAccessPolicy -Identity GranularFederationExample -CommunicationWithExternalOrgs "AllowSpecificExternalDomains" -AllowedExternalDomains @("example1.com", "example2.com")
+Set-CsTenantFederationConfiguration -CustomizeFederation $true
+```
+
+In this example, we create an ExternalAccessPolicy named "GranularFederationExample" that allows communication with specific external domains, namely `example1.com` and `example2.com`. The federation policy is set to restrict communication to only these allowed domains. After that, we still have to enable the `CustomizeFederation` setting in the TenantFederationConfiguration to allow the federation settings as defined in the ExternalAccessPolicy to work.
+
 ## PARAMETERS
 
 ### -Identity
@@ -167,6 +175,53 @@ Aliases:
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CommunicationWithExternalOrgs
+Indicates how the users get assigned by this policy can communicate with the external orgs. There are 5 options:
+* OrganizationDefault: the users of this policy will follow the federation settings defined in TenantFederationConfiguration
+* AllowAllExternalDomains: the users are open to communicate with all domains
+* AllowSpecificExternalDomains: the users can only communicate with the users of the domains defined in `AllowedExternalDomains`
+* BlockSpecificExternalDomains: only users from the domains defined in `BlockedExternalDomains` are blocked from communicating with the users of this policy
+* BlockAllExternalDomains: the users are not able to communicate with any external domains
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
+Required: False
+Position: Named
+Default value: OrganizationDefault
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowedExternalDomains
+Indicates the domains that are allowed to communicate with the users of this policy. This is referenced only when `CommunicationWithExternalOrgs` is set to be `AllowSpecificExternalDomains`
+```yaml
+Type: List
+Parameter Sets: (All)
+Aliases:
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BlockedExternalDomains
+Indicates the domains that are blocked from communicating with the users of this policy. This is referenced only when `CommunicationWithExternalOrgs` is set to be `BlockSpecificExternalDomains`
+```yaml
+Type: List
+Parameter Sets: (All)
+Aliases:
+Applicable: Lync Server 2010, Lync Server 2013, Skype for Business Server 2015, Skype for Business Server 2019
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/New-CsExternalAccessPolicy.md
+++ b/teams/teams-ps/teams/New-CsExternalAccessPolicy.md
@@ -24,7 +24,7 @@ For information about external access in Microsoft Teams, see [Manage external a
 ## SYNTAX
 
 ```powershell
-New-CsExternalAccessPolicy [-Tenant <Guid>] [-Description <String>] [-EnableFederationAccess <Boolean>] [-EnableAcsFederationAccess <Boolean>]
+New-CsExternalAccessPolicy [-Tenant <Guid>] [-Description <String>] [-EnableFederationAccess <Boolean>] [-CommunicationWithExternalOrgs <Boolean>] [-AllowedExternalDomains <List>] [-BlockedExternalDomains <List>] [-EnableAcsFederationAccess <Boolean>]
  [-EnableXmppAccess <Boolean>] [-EnablePublicCloudAccess <Boolean>]
  [-EnablePublicCloudAudioVideoAccess <Boolean>] [-EnableTeamsConsumerAccess <Boolean>] [-EnableTeamsConsumerInbound <Boolean>] [-EnableOutsideAccess <Boolean>] [-Identity] <XdsIdentity>
  [-InMemory] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]


### PR DESCRIPTION
We have updated Set-CsExternalAccessPolicy.md in https://github.com/MicrosoftDocs/office-docs-powershell/pull/12143 for granular federation control. This is to update New-CsExternalAccessPolicy.md to align both files