### PR TITLE
Update default value for the policy VoiceSimulationInInterpreter

### DIFF
--- a/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsCallingPolicy.md
@@ -665,7 +665,7 @@ Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: Disabled
+Default value: Enabled
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/New-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/New-CsTeamsMeetingPolicy.md
@@ -168,9 +168,6 @@ Accept wildcard characters: False
 ```
 
 ### -AIInterpreter
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Enables the user to use the AI Interpreter related features
 
 Possible values:
@@ -1772,10 +1769,6 @@ Accept wildcard characters: False
 ```
 
 ### -VoiceSimulationInInterpreter
-
-> [!NOTE]
-> This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Enables the user to use the voice simulation feature while being AI interpreted.
 
 Possible Values:
@@ -1791,7 +1784,7 @@ Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: Disabled
+Default value: Enabled
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsCallingPolicy.md
@@ -669,7 +669,7 @@ Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: Disabled
+Default value: Enabled
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/teams/Set-CsTeamsMeetingPolicy.md
@@ -125,7 +125,7 @@ Set-CsTeamsMeetingPolicy [[-Identity] <XdsIdentity>]
  [-WatermarkForScreenSharingPattern <String>]
  [-AllowedUsersForMeetingDetails <String>]
  [-RealTimeText <String>]
- [-ParticipantSlideControl <String>
+ [-ParticipantSlideControl <String>]
  [-WhatIf]
  [-WhoCanRegister <String>]
  [<CommonParameters>]
@@ -184,9 +184,6 @@ Accept wildcard characters: False
 ```
 
 ### -AIInterpreter
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Enables the user to use the AI Interpreter related features
 
 Possible values:
@@ -1834,10 +1831,6 @@ Accept wildcard characters: False
 ```
 
 ### -VoiceSimulationInInterpreter
-
-> [!NOTE]
-> This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Enables the user to use the voice simulation feature while being AI interpreted.
 
 Possible Values:
@@ -1853,7 +1846,7 @@ Applicable: Microsoft Teams
 
 Required: False
 Position: Named
-Default value: Disabled
+Default value: Enabled
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
1. AI Interpreter is now enabled in public for meeting scenario.
2. The default value of meeting/calling policy VoiceSimulationInInterpreter is changed from Diabled to **Enabled**