### PR TITLE
Switch 'UPN' to 'email address' in Remove-TeamChannelUser docs

### DIFF
--- a/exchange/docs-conceptual/index.yml
+++ b/exchange/docs-conceptual/index.yml
@@ -8,7 +8,6 @@ metadata:
   description: Learn about the PowerShell environments that are available in on-premises Exchange and Microsoft 365. # Required; article description that is displayed in search results. < 160 chars.
   services: exchange-online
   ms.service: exchange-online #Required; service per approved list. service slug assigned to your service by ACOM.
-  ms.subservice: subservice # Optional; Remove if no subservice is used.
   ms.topic: landing-page # Required
   ms.assetid: 9983a964-f642-4fcd-856b-452a172bcd4e
   manager: deniseb

--- a/exchange/docs-conceptual/index.yml
+++ b/exchange/docs-conceptual/index.yml
@@ -8,6 +8,7 @@ metadata:
   description: Learn about the PowerShell environments that are available in on-premises Exchange and Microsoft 365. # Required; article description that is displayed in search results. < 160 chars.
   services: exchange-online
   ms.service: exchange-online #Required; service per approved list. service slug assigned to your service by ACOM.
+  ms.subservice: subservice # Optional; Remove if no subservice is used.
   ms.topic: landing-page # Required
   ms.assetid: 9983a964-f642-4fcd-856b-452a172bcd4e
   manager: deniseb

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -65,7 +65,8 @@ Accept wildcard characters: False
 ```
 
 ### -User
-User's email (e.g. johndoe@example.com)
+User's email (e.g.
+johndoe@example.com)
 
 ```yaml
 Type: String

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -65,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -User
-User's email (e.g.
+User's email address (e.g.
 johndoe@example.com)
 
 ```yaml

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -8,11 +8,13 @@ schema: 2.0.0
 # Remove-TeamChannelUser
 
 ## SYNOPSIS
-Note: the command will return immediately, but the Teams application will not reflect the update immediately, please refresh the members page to see the update.
+> [!Note]
+> The command will return immediately, but the Teams application will not reflect the update immediately, please refresh the members page to see the update.
 
 To turn an existing Owner into a Member, specify role parameter as Owner.
 
-Note: last owner cannot be removed from the private channel.
+> [!Note] 
+> Last owner cannot be removed from the private channel.
 
 ## SYNTAX
 
@@ -23,7 +25,8 @@ Remove-TeamChannelUser -GroupId <String> -DisplayName <String> -User <String> [-
 
 ## DESCRIPTION
 
-Note: This cmdlet is part of the Public Preview version of Teams PowerShell Module, for more information see [Install Teams PowerShell public preview](https://learn.microsoft.com/microsoftteams/teams-powershell-install#install-teams-powershell-public-preview) and also see [Microsoft Teams PowerShell Release Notes](https://learn.microsoft.com/microsoftteams/teams-powershell-release-notes).
+> [!Note]
+> This cmdlet is part of the Public Preview version of Teams PowerShell Module, for more information see [Install Teams PowerShell public preview](https://learn.microsoft.com/microsoftteams/teams-powershell-install#install-teams-powershell-public-preview) and also see [Microsoft Teams PowerShell Release Notes](https://learn.microsoft.com/microsoftteams/teams-powershell-release-notes).
 
 ## EXAMPLES
 

--- a/teams/teams-ps/teams/Remove-TeamChannelUser.md
+++ b/teams/teams-ps/teams/Remove-TeamChannelUser.md
@@ -65,8 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -User
-User's UPN (user principal name - e.g.
-johndoe@example.com)
+User's email (e.g. johndoe@example.com)
 
 ```yaml
 Type: String


### PR DESCRIPTION
A change needs to be made to the documentation due to the following ICM: [Incident-559667947 Details - IcM](https://portal.microsofticm.com/imp/v5/incidents/details/559667947/summary)