### PR TITLE
Adding public documentation to new tenant setting: TeamsMultiTenantOrganizationConfiguration

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsMultiTenantOrganizationConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMultiTenantOrganizationConfiguration.md
@@ -3,7 +3,7 @@ external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
 Module Name: MicrosoftTeams
 applicable: Microsoft Teams
 title: Get-CsTeamsMultiTenantOrganizationConfiguration 
-online version: https://learn.microsoft.com/powershell/module/teams/get-csteamsmultiTenantorganizationconfiguration 
+online version: https://learn.microsoft.com/powershell/module/teams/get-csteamsmultitenantorganizationconfiguration 
 schema: 2.0.0
 author: samlyu
 ms.author: samlyu
@@ -23,7 +23,7 @@ Get-CsTeamsMultiTenantOrganizationConfiguration [<CommonParameters>]
 
 ## DESCRIPTION
 
-The new Get-CsTeamsMultiTenantOrganizationConfiguration cmdlet enables Teams meeting administrators to retrieve the Multi-Tenant Organization settings for their tenant. This includes the *isCopilotFromHomeTenant* field, which specifies whether users in a Multi-Tenant Organization are allowed to utilize their Copilot license from their home tenant during cross-tenant meetings.
+The new Get-CsTeamsMultiTenantOrganizationConfiguration cmdlet enables Teams meeting administrators to retrieve the Multi-Tenant Organization settings for their tenant. This includes the *CopilotFromHomeTenant* field, which specifies whether users in a Multi-Tenant Organization are allowed to utilize their Copilot license from their home tenant during cross-tenant meetings.
 
 ## EXAMPLES
 
@@ -32,7 +32,7 @@ The new Get-CsTeamsMultiTenantOrganizationConfiguration cmdlet enables Teams mee
 PS C:\> Get-CsTeamsMultiTenantOrganizationConfiguration
 ```
 
-Retrieves tenant's Multi-tenant Organization Configuration, including isCopilotFromHomeTenant.
+Retrieves tenant's Multi-tenant Organization Configuration, including CopilotFromHomeTenant.
 
 ## PARAMETERS
 
@@ -47,4 +47,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Set-CsTeamsMultiTenantOrganizationConfiguration](https://learn.microsoft.com/powershell/module/teams/set-csteamsmultiTenantorganizationconfiguration)
+[Set-CsTeamsMultiTenantOrganizationConfiguration](https://learn.microsoft.com/powershell/module/teams/set-csteamsmultitenantorganizationconfiguration)

--- a/teams/teams-ps/teams/Get-CsTeamsMultiTenantOrganizationConfiguration.md
+++ b/teams/teams-ps/teams/Get-CsTeamsMultiTenantOrganizationConfiguration.md
@@ -1,0 +1,50 @@
+---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
+Module Name: MicrosoftTeams
+applicable: Microsoft Teams
+title: Get-CsTeamsMultiTenantOrganizationConfiguration 
+online version: https://learn.microsoft.com/powershell/module/teams/get-csteamsmultiTenantorganizationconfiguration 
+schema: 2.0.0
+author: samlyu
+ms.author: samlyu
+---
+
+# Get-CsTeamsMultiTenantOrganizationConfiguration 
+
+## SYNOPSIS
+
+This cmdlet retrieves tenant settings for Multi-tenant Organzation.
+
+## SYNTAX
+
+```
+Get-CsTeamsMultiTenantOrganizationConfiguration [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The new Get-CsTeamsMultiTenantOrganizationConfiguration cmdlet enables Teams meeting administrators to retrieve the Multi-Tenant Organization settings for their tenant. This includes the *isCopilotFromHomeTenant* field, which specifies whether users in a Multi-Tenant Organization are allowed to utilize their Copilot license from their home tenant during cross-tenant meetings.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-CsTeamsMultiTenantOrganizationConfiguration
+```
+
+Retrieves tenant's Multi-tenant Organization Configuration, including isCopilotFromHomeTenant.
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Set-CsTeamsMultiTenantOrganizationConfiguration](https://learn.microsoft.com/powershell/module/teams/set-csteamsmultiTenantorganizationconfiguration)

--- a/teams/teams-ps/teams/Set-CsTeamsMultiTenantOrganizationConfiguration.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMultiTenantOrganizationConfiguration.md
@@ -1,0 +1,90 @@
+---
+external help file: Microsoft.TeamsCmdlets.PowerShell.Custom.dll-Help.xml
+Module Name: MicrosoftTeams
+applicable: Microsoft Teams
+title: Set-CsTeamsMultiTenantOrganizationConfiguration
+online version: https://learn.microsoft.com/powershell/module/teams/set-csteamsmultitenantorganizationconfiguration
+schema: 2.0.0
+author: samlyu
+ms.author: samlyu
+---
+
+# Set-CsTeamsMultiTenantOrganizationConfiguration
+
+## SYNOPSIS
+
+This cmdlet Set Multi-tenant Organization tenant settings for current tenant.
+
+## SYNTAX
+
+```
+Set-CsTeamsMultiTenantOrganizationConfiguration
+       [[-Identity] <string>]
+       [-CopilotFromHomeTenant <Enabled/Disabled>]
+```
+
+## DESCRIPTION
+The Set-CsTeamsMultiTenantOrganizationConfiguration set tenant setting for Multi-tenant Organization, including CopilotFromHomeTenant, which specifies whether users in a Multi-Tenant Organization are allowed to utilize their Copilot license from their home tenant during cross-tenant meetings.
+This cmdlet sets the Teams Multi-tenant Organization tenant setting, CopilotFromHomeTenant, for the tenant. The value of CopilotFromHomeTenant can be set to "Enabled" or "Disabled".
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-CsTeamsMultiTenantOrganizationConfiguration -Identity Global -CopilotFromHomeTenant Disabled
+```
+
+Set Teams Multi-tenant Organization Setting "CopilotFromHomeTenant" value to "Disabled" for global as default.
+
+### Example 2
+```powershell
+PS C:\> Set-CsTeamsMultiTenantOrganizationConfiguration -Identity Global -CopilotFromHomeTenant Enabled
+
+```
+
+Set Teams Multi-tenant Organization Setting "CopilotFromHomeTenant" value to "Enabled" for global as default.
+
+## PARAMETERS
+
+### -Identity
+Identity of the Teams Multi-tenant Organization Setting.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CopilotFromHomeTenant 
+Setting value of the Teams Multi-tenant Organization Setting. CopilotFromHomeTenant controls user access to Copilot license in their home tenant during cross-tenant meetings.
+
+```yaml
+Type: Boolean
+Parameter Sets: ("Enabled","Disabled")
+Aliases:
+
+Required: True
+Position: Named
+Default value: Enabled
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-CsTeamsMultiTenantOrganizationConfiguration](https://learn.microsoft.com/powershell/module/teams/get-csteamsmultitenantorganizationconfiguration)


### PR DESCRIPTION
Adding public documentation to new tenant setting: TeamsMultiTenantOrganizationConfiguration

The field CopilotFromHomeTenant Can either be Enabled/Disabled.
![image](https://github.com/user-attachments/assets/2ab23fa2-c702-4945-8c9e-12f236f12947)
