### PR TITLE
Update Set-PublicFolder.md - Clarification - Age Limit

### DIFF
--- a/exchange/exchange-ps/exchange/Set-PublicFolder.md
+++ b/exchange/exchange-ps/exchange/Set-PublicFolder.md
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 ```
 
 ### -AgeLimit
-The AgeLimit parameter specifies the overall age limit on the folder. Items that reach the age limit are deleted from the Public Folder. Replicas of this public folder are automatically deleted when the age limit is exceeded.
+The AgeLimit parameter specifies the overall age limit on the folder. Items that reach the age limit are deleted from the public folder. Replicas of this public folder are automatically deleted when the age limit is exceeded.
 
 To specify a value, enter it as a time span: dd.hh:mm:ss where dd = days, hh = hours, mm = minutes, and ss = seconds.
 


### PR DESCRIPTION
Clarifying that AgeLimit does not only impact the replica behavior, but primarily affects the items in the folder. The replica information, while good to know, is not how a majority of sysadmins will be utilizing this parameter.