### PR TITLE
Add TeamsRemoteLogCollection documentation

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionConfiguration.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionConfiguration.md
@@ -1,0 +1,81 @@
+---
+applicable: Microsoft Teams
+author: lakshmiroy
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+Locale: en-US
+manager: wayvad
+Module Name: MicrosoftTeams
+ms.author: lakshmiroy
+online version: https://learn.microsoft.com/powershell/module/skype/get-csTeamsRemoteLogCollectionConfiguration
+schema: 2.0.0
+title: Get-CsTeamsRemoteLogCollectionConfiguration
+---
+
+# Get-CsTeamsRemoteLogCollectionConfiguration
+
+## SYNOPSIS
+Returns list of devices for which remote log collection has been initiated for.
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsTeamsRemoteLogCollectionConfiguration [-Identity <Guid>]
+[<CommonParameters>]
+
+```
+
+## DESCRIPTION
+
+Remote log collection is a feature in Microsoft Teams that allows IT administrators to remotely trigger the collection of diagnostic logs from user devices through the Teams Admin Center (TAC). Instead of relying on manual user intervention, admins can initiate log collection for troubleshooting directly from the TAC portal. 
+
+TeamsRemoteLogCollectionConfiguration is updated with a list of devices when an administrator wants to initiate a request for remote log collection for a user's device. Each device has a unique GUID identity, userId, deviceId and expiry date.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> Get-CsTeamsRemoteLogCollectionConfiguration
+```
+
+The above cmdlet lists the devices of TeamsRemoteLogCollectionConfiguration.
+
+## PARAMETERS
+
+### -Identity
+{{Fill Identity Description}}
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## RELATED LINKS
+
+[Get-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionDevice)
+
+[Set-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice)
+
+[New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
+
+[Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
+
+[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionConfiguration.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionConfiguration.md
@@ -77,5 +77,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
 
 [Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
-
-[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionDevice.md
@@ -75,5 +75,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
 
 [Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
-
-[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsTeamsRemoteLogCollectionDevice.md
@@ -1,0 +1,79 @@
+---
+applicable: Microsoft Teams
+author: lakshmiroy
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+Locale: en-US
+manager: wayvad
+Module Name: MicrosoftTeams
+ms.author: lakshmiroy
+online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionDevice
+schema: 2.0.0
+title: Get-CsTeamsRemoteLogCollectionDevice
+---
+
+# Get-CsTeamsRemoteLogCollectionDevice
+
+## SYNOPSIS
+Returns a list of devices for which remote log collection has been initiated for.
+
+## SYNTAX
+
+### Identity (Default)
+```
+Get-CsTeamsRemoteLogCollectionDevice [[-Identity] <Guid>]
+[<CommonParameters>]
+```
+
+## DESCRIPTION
+Remote log collection is a feature in Microsoft Teams that allows IT administrators to remotely trigger the collection of diagnostic logs from user devices through the Teams Admin Center (TAC). Instead of relying on manual user intervention, admins can initiate log collection for troubleshooting directly from the TAC portal. 
+
+TeamsRemoteLogCollectionConfiguration is updated with a list of devices when an administrator wants to initiate a request for remote log collection for a user's device. Each device has a unique GUID identity, userId, deviceId and expiry date.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> Get-CsTeamsRemoteLogCollectionDevice
+```
+
+The above cmdlet lists all the devices of TeamsRemoteLogCollectionDevice.
+
+## PARAMETERS
+
+### -Identity
+The Identity parameter identifies the remote log collection configuration.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## RELATED LINKS
+
+[Get-CsTeamsRemoteLogCollectionConfiguration](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionConfiguration)
+
+[Set-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice)
+
+[New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
+
+[Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
+
+[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/MicrosoftTeams.md
+++ b/teams/teams-ps/MicrosoftTeams/MicrosoftTeams.md
@@ -266,7 +266,7 @@ This cmdlet supports retrieving all the policy packages available on a tenant.
 ### [Get-CsTeamsRemoteLogCollectionConfiguration](Get-CsTeamsRemoteLogCollectionConfiguration.md)
 This cmdlet displays all the devices added to the configuration for remote log collection.
 
-### [Get-CsTeamsRemoteLogCollectionConfiguration](Get-CsTeamsRemoteLogCollectionDevice.md)
+### [Get-CsTeamsRemoteLogCollectionDevice](Get-CsTeamsRemoteLogCollectionDevice.md)
 This cmdlet displays all the devices added to the configuration for remote log collection.
 
 ### [Get-CsSdgBulkSignInRequestsSummary](Get-CsSdgBulkSignInRequestsSummary.md)
@@ -875,7 +875,7 @@ Creates a new online voice route.
 ### [New-CsOnlineVoiceRoutingPolicy](New-CsOnlineVoiceRoutingPolicy.md)
 Creates a new online voice routing policy. Online voice routing policies manage online PSTN usages for Phone System users.
 
-### [New-CsTeamsRemoteLogCollectionConfiguration](New-CsTeamsRemoteLogCollectionDevice.md)
+### [New-CsTeamsRemoteLogCollectionDevice](New-CsTeamsRemoteLogCollectionDevice.md)
 This cmdlet creates a request for remote log collection for a device.
 
 ### [New-CsSdgBulkSignInRequest](New-CsSdgBulkSignInRequest.md)
@@ -1175,7 +1175,7 @@ This cmdlet will remove/unassign a phone number from a user or a resource accoun
 ### [Remove-CsPhoneNumberTag](Remove-CsPhoneNumberTag.md)
 This cmdlet allows admin to remove a tag from phone number.
 
-### [Remove-CsTeamsRemoteLogCollectionConfiguration](Remove-CsTeamsRemoteLogCollectionDevice.md)
+### [Remove-CsTeamsRemoteLogCollectionDevice](Remove-CsTeamsRemoteLogCollectionDevice.md)
 This cmdlet will remove/delete a device from the remote log collection configuration.
 
 ### [Remove-CsSharedCallQueueHistoryTemplate](Remove-CsSharedCallQueueHistoryTemplate.md)
@@ -1490,7 +1490,7 @@ This cmdlet assigns a policy to a specific telephone number in Microsoft Teams.
 ### [Set-CsPhoneNumberTag](Set-CsPhoneNumberTag.md)
 This cmdlet allows the admin to create and assign a tag to a phone number.
 
-### [Set-CsTeamsRemoteLogCollectionConfiguration](Set-CsTeamsRemoteLogCollectionDevice.md)
+### [Set-CsTeamsRemoteLogCollectionDevice](Set-CsTeamsRemoteLogCollectionDevice.md)
 This cmdlet allows the admin to create and edit a device requested for remote log collection.
 
 ### [Set-CsSharedCallQueueHistoryTemplate](Set-CsSharedCallQueueHistoryTemplate.md)

--- a/teams/teams-ps/MicrosoftTeams/MicrosoftTeams.md
+++ b/teams/teams-ps/MicrosoftTeams/MicrosoftTeams.md
@@ -263,6 +263,12 @@ This cmdlet allows the admin to get a list of existing tags for telephone number
 ### [Get-CsPolicyPackage](Get-CsPolicyPackage.md)
 This cmdlet supports retrieving all the policy packages available on a tenant.
 
+### [Get-CsTeamsRemoteLogCollectionConfiguration](Get-CsTeamsRemoteLogCollectionConfiguration.md)
+This cmdlet displays all the devices added to the configuration for remote log collection.
+
+### [Get-CsTeamsRemoteLogCollectionConfiguration](Get-CsTeamsRemoteLogCollectionDevice.md)
+This cmdlet displays all the devices added to the configuration for remote log collection.
+
 ### [Get-CsSdgBulkSignInRequestsSummary](Get-CsSdgBulkSignInRequestsSummary.md)
 Get the tenant level summary of all bulk sign in requests executed in the past 30 days.
 
@@ -869,6 +875,9 @@ Creates a new online voice route.
 ### [New-CsOnlineVoiceRoutingPolicy](New-CsOnlineVoiceRoutingPolicy.md)
 Creates a new online voice routing policy. Online voice routing policies manage online PSTN usages for Phone System users.
 
+### [New-CsTeamsRemoteLogCollectionConfiguration](New-CsTeamsRemoteLogCollectionDevice.md)
+This cmdlet creates a request for remote log collection for a device.
+
 ### [New-CsSdgBulkSignInRequest](New-CsSdgBulkSignInRequest.md)
 Use the New-CsSdgBulkSignInRequest cmdlet to sign in a batch of up to 100 devices.
 
@@ -1165,6 +1174,9 @@ This cmdlet will remove/unassign a phone number from a user or a resource accoun
 
 ### [Remove-CsPhoneNumberTag](Remove-CsPhoneNumberTag.md)
 This cmdlet allows admin to remove a tag from phone number.
+
+### [Remove-CsTeamsRemoteLogCollectionConfiguration](Remove-CsTeamsRemoteLogCollectionDevice.md)
+This cmdlet will remove/delete a device from the remote log collection configuration.
 
 ### [Remove-CsSharedCallQueueHistoryTemplate](Remove-CsSharedCallQueueHistoryTemplate.md)
 ```powershell Remove-CsSharedCallQueueHistoryTemplate -Id <String> [<CommonParameters>] ```
@@ -1477,6 +1489,9 @@ This cmdlet assigns a policy to a specific telephone number in Microsoft Teams.
 
 ### [Set-CsPhoneNumberTag](Set-CsPhoneNumberTag.md)
 This cmdlet allows the admin to create and assign a tag to a phone number.
+
+### [Set-CsTeamsRemoteLogCollectionConfiguration](Set-CsTeamsRemoteLogCollectionDevice.md)
+This cmdlet allows the admin to create and edit a device requested for remote log collection.
 
 ### [Set-CsSharedCallQueueHistoryTemplate](Set-CsSharedCallQueueHistoryTemplate.md)
 ```powershell Set-CsSharedCallQueueHistoryTemplate -Instance <instance> [<CommonParameters>] ```

--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsRemoteLogCollectionDevice.md
@@ -166,5 +166,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Set-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice)
 
 [Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
-
-[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsRemoteLogCollectionDevice.md
@@ -1,0 +1,170 @@
+---
+applicable: Microsoft Teams
+author: lakshmiroy
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+Locale: en-US
+manager: wayvad
+Module Name: MicrosoftTeams
+ms.author: lakshmiroy
+online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice
+schema: 2.0.0
+title: New-CsTeamsRemoteLogCollectionDevice
+
+---
+
+# New-CsTeamsRemoteLogCollectionDevice
+
+## SYNOPSIS
+
+This cmdlet allows you to create a new TeamsRemoteLogCollectionDevice instance and set it's properties.
+
+## SYNTAX
+
+```powershell
+New-CsTeamsRemoteLogCollectionDevice [-Identity <Guid>] [-UserId <String>]
+ [-DeviceId <String>] [-ExpireAfter <String>] [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet allows you to create a TeamsRemoteLogCollectionDevice instance. 
+
+Remote log collection is a feature in Microsoft Teams that allows IT administrators to remotely trigger the collection of diagnostic logs from user devices through the Teams Admin Center (TAC). Instead of relying on manual user intervention, admins can initiate log collection for troubleshooting directly from the TAC portal. 
+
+TeamsRemoteLogCollectionConfiguration is updated with a list of devices when an administrator wants to initiate a request for remote log collection for a user's device. Each device has a unique GUID identity, userId, deviceId and expiry date.
+
+## EXAMPLES
+
+Each Identity, userId and deviceId must be a valid GUID
+### Example 1
+```powershell
+PS C:\> New-CsTeamsRemoteLogCollectionDevice -UserId "765267a2-aa73-4984-a37e-43470f5e21a7" -DeviceId "765267a2-aa73-4984-a37e-43470f5e21a7" -ExpireAfter "06/07/2025 15:30:45"
+```
+
+Creates a new instance of TeamsRemoteLogCollectionDevice.
+
+## PARAMETERS
+
+### -UserId
+
+> Applicable: Microsoft Teams
+
+Indicates the userId of the user for which an admin is requesting logs for. This userId must be a valid GUID.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeviceId
+
+> Applicable: Microsoft Teams
+
+Indicates the deviceId of the device for which an admin is requesting logs for. This deviceId must be a valid GUID.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpireAfter
+
+> Applicable: Microsoft Teams
+
+Indicates the expiry date after which the remote log collection request will expire. This expire after date should be set to now() + 3 days. This expiry date should be in ISO 8601 UTC format.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+
+> Applicable: Microsoft Teams
+
+Policy instance name.
+
+```yaml
+Type: XdsIdentity
+Parameter Sets: (All)
+Aliases:
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-CsTeamsRemoteLogCollectionConfiguration](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionConfiguration)
+
+[Get-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionDevice)
+
+[Set-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice)
+
+[Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
+
+[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsTeamsRemoteLogCollectionDevice.md
@@ -1,0 +1,137 @@
+---
+applicable: Microsoft Teams
+author: lakshmiroy
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+Locale: en-US
+manager: wayvad
+Module Name: MicrosoftTeams
+ms.author: lakshmiroy
+online version: https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice
+schema: 2.0.0
+title: Remove-CsTeamsRemoteLogCollectionDevice
+---
+
+# Remove-CsTeamsRemoteLogCollectionDevice
+
+## SYNOPSIS
+Removes a device for which remote log collection was requested for.
+
+## SYNTAX
+
+```
+Remove-CsTeamsRemoteLogCollectionDevice [-Identity] <Guid>> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Deletes a previously created TeamsRemoteLogCollectionDevice. 
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-CsTeamsRemoteLogCollectionDevice -Identity
+```
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Suppresses all non-fatal errors.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+Unique identifier for the teams remote log collecton device to be removed. 
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+{{ Fill Tenant Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### Microsoft.Rtc.Management.Xds.XdsIdentity
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-CsTeamsRemoteLogCollectionConfiguration](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionConfiguration)
+
+[Get-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionDevice)
+
+[Set-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice)
+
+[New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
+
+[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsTeamsRemoteLogCollectionDevice.md
@@ -133,5 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Set-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice)
 
 [New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
-
-[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsRemoteLogCollectionDevice.md
@@ -162,5 +162,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
 
 [Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
-
-[Remote log collection](aka.ms/logcollection)

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsRemoteLogCollectionDevice.md
@@ -1,0 +1,166 @@
+---
+applicable: Microsoft Teams
+author: lakshmiroy
+external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
+Locale: en-US
+manager: wayvad
+Module Name: MicrosoftTeams
+ms.author: lakshmiroy
+online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csTeamsRemoteLogCollectionDevice
+schema: 2.0.0
+title: Set-CsTeamsRemoteLogCollectionDevice
+---
+
+# Set-CsTeamsRemoteLogCollectionDevice
+
+## SYNOPSIS
+
+This cmdlet allows you to edit the properties of an existing TeamsRemoteLogCollectionDevice instance.
+
+## SYNTAX
+
+```powershell
+Set-CsTeamsRemoteLogCollectionDevice [-Identity <Guid>] [-UserId <String>]
+ [-DeviceId <String>] [-ExpireAfter <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This cmdlet allows you to edit a TeamsRemoteLogCollectionDevice instance. 
+
+Remote log collection is a feature in Microsoft Teams that allows IT administrators to remotely trigger the collection of diagnostic logs from user devices through the Teams Admin Center (TAC). Instead of relying on manual user intervention, admins can initiate log collection for troubleshooting directly from the TAC portal. 
+
+TeamsRemoteLogCollectionConfiguration is updated with a list of devices when an administrator wants to initiate a request for remote log collection for a user's device. Each device has a unique GUID identity, userId, deviceId and expiry date.
+
+## EXAMPLES
+
+Each Identity, userId and deviceId must be a valid GUID
+
+### Example 
+In this example, the expiry date parameter is changed and set.
+```powershell
+PS C:\> New-CsTeamsRemoteLogCollectionDevice -ExpireAfter "06/07/2025 15:30:45"
+```
+
+## PARAMETERS
+
+### -UserId
+
+> Applicable: Microsoft Teams
+
+Indicates the userId of the user for which an admin is requesting logs for. This userId must be a valid GUID.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeviceId
+
+> Applicable: Microsoft Teams
+
+Indicates the deviceId of the device for which an admin is requesting logs for. This deviceId must be a valid GUID.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpireAfter
+
+> Applicable: Microsoft Teams
+
+Indicates the expiry date after which the remote log collection request will expire. This expire after date should be set to now() + 3 days. This expiry date should be in ISO 8601 UTC format.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Identity
+
+> Applicable: Microsoft Teams
+
+Policy instance name.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-CsTeamsRemoteLogCollectionConfiguration](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionConfiguration)
+
+[Get-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/get-csTeamsRemoteLogCollectionDevice)
+
+[New-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/new-csTeamsRemoteLogCollectionDevice)
+
+[Remove-CsTeamsRemoteLogCollectionDevice](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csTeamsRemoteLogCollectionDevice)
+
+[Remote log collection](aka.ms/logcollection)


### PR DESCRIPTION
This PR adds documentation for TeamsRemoteLogCollectionConfiguration parent cmdlet (Get-CsTeamsRemoteLogCollectionConfiguration) and child cmdlets (Get-CsTeamsRemoteLogCollectionDevice, Set-CsTeamsRemoteLogCollectionDevice, New-CsTeamsRemoteLogCollectionDevice, Remove-CsTeamsRemoteLogCollectionDevice)