### PR TITLE
Update Get-MessageTrackingReport.md

### DIFF
--- a/exchange/exchange-ps/exchange/Get-MessageTrackingReport.md
+++ b/exchange/exchange-ps/exchange/Get-MessageTrackingReport.md
@@ -48,7 +48,9 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 ```powershell
 $Temp = Search-MessageTrackingReport -Identity "David Jones" -Recipients "wendy@contoso.com"
 
-Get-MessageTrackingReport -Identity $Temp.MessageTrackingReportID -ReportTemplate Summary
+foreach ($reportId in $Temp.MessageTrackingReportId) {
+    Get-MessageTrackingReport -Identity $reportId -ReportTemplate Summary -Status Delivered
+}
 ```
 
 This example gets the message tracking report for messages sent from one user to another. This example returns the summary of the message tracking report for a message that David Jones sent to Wendy Richardson.


### PR DESCRIPTION
When you do something like:


$Temp = Search-MessageTrackingReport -Identity "Jane" -Recipients John@contoso.com -TraceLevel High

You are storing several instances in the $Temp variable (which means $Temp is essentially a collection). 

When running this next command:

Get-MessageTrackingReport -Identity $Temp.MessageTrackingReportID -ReportTemplate Summary -Status Delivered

You're providing multiple MessageTrackingReportIds at once—but this particular cmdlet expects just one identity at a time. 

Hence, you receive an error saying PowerShell couldn't transform an ArrayList into an expected single identity.

Solution:

Handle this using a loop, iterating over each MessageTrackingReportId one-by-one. Here's an easy method:

# Loop through each MessageTrackingReportId stored in $Temp and retrieve detailed tracking report summary

foreach ($reportId in $Temp.MessageTrackingReportId) {
    Get-MessageTrackingReport -Identity $reportId -ReportTemplate Summary -Status Delivered
}