### PR TITLE
Update Teams Calling Policy - Add spend limits parameters

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
@@ -444,7 +444,7 @@ Aliases:
 Applicable: Microsoft Teams
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
@@ -21,38 +21,38 @@ Use this cmdlet to create a new instance of a Teams Calling Policy.
 ### Identity (Default)
 ```
 New-CsTeamsCallingPolicy [-Identity] <string>
- [-Description <string>]
- [-AllowPrivateCalling <boolean>]
- [-AllowWebPSTNCalling <boolean>]
- [-AllowSIPDevicesCalling <boolean>]
- [-AllowVoicemail <string>]
- [-AllowCallGroups <boolean>]
- [-AllowDelegation <boolean>]
- [-AllowCallForwardingToUser <boolean>]
- [-AllowCallForwardingToPhone <boolean>]
- [-PreventTollBypass <boolean>]
- [-BusyOnBusyEnabledType <string>]
- [-MusicOnHoldEnabledType <string>]
- [-AllowCloudRecordingForCalls <boolean>]
- [-AllowTranscriptionForCalling <boolean>]
- [-PopoutForIncomingPstnCalls <string>]
- [-PopoutAppPathForIncomingPstnCalls <string>]
- [-LiveCaptionsEnabledTypeForCalling <string>]
- [-AutoAnswerEnabledType <string>]
- [-SpamFilteringEnabledType <string>]
- [-CallRecordingExpirationDays <long>]
- [-AllowCallRedirect <string>]
- [-Copilot <string>]
- [-EnableWebPstnMediaBypass <Boolean>]
- [-InboundPstnCallRoutingTreatment <string>]
- [-InboundFederatedCallRoutingTreatment <string>]
  [-AIInterpreter <string>]
- [-VoiceSimulationInInterpretation <string>]
- [-EnableSpendLimits <boolean>]
+ [-AllowCallForwardingToPhone <boolean>]
+ [-AllowCallForwardingToUser <boolean>]
+ [-AllowCallGroups <boolean>]
+ [-AllowCallRedirect <string>]
+ [-AllowCloudRecordingForCalls <boolean>]
+ [-AllowDelegation <boolean>]
+ [-AllowPrivateCalling <boolean>]
+ [-AllowSIPDevicesCalling <boolean>]
+ [-AllowTranscriptionForCalling <boolean>]
+ [-AllowVoicemail <string>]
+ [-AllowWebPSTNCalling <boolean>]
+ [-AutoAnswerEnabledType <string>]
+ [-BusyOnBusyEnabledType <string>]
  [-CallingSpendUserLimit <long>]
- [-Force]
- [-WhatIf]
+ [-CallRecordingExpirationDays <long>]
  [-Confirm]
+ [-Copilot <string>]
+ [-Description <string>]
+ [-EnableSpendLimits <boolean>]
+ [-EnableWebPstnMediaBypass <Boolean>]
+ [-Force]
+ [-InboundFederatedCallRoutingTreatment <string>]
+ [-InboundPstnCallRoutingTreatment <string>]
+ [-LiveCaptionsEnabledTypeForCalling <string>]
+ [-MusicOnHoldEnabledType <string>]
+ [-PopoutAppPathForIncomingPstnCalls <string>]
+ [-PopoutForIncomingPstnCalls <string>]
+ [-PreventTollBypass <boolean>]
+ [-SpamFilteringEnabledType <string>]
+ [-VoiceSimulationInInterpretation <string>]
+ [-WhatIf]
  [<CommonParameters>]
 ```
 
@@ -71,13 +71,29 @@ values in the Global policy instance.
 
 ## PARAMETERS
 
+### -Identity
+Name of the policy instance being created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -AIInterpreter
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
+> [!NOTE]
+> This feature has not been released yet and will have no changes if it is enabled or disabled.
 
 Enables the user to use the AI Interpreter related features
 
-Possible Values:
+Possible values:
+
 - Disabled
 - Enabled
 
