### PR TITLE
Update maximum entries and size for SetExternalinOutlook

### DIFF
--- a/exchange/exchange-ps/ExchangePowerShell/Set-ExternalInOutlook.md
+++ b/exchange/exchange-ps/ExchangePowerShell/Set-ExternalInOutlook.md
@@ -94,7 +94,7 @@ To add or remove one or more values without affecting any existing entries, use 
 
 This parameter is meaningful only when the value of the Enabled parameter is $true.
 
-The maximum number of entries is 50, and the total size of all entries can't exceed one kilobyte.
+The maximum number of entries is 200, and the total size of all entries can't exceed eight kilobytes.
 
 ```yaml
 Type: MultiValuedProperty


### PR DESCRIPTION
We are rolling out changes to expand the limits for the number of entries on the SetExternalinOutlook exclusion list to 200 entries and 8Kb. This change is currently at 50% WW and will complete it's rollout in the next couple days. 