### PR TITLE
Update documentation with new policy attribute usersCanDeleteBotMessages

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsMessagingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMessagingPolicy.md
@@ -55,6 +55,7 @@ New-CsTeamsMessagingPolicy [[-Identity] <XdsIdentity>]
  [-InOrganizationChatControl <String>]
  [-ReadReceiptsEnabledType <String>]
  [-Tenant <Guid>]
+ [-UsersCanDeleteBotMessages <Boolean>]
  [<CommonParameters>]
  [-WhatIf]
  ```
@@ -711,6 +712,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UsersCanDeleteBotMessages
+
+Determines whether a user is allowed to delete messages sent by bots. Set this to TRUE to allow. Set this to FALSE to prohibit.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/Set-CsTeamsGuestMessagingConfiguration.md
+++ b/teams/teams-ps/teams/Set-CsTeamsGuestMessagingConfiguration.md
@@ -21,7 +21,7 @@ TeamsGuestMessagingConfiguration determines the messaging settings for the guest
 ```
 Set-CsTeamsGuestMessagingConfiguration [-Tenant <Guid>] [-AllowUserEditMessage <Boolean>]
  [-AllowImmersiveReader <Boolean>] [-AllowUserDeleteMessage <Boolean>] [-AllowUserChat <Boolean>] [-AllowGiphy <Boolean>]
- [-AllowUserDeleteChat <Boolean>] [-GiphyRatingType <String>] [-AllowMemes <Boolean>] [-AllowStickers <Boolean>] [[-Identity] <XdsIdentity>]
+ [-AllowUserDeleteChat <Boolean>] [-GiphyRatingType <String>] [-AllowMemes <Boolean>] [-AllowStickers <Boolean>] [-UsersCanDeleteBotMessages <Boolean>] [[-Identity] <XdsIdentity>]
  [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -29,7 +29,7 @@ Set-CsTeamsGuestMessagingConfiguration [-Tenant <Guid>] [-AllowUserEditMessage <
 ```
 Set-CsTeamsGuestMessagingConfiguration [-Tenant <Guid>] [-AllowUserEditMessage <Boolean>]
  [-AllowImmersiveReader <Boolean>] [-AllowUserDeleteMessage <Boolean>] [-AllowUserChat <Boolean>] [-AllowGiphy <Boolean>]
- [-AllowUserDeleteChat <Boolean>] [-GiphyRatingType <String>] [-AllowMemes <Boolean>] [-AllowStickers <Boolean>] [-Instance <PSObject>] [-Force]
+ [-AllowUserDeleteChat <Boolean>] [-GiphyRatingType <String>] [-AllowMemes <Boolean>] [-AllowStickers <Boolean>] [-UsersCanDeleteBotMessages <Boolean>] [-Instance <PSObject>] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -133,6 +133,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UsersCanDeleteBotMessages
+Determines if a user is allowed to delete messages sent by bots.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/Set-CsTeamsGuestMessagingConfiguration.md
+++ b/teams/teams-ps/teams/Set-CsTeamsGuestMessagingConfiguration.md
@@ -138,7 +138,7 @@ Accept wildcard characters: False
 ```
 
 ### -UsersCanDeleteBotMessages
-Determines if a user is allowed to delete messages sent by bots.
+Determines whether a user is allowed to delete messages sent by bots. Set this to TRUE to allow. Set this to FALSE to prohibit.
 
 ```yaml
 Type: Boolean

--- a/teams/teams-ps/teams/Set-CsTeamsMessagingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMessagingPolicy.md
@@ -55,6 +55,7 @@ Set-CsTeamsMessagingPolicy [[-Identity] <XdsIdentity>]
  [-InOrganizationChatControl <String>]
  [-ReadReceiptsEnabledType <String>]
  [-Tenant <Guid>]
+ [-UsersCanDeleteBotMessages <Boolean>]
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -100,6 +101,7 @@ Set-CsTeamsMessagingPolicy [-Instance <PSObject>]
  [-InOrganizationChatControl <String>]
  [-ReadReceiptsEnabledType <String>]
  [-Tenant <Guid>]
+ [-UsersCanDeleteBotMessages <Boolean>]
  [-WhatIf]
  [<CommonParameters>]
 ```
@@ -765,6 +767,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UsersCanDeleteBotMessages
+Determines whether a user is allowed to delete messages sent by bots. Set this to TRUE to allow. Set this to FALSE to prohibit.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Update TeamsMessagingPolicy as well as TeamsGuestMessagingConfiguration with new attribute UsersCanDeleteBotMessages.

This is a boolean property to provide admins with additional control on whether a message sent by bot can be deleted in any scope.