@@ -249,6 +265,7 @@ Accept wildcard characters: False
 Enables inbound calls to be routed to voicemail.
 
 Valid options are:
+
 - AlwaysEnabled: Calls are always forwarded to voicemail on unanswered after ringing for thirty seconds, regardless of the unanswered call forward setting for the user.
 - AlwaysDisabled: Calls are never routed to voicemail, regardless of the call forward or unanswered settings for the user. Voicemail isn't available as a call forwarding or unanswered setting in Teams.
 - UserOverride: Calls are forwarded to voicemail based on the call forwarding and/or unanswered settings for the user.
@@ -286,6 +303,7 @@ Accept wildcard characters: False
 Setting this parameter allows you to enable or disable auto-answer for incoming meeting invites on Teams Phones. This setting applies only to incoming meeting invites and does not include support for other call types.
 
 Valid options are:
+
 - Enabled: Auto-answer is enabled.
 - Disabled: Auto-answer is disabled. This is the default setting.
 
@@ -306,6 +324,7 @@ Accept wildcard characters: False
 Setting this parameter lets you configure how incoming calls are handled when a user is already in a call or conference or has a call placed on hold.
 
 Valid options are:
+
 - Enabled: New or incoming calls will be rejected with a busy signal.
 - Unanswered: The user's unanswered settings will take effect, such as routing to voicemail or forwarding to another user.
 - Disabled: New or incoming calls will be presented to the user.
@@ -317,6 +336,23 @@ Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams
 
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CallingSpendUserLimit
+The maximum amount a user can spend on outgoing PSTN calls, including all calls made through Pay-as-you-go Calling Plans and any overages on plans with bundled minutes.
+
+Possible values: any positive integer
+
+```yaml
+Type: Long
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
 Required: False
 Position: Named
 Default value: None
@@ -340,18 +376,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Description
-Enables administrators to provide explanatory text about the calling policy. For example, the Description might indicate the users to whom the policy should be assigned.
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: String
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: cf
 Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -377,8 +413,44 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Description
+Enables administrators to provide explanatory text about the calling policy. For example, the Description might indicate the users to whom the policy should be assigned.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableSpendLimits
+This setting allows an admin to enable or disable spend limits on PSTN calls for their user base.
+
+Possible values:
+
+- True
+- False
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -EnableWebPstnMediaBypass
- Determines if MediaBypass is enabled for PSTN calls on specified Web platforms.
+Determines if MediaBypass is enabled for PSTN calls on specified Web platforms.
 
 ```yaml
 Type: Boolean
@@ -392,17 +464,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Identity
-Name of the policy instance being created.
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
 
 ```yaml
-Type: String
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: wi
+Applicable: Microsoft Teams
 
 Required: False
-Position: 1
-Default value: None
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -411,6 +484,7 @@ Accept wildcard characters: False
 Setting this parameter lets you control how inbound federated calls should be routed.
 
 Valid options are:
+
 - RegularIncoming: No changes are made to default inbound routing. This is the default setting.
 - Unanswered: The inbound federated call will be routed according to the called user's unanswered call settings and the call will not be presented to the called user. The called user will see a missed call notification. If the called user has not enabled unanswered call settings the call will be disconnected.
 
@@ -435,9 +509,9 @@ Accept wildcard characters: False
 Setting this parameter lets you control how inbound PSTN calls should be routed.
 
 Valid options are:
+
 - RegularIncoming: No changes are made to default inbound routing. This is the default setting.
 - Unanswered: The inbound PSTN call will be routed according to the called user's unanswered call settings and the call will not be presented to the called user. The called user will see a missed call notification. If the called user has not enabled unanswered call settings the call will be disconnected.
-
 - Voicemail: The inbound PSTN call will be routed directly to the called user's voicemail and the call will not be presented to the user. If the called user does not have voicemail enabled the call will be disconnected.
 - UserOverride: For now, setting the value to UserOverride is the same as RegularIncoming.
 
@@ -460,8 +534,8 @@ Accept wildcard characters: False
 Determines whether real-time captions are available for the user in Teams calls.
 
 Valid options are:
-- DisabledUserOverride: Allows the user to turn on live captions.
 
+- DisabledUserOverride: Allows the user to turn on live captions.
 - Disabled: Prohibits the user from turning on live captions.
 
 ```yaml
