### PR TITLE
Update New-CsTeamsAIPolicy.md

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsAIPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsAIPolicy.md
@@ -20,14 +20,14 @@ This cmdlet creates a Teams AI policy.
 New-CsTeamsAIPolicy -Identity <String> 
  [-EnrollFace <string>]
  [-EnrollVoice <string>]
- [-SpeakerAttributionBYOD <string>]
+ [-SpeakerAttributionForBYOD <string>]
  [-Description <string>]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The new csTeamsAIPolicy will replace the existing enrollment settings in csTeamsMeetingPolicy, providing enhanced flexibility and control for Teams meeting administrators. Unlike the current single setting, EnrollUserOverride, which applies to both face and voice enrollment, the new policy introduces two distinct settings: EnrollFace and EnrollVoice. These can be individually set to Enabled or Disabled, offering more granular control over biometric enrollments. A new setting, SpeakerAttributionBYOD, is also being added to csTeamsAIPolicy. This allows IT admins to turn off speaker attribution in BYOD scenarios, giving them greater control over how voice data is managed in such environments. This setting can be set to Enabled or Disabled, and will be Enabled by default. In addition to improving the management of face and voice data, the csTeamsAIPolicy is designed to support future AI-related settings in Teams, making it a scalable solution for evolving needs.
+The new csTeamsAIPolicy will replace the existing enrollment settings in csTeamsMeetingPolicy, providing enhanced flexibility and control for Teams meeting administrators. Unlike the current single setting, EnrollUserOverride, which applies to both face and voice enrollment, the new policy introduces two distinct settings: EnrollFace and EnrollVoice. These can be individually set to Enabled or Disabled, offering more granular control over biometric enrollments. A new setting, SpeakerAttributionForBYOD, is also being added to csTeamsAIPolicy. This allows IT admins to turn off speaker attribution in BYOD scenarios, giving them greater control over how voice data is managed in such environments. This setting can be set to Enabled or Disabled, and will be Enabled by default. In addition to improving the management of face and voice data, the csTeamsAIPolicy is designed to support future AI-related settings in Teams, making it a scalable solution for evolving needs.
 
 This cmdlet creates a Teams AI policy. If you get an error that the policy already exists, it means that the policy already exists for your tenant. In this case, run Get-CsTeamsAIPolicy.
 
@@ -87,8 +87,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SpeakerAttributionBYOD
-Policy value of the Teams AI SpeakerAttributionBYOD policy. Setting to "Enabled" turns on speaker attribution in BYOD scenarios while "Disabled" will turn off the function. 
+### -SpeakerAttributionForBYOD
+Policy value of the Teams AI SpeakerAttributionForBYOD policy. Setting to "Enabled" turns on speaker attribution in BYOD scenarios while "Disabled" will turn off the function. 
 
 ```yaml
 Type: String


### PR DESCRIPTION
According to the PowerShell Release Notes, "SpeakerAttributionBYOD" is incorrect; the actual value is "SpeakerAttributionForBYOD"

https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-release-notes  Adds SpeakerAttributionForBYOD parameter to [New|Set]-CsTeamsAIPolicy.