### PR TITLE
Update -Identity Parameter for SetExternal

### DIFF
--- a/exchange/exchange-ps/exchange/Set-ExternalInOutlook.md
+++ b/exchange/exchange-ps/exchange/Set-ExternalInOutlook.md
@@ -58,7 +58,7 @@ This example adds and removes the specified email addresses from the exception l
 ## PARAMETERS
 
 ### -Identity
-The Identity parameter specifies the GUID of the external sender identification object that you want to modify. Although this parameter is available, you don't need to use it.
+The Identity parameter specifies the GUID of the external sender identification object that you want to modify. This parameter is optional and typically not needed as the organization's GUID is resolved automatically. If an invalid identity is provided, the cmdlet will still execute and change the settings for the entire organization. Always verify the identity value before execution.
 
 ```yaml
 Type: OrganizationIdParameter

--- a/exchange/exchange-ps/exchange/Set-ExternalInOutlook.md
+++ b/exchange/exchange-ps/exchange/Set-ExternalInOutlook.md
@@ -58,7 +58,11 @@ This example adds and removes the specified email addresses from the exception l
 ## PARAMETERS
 
 ### -Identity
-The Identity parameter specifies the GUID of the external sender identification object that you want to modify. This parameter is optional and typically not needed as the organization's GUID is resolved automatically. If an invalid identity is provided, the cmdlet will still execute and change the settings for the entire organization. Always verify the identity value before execution.
+The Identity parameter specifies the GUID of the external sender identification object that you want to modify.
+
+This parameter is optional and typically isn't needed, because the organization's GUID resolves automatically when you use this cmdlet.
+
+If you specify an invalid Identity value, the cmdlet still runs and changes the settings for the entire organization. Always verify the Identity value before you run this cmdlet.
 
 ```yaml
 Type: OrganizationIdParameter


### PR DESCRIPTION
The -Identity parameter for Set-ExternalInOutlook is optional and generally not required as the original documentation indicates, but recent instances of customer feedback have indicated some of the potentially unexpected side effects of passing it. 

In cases where the identity is not resolved or a specific user GUID is passed, the command will execute without error and act on the organization as a whole derived from the admin's identity. This changes makes this behavior more clear. Not that other cmdlets such as  Set-IRMConfiguration also exhibit this behavior, though we are not aware of similar feedback on those ones yet (nor am I in a position of knowledge on them). 

@chrisda could you please review?