### PR TITLE
Update CsTeamsWorkLocationDetectionPolicy documentation

### DIFF
--- a/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Get-CsTeamsWorkLocationDetectionPolicy.md
@@ -39,19 +39,19 @@ PS C:\> Get-CsTeamsWorkLocationDetectionPolicy
 Identity            EnableWorkLocationDetection
 --------                 ----------------------
 Global                                     False
-Tag:wld-enabled                            True
-Tag:wld-disabled                           False
+Tag:wld-policy1                            True
+Tag:wld-policy2                           False
 ```
 Fetches all the policy instances currently available.
 
 ### Example 2
 ```powershell
-PS C:\> Get-CsTeamsWorkLocationDetectionPolicy -Identity wld-enabled
+PS C:\> Get-CsTeamsWorkLocationDetectionPolicy -Identity wld-policy1
 ```
 ```output
 Identity            EnableWorkLocationDetection
 --------                 ----------------------
-Tag:wld-enabled                            True
+Tag:wld-policy1                            True
 ```
 Fetches an instance of a policy with a known identity.
 
@@ -62,8 +62,8 @@ PS C:\> Get-CsTeamsWorkLocationDetectionPolicy -Filter *wld*
 ```output
 Identity            EnableWorkLocationDetection
 --------                 ----------------------
-Tag:wld-enabled                            True
-Tag:wld-disabled                          False
+Tag:wld-policy1                            True
+Tag:wld-policy2                           False
 ```
 The `Filter` parameter can be used to fetch policy instances based on partial matches on Identity.
 

--- a/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Grant-CsTeamsWorkLocationDetectionPolicy.md
@@ -46,28 +46,28 @@ Passes in the `Identity` of the policy instance in the `PolicyName` parameter an
 
 ### Example 1
 ```powershell
-PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -PolicyName sms-enabled -Identity testuser@test.onmicrosoft.com
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -PolicyName sms-policy -Identity testuser@test.onmicrosoft.com
 ```
 
 Assigns a given policy to a user.
 
 ### Example 2
 ```powershell
-PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Group f13d6c9d-ce76-422c-af78-b6018b4d9c80 -PolicyName wld-enabled
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Group f13d6c9d-ce76-422c-af78-b6018b4d9c80 -PolicyName wld-policy
 ```
 
 Assigns a given policy to a group.
 
 ### Example 3
 ```powershell
-PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Global -PolicyName wld-enabled
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Global -PolicyName wld-policy
 ```
 
 Assigns a given policy to the tenant.
 
 ### Example 3
 ```powershell
-PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Global -PolicyName wld-enabled
+PS C:\> Grant-CsTeamsWorkLocationDetectionPolicy -Global -PolicyName wld-policy
 ```
 
 Note: _Using $null in place of a policy name can be used to unassigned a policy instance._

--- a/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsWorkLocationDetectionPolicy.md
@@ -28,25 +28,25 @@ This gives users the ability to consent to the use of this location data to set 
 
 ### Example 1
 ```powershell
-PS C:\> New-CsTeamsWorkLocationDetectionPolicy -Identity wld-enabled -EnableWorkLocationDetection $true
+PS C:\> New-CsTeamsWorkLocationDetectionPolicy -Identity wld-policy -EnableWorkLocationDetection $true
 ```
 ```output
 Identity                 EnableWorkLocationDetection
 --------                 ----------------------
-Tag:wld-enabled                            True
+Tag:wld-policy                            True
 ```
 Creates a new policy instance with the identity wld-enabled. `EnableWorkLocationDetection` is set to the value specified in the command.
 
 ### Example 2
 ```powershell
-PS C:\> New-CsTeamsWorkLocationDetectionPolicy -Identity wld-disable
+PS C:\> New-CsTeamsWorkLocationDetectionPolicy -Identity wld-policy
 ```
 ```output
 Identity                 EnableWorkLocationDetection
 --------                 ----------------------
-Tag:wld-disable                            False
+Tag:wld-policy                            False
 ```
-Creates a new policy instance with the identity wld-disable. `EnableWorkLocationDetection` will default to false if it is not specified.
+Creates a new policy instance with the identity wld-policy. `EnableWorkLocationDetection` will default to false if it is not specified.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
+++ b/teams/teams-ps/teams/Remove-CsTeamsWorkLocationDetectionPolicy.md
@@ -29,10 +29,10 @@ Deletes an instance of TeamsWorkLocationDetectionPolicy. The `Identity` paramete
 
 ### Example 1
 ```powershell
-PS C:\>Remove-CsTeamsWorkLocationDetectionPolicy -Identity Foobar
+PS C:\>Remove-CsTeamsWorkLocationDetectionPolicy -Identity wld-policy
 ```
 
-Deletes a given policy instance with the Identity Foobar.
+Deletes a given policy instance with the Identity wld-policy.
 
 ## PARAMETERS
 


### PR DESCRIPTION
* Update New-CsTeamsWorkLocationDetectionPolicy.md
* Update Get-CsTeamsWorkLocationDetectionPolicy.md
* Update Remove-CsTeamsWorkLocationDetectionPolicy.md
* Update Grant-CsTeamsWorkLocationDetectionPolicy.md

Change policy identity name in examples for New and Get commands pages to a more generic one, change policy name in Remove and Grant command page to align it with the others. Feedback for the documentation suggested that some people might find it confusing and assign the meaning to the name. Having enabled/disabled as part of the name in examples might be perceived as directly connected to boolean value that the policy holds.