### PR TITLE
Updating Set/New-InboxRule to specify the mailbox the inbox rule will be created in.

### DIFF
--- a/exchange/exchange-ps/exchange/New-InboxRule.md
+++ b/exchange/exchange-ps/exchange/New-InboxRule.md
@@ -122,7 +122,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-New-InboxRule "CheckActionRequired" -MyNameInToBox $true -FlaggedForAction Any -MarkImportance "High"
+New-InboxRule -Mailbox chris@contoso.com -Name "CheckActionRequired" -MyNameInToBox $true -FlaggedForAction Any -MarkImportance "High"
 ```
 
 This example raises the message importance to High if the mailbox owner is in the To field. In addition, the message is flagged for action.

--- a/exchange/exchange-ps/exchange/Set-InboxRule.md
+++ b/exchange/exchange-ps/exchange/Set-InboxRule.md
@@ -105,7 +105,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Set-InboxRule ProjectContoso -MarkImportance "High"
+Set-InboxRule -Mailbox chris@contoso.com -Name ProjectContoso -MarkImportance "High"
 ```
 
 This example modifies the action of the existing Inbox rule ProjectContoso. The MarkImportance parameter is used to mark the message with high importance.


### PR DESCRIPTION
Specifying the -Name parameter, as is the parameter is implied. Not ideal for those learning PowerShell.

Adding -Mailbox since the cmdlet creates the inbox rules in the specified mailbox. If the mailbox isn't specified the inbox rule is created in the admin's mailbox who is running the cmdlet. Again, not ideal for those learning PowerShell.