### PR TITLE
Update SamAccountName description

### DIFF
--- a/exchange/exchange-ps/exchange/New-DistributionGroup.md
+++ b/exchange/exchange-ps/exchange/New-DistributionGroup.md
@@ -602,7 +602,7 @@ Accept wildcard characters: False
 ### -SamAccountName
 This parameter is available only in on-premises Exchange.
 
-The SamAccountName parameter (also known as the pre-Windows 2000 user account or group name) specifies an object identifier that's compatible with older versions of Microsoft Windows client and server operating systems. The value can contain letters, numbers, spaces, periods (.), and the following characters: !, #, $, %, ^, &, -, \_, {, }, and ~. The last character can't be a period. Unicode characters are allowed, but accented characters may generate collisions (for example, o and ö match). The maximum length is 20 characters.
+The SamAccountName parameter (also known as the pre-Windows 2000 user account or group name) specifies an object identifier that's compatible with older versions of Microsoft Windows client and server operating systems. The value can contain letters, numbers, spaces, periods (.), and the following characters: !, #, $, %, ^, &, -, \_, {, }, and ~. The last character can't be a period. Unicode characters are allowed, but accented characters may generate collisions (for example, o and ö match).
 
 ```yaml
 Type: String

--- a/exchange/exchange-ps/exchange/Set-DistributionGroup.md
+++ b/exchange/exchange-ps/exchange/Set-DistributionGroup.md
@@ -1547,7 +1547,7 @@ Accept wildcard characters: False
 ### -SamAccountName
 This parameter is available only in on-premises Exchange.
 
-The SamAccountName parameter (also known as the pre-Windows 2000 user account or group name) specifies an object identifier that's compatible with older versions of Microsoft Windows client and server operating systems. The value can contain letters, numbers, spaces, periods (.), and the following characters: !, #, $, %, ^, &, -, \_, {, }, and ~. The last character can't be a period. Unicode characters are allowed, but accented characters may generate collisions (for example, o and ö match). The maximum length is 20 characters.
+The SamAccountName parameter (also known as the pre-Windows 2000 user account or group name) specifies an object identifier that's compatible with older versions of Microsoft Windows client and server operating systems. The value can contain letters, numbers, spaces, periods (.), and the following characters: !, #, $, %, ^, &, -, \_, {, }, and ~. The last character can't be a period. Unicode characters are allowed, but accented characters may generate collisions (for example, o and ö match).
 
 ```yaml
 Type: String


### PR DESCRIPTION
The explanation "The maximum length is 20 characters." has been removed. 

This explanation applies to user objects (New-Mailbox), and it is possible to set a SamAccountName longer than 20 characters for group objects. In fact, in Exchange Server 2016 and 2019, you can create groups with a SamAccountName longer than 20 characters using the New-DistributionGroup. (New-Mailbox will fail with an error.)