### PR TITLE
Update RealTimeText documentation in TeamsMeetingPolicy and TeamsCallingPolicy

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsCallingPolicy.md
@@ -684,9 +684,6 @@ Accept wildcard characters: False
 
 > Applicable: Microsoft Teams
 
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Allows users to use real time text during a call, allowing them to communicate by typing their messages in real time.
 
 Possible Values:

--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsMeetingPolicy.md
@@ -1602,9 +1602,6 @@ Accept wildcard characters: False
 
 > Applicable: Microsoft Teams
 
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Allows users to use real time text during a meeting, allowing them to communicate by typing their messages in real time.
 
 Possible Values:

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsCallingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsCallingPolicy.md
@@ -687,9 +687,6 @@ Accept wildcard characters: False
 
 > Applicable: Microsoft Teams
 
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Allows users to use real time text during a call, allowing them to communicate by typing their messages in real time.
 
 Possible Values:

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
@@ -1655,9 +1655,6 @@ Accept wildcard characters: False
 
 > Applicable: Microsoft Teams
 
->[!NOTE]
->This feature has not been released yet and will have no changes if it is enabled or disabled.
-
 Allows users to use real time text during a meeting, allowing them to communicate by typing their messages in real time.
 
 Possible Values:


### PR DESCRIPTION
Real time text feature is fully released, so remove "NOTE: This feature has not been released yet and will have no changes if it is enabled or disabled."