@@ -481,6 +555,7 @@ Accept wildcard characters: False
 Setting this parameter allows you to turn on or turn off the music on hold when a caller is placed on hold.
 
 Valid options are:
+
 - Enabled: Music on hold is enabled. This is the default.
 - Disabled: Music on hold is disabled.
 - UserOverride: For now, setting the value to UserOverride is the same as Enabled.
@@ -550,6 +625,7 @@ Accept wildcard characters: False
 Determines Spam filtering mode.
 
 Possible values:
+
 - Enabled: Spam Filtering is fully enabled. Both Basic and Captcha Interactive Voice Response (IVR) checks are performed. In case the call is considered spam, the user will get a "Spam Likely" notification in Teams.
 - Disabled: Spam Filtering is completely disabled. No checks are performed. A "Spam Likely" notification will not appear.
 - EnabledWithoutIVR: Spam Filtering is partially enabled. Captcha IVR checks are disabled. A "Spam Likely" notification will appear. A call might get dropped if it gets a high score from Basic checks.
@@ -575,6 +651,7 @@ Accept wildcard characters: False
 Enables the user to use the voice simulation feature while being AI interpreted.
 
 Possible Values:
+
 - DisabledUserOverride
 - Disabled
 - Enabled
@@ -593,58 +670,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -EnableSpendLimits
-This setting allows an admin to enable or disable spend limits on PSTN calls for their user base.
-
-Possible values: 
-- True
-- False
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CallingSpendUserLimit
-The maximum amount a user can spend on outgoing PSTN calls, including all calls made through Pay-as-you-go Calling Plans and any overages on plans with bundled minutes.
-
-Possible values: any positive integer
-
-```yaml
-Type: Long
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses any confirmation prompts that would otherwise be displayed before making changes.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
@@ -653,22 +678,6 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
 Applicable: Microsoft Teams
 
 Required: False

--- a/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
@@ -20,15 +20,40 @@ Use this cmdlet to create a new instance of a Teams Calling Policy.
 
 ### Identity (Default)
 ```
