### PR TITLE
Update Add-AvailabilityAddressSpace to clarify configurations for relationships between online tenants

### DIFF
--- a/exchange/exchange-ps/ExchangePowerShell/Add-AvailabilityAddressSpace.md
+++ b/exchange/exchange-ps/ExchangePowerShell/Add-AvailabilityAddressSpace.md
@@ -81,8 +81,8 @@ In Exchange Online, this example sets up the sharing of free/busy information wi
 The AccessMethod parameter specifies how the free/busy data is accessed. Valid values are:
 
 - PerUserFB: Per-user free/busy information can be requested. The free/busy data is accessed in the defined per-user free/busy proxy account or group, or in the All Exchange Servers group. This value requires a trust between the two forests, and requires you to use either the UseServiceAccount parameter or Credentials parameter.
-- OrgWideFB: Only default free/busy for each user can be requested. The free/busy data is accessed in the per-user free/busy proxy account or group in the target forest. This value requires you to use either the UseServiceAccount parameter or Credentials parameter.
-- OrgWideFBBasic: Free/busy sharing between tenants that are all in Exchange Online.
+- OrgWideFB: Only the default free/busy for each user can be requested. The free/busy data is accessed in the per-user free/busy proxy account or group in the target forest. This value requires you to use either the UseServiceAccount parameter or Credentials parameter. This is deprecated for accessing target forests in Exchange Online.
+- OrgWideFBToken: Used for free/busy sharing between two tenants in Exchange Online. Only the default free/busy for each user can be requested. This option also requires you to set both TargetTenantId and TargetServiceEpr.
 - InternalProxy: The request is proxied to an Exchange server in the site that's running a later version of Exchange.
 - PublicFolder: This value was used to access free/busy data on Exchange Server 2003 servers.
 
@@ -221,7 +221,7 @@ Accept wildcard characters: False
 
 > Applicable: Exchange Online, Exchange Online Protection
 
-This parameter is available only in the cloud-based service.
+This parameter is available only in the cloud-based service and is only used when AccessMethod is OrgWideFBToken.
 
 The TargetServiceEpr parameter specifies the Exchange Online Calendar Service URL of the external Microsoft 365 organization that you're trying to read free/busy information from. Valid values are:
 
@@ -245,7 +245,7 @@ Accept wildcard characters: False
 
 > Applicable: Exchange Online, Exchange Online Protection
 
-This parameter is available only in the cloud-based service.
+This parameter is available only in the cloud-based service and is only used when AccessMethod is OrgWideFBToken.
 
 The TargetTenantID parameter specifies the tenant ID of the external Microsoft 365 organization that you're trying to read free/busy information from.
 


### PR DESCRIPTION
Removes -AccessMethod OrgWideFBBasic which was deprecated some time ago when basic auth was deprecated in Exchange Online.

Clarifies that -AccessMethod OrgWideFB is deprecated for accessing target forests in Exchange Online.

Adds -AccessMethod OrgWideFBToken which is now the only way to establish AvailabilityAddressSpace for Freebusy sharing across two tenants in Exchange Online.

Clarifies that -AccessMethod OrgWideFBToken also requires TargetTenantId and TargetServiceEpr for a successful configuration.