### PR TITLE
add info re: licensing as this appears to  not function with P2.

### DIFF
--- a/exchange/exchange-ps/exchange/New-ProtectionAlert.md
+++ b/exchange/exchange-ps/exchange/New-ProtectionAlert.md
@@ -14,9 +14,15 @@ ms.reviewer:
 ## SYNOPSIS
 This cmdlet is available only in Security & Compliance PowerShell. For more information, see [Security & Compliance PowerShell](https://learn.microsoft.com/powershell/exchange/scc-powershell).
 
-Use the New-ProtectionAlert cmdlet to create alert policies in the Microsoft Purview compliance portal. Alert policies contain conditions that define the user activities to monitor, and the notification options for email alerts and entries in the Microsoft Purview compliance portal.
+Use the New-ProtectionAlert cmdlet to create alert policies in the Microsoft Purview compliance portal and the Microsoft Defender portal. Alert policies contain conditions that define the user activities to monitor, and the notification options for email alerts and entries.
 
-This cmdlet will not work without Enterprise licenses (including P2) - input will be accepted, but it will return that an Enterprise license is required. Because Default alert policies cannot be edited with PowerShell, Alert Policies cannot be managed by PowerShell with P1/P2 licenses - [only Enterprise/Government licenses](https://learn.microsoft.com/en-us/purview/alert-policies)
+> [!NOTE]
+> Although the cmdlet is available, you receive the following error if you don't have an enterprise license:
+>
+> _Creating advanced alert policies requires an Office 365 E5 subscription or Office 365 E3 subscription with an Office 365 Threat Intelligence or
+Office 365 EquivioAnalytics add-on subscription for your organization. With your current subscription, only single event alerts can be created._
+>
+> For more information, see [Alert policies in Microsoft 365](https://learn.microsoft.com/purview/alert-policies).
 
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://learn.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 

--- a/exchange/exchange-ps/exchange/New-ProtectionAlert.md
+++ b/exchange/exchange-ps/exchange/New-ProtectionAlert.md
@@ -16,6 +16,8 @@ This cmdlet is available only in Security & Compliance PowerShell. For more info
 
 Use the New-ProtectionAlert cmdlet to create alert policies in the Microsoft Purview compliance portal. Alert policies contain conditions that define the user activities to monitor, and the notification options for email alerts and entries in the Microsoft Purview compliance portal.
 
+This cmdlet will not work without Enterprise licenses (including P2) - input will be accepted, but it will return that an Enterprise license is required. Because Default alert policies cannot be edited with PowerShell, Alert Policies cannot be managed by PowerShell with P1/P2 licenses - [only Enterprise/Government licenses](https://learn.microsoft.com/en-us/purview/alert-policies)
+
 For information about the parameter sets in the Syntax section below, see [Exchange cmdlet syntax](https://learn.microsoft.com/powershell/exchange/exchange-cmdlet-syntax).
 
 ## SYNTAX


### PR DESCRIPTION
Have been trying to add a user to Quarantine Release notifs - but have unfortunately learned that Set doesn't  work on Defaults, and New only works with Enterprise. So that's a bummer. Adding to doc for transparency, I wasted too much time on this.