-New-CsTeamsCallingPolicy [-Identity] <string> [-Description <string>] [-AllowPrivateCalling <boolean>] [-AllowWebPSTNCalling <boolean>]
- [-AllowSIPDevicesCalling <boolean>] [-AllowVoicemail <string>] [-AllowCallGroups <boolean>] [-AllowDelegation <boolean>]
- [-AllowCallForwardingToUser <boolean>] [-AllowCallForwardingToPhone <boolean>] [-PreventTollBypass <boolean>]
- [-BusyOnBusyEnabledType <string>] [-MusicOnHoldEnabledType <string>] [-AllowCloudRecordingForCalls <boolean>]
- [-AllowTranscriptionForCalling <boolean>] [-PopoutForIncomingPstnCalls <string>] [-PopoutAppPathForIncomingPstnCalls <string>]
- [-LiveCaptionsEnabledTypeForCalling <string>] [-AutoAnswerEnabledType <string>] [-SpamFilteringEnabledType <string>]
- [-CallRecordingExpirationDays <long>] [-AllowCallRedirect <string>] [-Copilot <string>] [-EnableWebPstnMediaBypass <Boolean>]
- [-InboundPstnCallRoutingTreatment <string>] [-InboundFederatedCallRoutingTreatment <string>] [-AIInterpreter <string>]
- [-VoiceSimulationInInterpretation <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+New-CsTeamsCallingPolicy [-Identity] <string>
+ [-Description <string>]
+ [-AllowPrivateCalling <boolean>]
+ [-AllowWebPSTNCalling <boolean>]
+ [-AllowSIPDevicesCalling <boolean>]
+ [-AllowVoicemail <string>]
+ [-AllowCallGroups <boolean>]
+ [-AllowDelegation <boolean>]
+ [-AllowCallForwardingToUser <boolean>]
+ [-AllowCallForwardingToPhone <boolean>]
+ [-PreventTollBypass <boolean>]
+ [-BusyOnBusyEnabledType <string>]
+ [-MusicOnHoldEnabledType <string>]
+ [-AllowCloudRecordingForCalls <boolean>]
+ [-AllowTranscriptionForCalling <boolean>]
+ [-PopoutForIncomingPstnCalls <string>]
+ [-PopoutAppPathForIncomingPstnCalls <string>]
+ [-LiveCaptionsEnabledTypeForCalling <string>]
+ [-AutoAnswerEnabledType <string>]
+ [-SpamFilteringEnabledType <string>]
+ [-CallRecordingExpirationDays <long>]
+ [-AllowCallRedirect <string>]
+ [-Copilot <string>]
+ [-EnableWebPstnMediaBypass <Boolean>]
+ [-InboundPstnCallRoutingTreatment <string>]
+ [-InboundFederatedCallRoutingTreatment <string>]
+ [-AIInterpreter <string>]
+ [-VoiceSimulationInInterpretation <string>]
+ [-EnableSpendLimits <boolean>]
+ [-CallingSpendUserLimit <long>]
+ [-Force]
+ [-WhatIf]
+ [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -561,6 +586,42 @@ Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams
 
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableSpendLimits
+This setting allows an admin to enable or disable spend limits on PSTN calls for their user base.
+
+Possible values: 
+- True
+- False
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CallingSpendUserLimit
+The maximum amount a user can spend on outgoing PSTN calls, including all calls made through Pay-as-you-go Calling Plans and any overages on plans with bundled minutes.
+
+Possible values: any positive integer
+
+```yaml
+Type: Long
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
 Required: False
 Position: Named
 Default value: None

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -47,6 +47,8 @@ Set-CsTeamsCallingPolicy [-Identity] <string>
  [-PreventTollBypass <boolean>]
  [-SpamFilteringEnabledType <string>]
  [-VoiceSimulationInInterpretation <string>]
+ [-EnableSpendLimits <boolean>]
+ [-CallingSpendUserLimit <long>]
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -546,6 +548,44 @@ Possible Values:
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableSpendLimits
+This setting allows an admin to enable or disable spend limits on PSTN calls for their user base.
+
+Possible values: 
+- True
+- False
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CallingSpendUserLimit
+The maximum amount a user can spend on outgoing PSTN calls, including all calls made through Pay-as-you-go Calling Plans and any overages on plans with bundled minutes.
+
+Possible values: any positive integer
+
+```yaml
+Type: Long
 Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -35,9 +35,11 @@ Set-CsTeamsCallingPolicy [-Identity] <string>
  [-AllowWebPSTNCalling <boolean>]
  [-BusyOnBusyEnabledType <string>]
  [-CallRecordingExpirationDays <long>]
+ [-CallingSpendUserLimit <long>]
  [-Confirm]
+ [-Copilot <string>]
+ [-EnableSpendLimits <boolean>]
  [-Force]
- [-Copilot] <string>]
  [-InboundFederatedCallRoutingTreatment <string>]
  [-InboundPstnCallRoutingTreatment <string>]
  [-LiveCaptionsEnabledTypeForCalling <string>]
@@ -47,8 +49,6 @@ Set-CsTeamsCallingPolicy [-Identity] <string>
  [-PreventTollBypass <boolean>]
  [-SpamFilteringEnabledType <string>]
  [-VoiceSimulationInInterpretation <string>]
- [-EnableSpendLimits <boolean>]
- [-CallingSpendUserLimit <long>]
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -77,13 +77,29 @@ Sets the value of the parameter LiveCaptionsEnabledTypeForCalling to Disabled in
 
 ## PARAMETERS
 
+### -Identity
+Name of the policy instance being created.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -AIInterpreter
 >[!NOTE]
 >This feature has not been released yet and will have no changes if it is enabled or disabled.
 
 Enables the user to use the AI Interpreter related features
 
-Possible Values:
+Possible values:
+
 - Disabled
 - Enabled
 
@@ -152,6 +168,7 @@ Accept wildcard characters: False
 Setting this parameter enables local call redirection for SIP devices connecting via the Microsoft Teams SIP gateway.
 
 Valid options are:
+
 - Enabled: Enables the user to redirect an incoming call.
 - Disabled: The user is not enabled to redirect an incoming call.
 - UserOverride: This option is not available for use.
@@ -254,6 +271,7 @@ Accept wildcard characters: False
 Enables inbound calls to be routed to voicemail.
 
 Valid options are:
+
 - AlwaysEnabled: Calls are always forwarded to voicemail on unanswered after ringing for thirty seconds, regardless of the unanswered call forward setting for the user.
 - AlwaysDisabled: Calls are never routed to voicemail, regardless of the call forward or unanswered settings for the user. Voicemail isn't available as a call forwarding or unanswered setting in Teams.
 - UserOverride: Calls are forwarded to voicemail based on the call forwarding and/or unanswered settings for the user.
@@ -291,6 +309,7 @@ Accept wildcard characters: False
 Setting this parameter lets you configure how incoming calls are handled when a user is already in a call or conference or has a call placed on hold.
 
 Valid options are:
+
 - Enabled: New or incoming calls will be rejected with a busy signal.
 - Unanswered: The user's unanswered settings will take effect, such as routing to voicemail or forwarding to another user.
 - Disabled: New or incoming calls will be presented to the user.
@@ -298,6 +317,24 @@ Valid options are:
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CallingSpendUserLimit
+The maximum amount a user can spend on outgoing PSTN calls, including all calls made through Pay-as-you-go Calling Plans and any overages on plans with bundled minutes.
+
+Possible values: any positive integer
+
+```yaml
+Type: Long
 Parameter Sets: (All)
 Aliases:
 Applicable: Microsoft Teams
@@ -325,18 +362,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Description
-Enables administrators to provide explanatory text about the calling policy. For example, the Description might indicate the users to whom the policy should be assigned.
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: String
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: cf
 Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -345,6 +382,7 @@ Accept wildcard characters: False
 Setting this parameter lets you control how Copilot is used during calls and if transcription is needed to be turned on and saved after the call.
 
 Valid options are:
+
 - Enabled: Copilot can work with or without transcription during calls. This is the default value.
 - EnabledWithTranscript: Copilot will only work when transcription is enabled during calls.
 - Disabled: Copilot is disabled for calls.
@@ -362,17 +400,55 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Identity
-Name of the policy instance being created.
+### -Description
+Enables administrators to provide explanatory text about the calling policy. For example, the Description might indicate the users to whom the policy should be assigned.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
+Applicable: Microsoft Teams
 
 Required: False
-Position: 1
+Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableSpendLimits
+This setting allows an admin to enable or disable spend limits on PSTN calls for their user base.
+
+Possible values:
+
+- True
+- False
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses any confirmation prompts that would otherwise be displayed before making changes.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+Applicable: Microsoft Teams
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -381,6 +457,7 @@ Accept wildcard characters: False
 Setting this parameter lets you control how inbound federated calls should be routed.
 
 Valid options are:
+
 - RegularIncoming: No changes are made to default inbound routing. This is the default setting.
 - Unanswered: The inbound federated call will be routed according to the called user's unanswered call settings and the call will not be presented to the called user. The called user will see a missed call notification. If the called user has not enabled unanswered call settings the call will be disconnected.
 - Voicemail: The inbound federated call will be routed directly to the called user's voicemail and the call will not be presented to the user. If the called user does not have voicemail enabled the call will be disconnected.
@@ -404,6 +481,7 @@ Accept wildcard characters: False
 Setting this parameter lets you control how inbound PSTN calls should be routed.
 
 Valid options are:
+
 - RegularIncoming: No changes are made to default inbound routing. This is the default setting.
 - Unanswered: The inbound PSTN call will be routed according to the called user's unanswered call settings and the call will not be presented to the called user. The called user will see a missed call notification. If the called user has not enabled unanswered call settings the call will be disconnected.
 - Voicemail: The inbound PSTN call will be routed directly to the called user's voicemail and the call will not be presented to the user. If the called user does not have voicemail enabled the call will be disconnected.
@@ -428,6 +506,7 @@ Accept wildcard characters: False
 Determines whether real-time captions are available for the user in Teams calls.
 
 Valid options are:
+
 - DisabledUserOverride: Allows the user to turn on live captions.
 - Disabled: Prohibits the user from turning on live captions.
 
@@ -448,6 +527,7 @@ Accept wildcard characters: False
 Setting this parameter allows you to turn on or turn off the music on hold when a caller is placed on hold.
 
 Valid options are:
+
 - Enabled: Music on hold is enabled. This is the default.
 - Disabled: Music on hold is disabled.
 - UserOverride: For now, setting the value to UserOverride is the same as Enabled.
@@ -517,6 +597,7 @@ Accept wildcard characters: False
 Determines if spam detection is enabled for inbound PSTN calls.
 
 Possible values:
+
 - Enabled: Spam detection is enabled. In case the inbound call is considered spam, the user will get a "Spam Likely" label in Teams.
 - Disabled: Spam detection is disabled.
 
@@ -535,12 +616,13 @@ Accept wildcard characters: False
 
 ### -VoiceSimulationInInterpretation
 
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
+> [!NOTE]
+> This feature has not been released yet and will have no changes if it is enabled or disabled.
 
 Enables the user to use the voice simulation feature while being AI interpreted.
 
 Possible Values:
+
 - DisabledUserOverride
 - Disabled
 - Enabled
@@ -559,60 +641,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -EnableSpendLimits
-This setting allows an admin to enable or disable spend limits on PSTN calls for their user base.
-
-Possible values: 
-- True
-- False
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -CallingSpendUserLimit
-The maximum amount a user can spend on outgoing PSTN calls, including all calls made through Pay-as-you-go Calling Plans and any overages on plans with bundled minutes.
-
-Possible values: any positive integer
-
-```yaml
-Type: Long
-Parameter Sets: (All)
-Aliases:
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Force
-Suppresses any confirmation prompts that would otherwise be displayed before making changes.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: wi
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
@@ -621,22 +649,6 @@ The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-Applicable: Microsoft Teams
-
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
 Applicable: Microsoft Teams
 
 Required: False

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -432,7 +432,7 @@ Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: None
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
This pull request includes updates to the `New-CsTeamsCallingPolicy` and `Set-CsTeamsCallingPolicy` cmdlets documentation to include new parameters for managing spend limits on PSTN calls.

### New parameters added:

* [`teams/teams-ps/teams/New-CsTeamsCallingPolicy.md`](diffhunk://#diff-c1237908915625637cf126b674cb1f5375f006ebe25a9885f0a488341db0c2aeL23-R56): Added `-EnableSpendLimits` and `-CallingSpendUserLimit` parameters to the cmdlet. These parameters allow administrators to enable/disable spend limits and set a maximum spend limit for users on outgoing PSTN calls.
* [`teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md`](diffhunk://#diff-29e8a18c203e144bd51ebe7f8af91ae973062dd71297d15df797e8e47203d556R50-R51): Added `-EnableSpendLimits` and `-CallingSpendUserLimit` parameters to the cmdlet. These parameters allow administrators to enable/disable spend limits and set a maximum spend limit for users on outgoing PSTN calls.