### PR TITLE
Creating a new set of cmdlets for telephone number assignment blocking

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Get-CsPhoneNumberAssignment.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsPhoneNumberAssignment.md
@@ -710,6 +710,12 @@ The activation state of the telephone number.
 ### AssignedPstnTargetId
 The ID of the object the phone number is assigned to, either the ObjectId of a user or resource account or the policy instance ID of a Teams shared calling routing policy instance.
 
+### AssignmentBlockedState
+The state of the number in terms of blocked assignment: NotBlocked if there is no assignment block on the number, BlockedForever if assignment is blocked indefinitely for the number, BlockedUntil if assignment is blocked for a specific amount of days (limited time assignment block currently not available).
+
+### AssignmentBlockedUntil
+The date until which assignment is blocked for the phone number. Null if the number is blocked for assignment indefinitely.
+
 ### AssignmentCategory
 Contains the assignment category such as Primary or Private.
 

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsPhoneNumberAssignment.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsPhoneNumberAssignment.md
@@ -20,7 +20,7 @@ This cmdlet will remove/unassign a phone number from a user or a resource accoun
 ### RemoveSome (Default)
 ```
 Remove-CsPhoneNumberAssignment -Identity <String> -PhoneNumber <String> -PhoneNumberType <String>
- [-HttpPipelinePrepend <SendAsyncStep[]>] [-Notify] [<CommonParameters>]
+ [-HttpPipelinePrepend <SendAsyncStep[]>] [-Notify] [-AssignmentBlockedForever] [-AssignmentBlockedDays <Integer>] [<CommonParameters>]
 ```
 
 ### RemoveAll
@@ -67,6 +67,18 @@ This example removes/unassigns the Microsoft Calling Plan phone number +1 (206) 
 Remove-CsPhoneNumberAssignment -Identity user2@contoso.com -RemoveAll -Notify
 ```
 This example removes/unassigns all the telephone number from user2@contoso.com and also sends an email notification to the user about the change.
+
+### Example 5
+```powershell
+Remove-CsPhoneNumberAssignment -Identity user1@contoso.com -PhoneNumber +12065551234 -AssignmentBlockedForever
+```
+This example removes/unassigns the telephone number from user1@contoso.com and also sets an assignment block on the number for an indefinite duration.
+
+### Example 6
+```powershell
+Remove-CsPhoneNumberAssignment -Identity user1@contoso.com -PhoneNumber +12065551234 -AssignmentBlockedDays 30
+```
+This example removes/unassigns the telephone number from user1@contoso.com and also sets an assignment block on the number for 30 days. ***This feature is currently not available.***
 
 ## PARAMETERS
 
@@ -151,6 +163,36 @@ Sends a best-effort email notification when a phone number is removed. Failures 
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AssignmentBlockedForever
+Sets an assignment block for the phone number for an indefinite duration.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AssignmentBlockedDays (Not yet supported)
+Sets an assignment block for the phone number for a specifed number of days. The value must be a valid integer between 1 and 365. ***This feature is currently not available.***
+
+```yaml
+Type: Integer
 Parameter Sets: (All)
 Aliases:
 

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsPhoneNumberAssignmentBlock.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsPhoneNumberAssignmentBlock.md
@@ -1,0 +1,67 @@
+---
+external help file: Microsoft.Teams.ConfigAPI.Cmdlets-help.xml
+Module Name: Microsoft.Teams.ConfigAPI.Cmdlets
+online version: https://learn.microsoft.com/powershell/module/teams/remove-csphonenumberassignmentblock
+applicable: Microsoft Teams
+title: Remove-CsPhoneNumberAssignmentBlock
+author: pavellatif
+ms.author: pavellatif
+ms.reviewer: pavellatif
+manager: roykuntz
+schema: 2.0.0
+---
+
+# Remove-CsPhoneNumberAssignmentBlock
+
+## SYNOPSIS
+This cmdlet allows the admin to remove an assignment block on a telephone number.
+
+## SYNTAX
+```
+Remove-CsPhoneNumberAssignmentBlock -TelephoneNumber <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet allows telephone number administrators to remove an existing assignment block on a telephone number.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-CsPhoneNumberAssignmentBlock -TelephoneNumber +123456789
+```
+
+The above example shows how to remove the assignment block on a +123456789 number.
+
+## PARAMETERS
+
+### -TelephoneNumber
+Indicates the phone number for the assignment block be removed from.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS

--- a/teams/teams-ps/MicrosoftTeams/Set-CsPhoneNumberAssignmentBlock.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsPhoneNumberAssignmentBlock.md
@@ -1,0 +1,109 @@
+---
+external help file: Microsoft.Teams.ConfigAPI.Cmdlets-help.xml
+Module Name: Microsoft.Teams.ConfigAPI.Cmdlets
+online version: https://learn.microsoft.com/powershell/module/teams/set-csphonenumberassignmentblock
+applicable: Microsoft Teams
+title: Set-CsPhoneNumberAssignmentBlock
+author: pavellatif
+ms.author: pavellatif
+ms.reviewer: pavellatif
+manager: roykuntz
+schema: 2.0.0
+---
+
+# Set-CsPhoneNumberAssignmentBlock
+
+## SYNOPSIS
+This cmdlet allows the admin to create and assign a temporary block on telephone number assignment to selected telephone number.
+
+## SYNTAX
+
+```
+Set-CsPhoneNumberAssignmentBlock -TelephoneNumber <String> [-AssignmentBlockedForever] [-AssignmentBlockedDays <Integer>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This cmdlet allows the teams phone administrators to create and assign a temporary block on telephone number assignment to selected telephone number. There are two ways to create the assignment block:
+1. Assignment is blocked until cleared. This can be set by -AssignmentBlockedForever parameter. Once set, the telephone number will remain unassignable until the block is cleared by an admin.
+2. Assignment is blocked for a set number of days. This can be achieved by setting -AssignmentBlockedDays parameter (this value must be a valid integer between 1 and 365 days). Once set, the telephone number will remain unassignable until the time runs out or the block is cleared by an admin. ***The -AssignmentBlockedDays parameter is currently not available***. 
+
+ The admin **cannot** set both -AssignmentBlockedForever and -AssignmentBlockedDays for the same number. If there is an existing assignment block on the number, the admin must remove the existing block using [Remove-CsPhoneNumberAssignmentBlock](https://learn.microsoft.com/powershell/module/teams/remove-csphonenumberassignmentblock) before proceeding with setting the new assignment block.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-CsPhoneNumberAssignmentBlock -TelephoneNumber +123456789 -AssignmentBlockedForever
+```
+
+The above example shows how to set an indefinite assignment block to a +123456789 number.
+
+### Example 2
+```powershell
+PS C:\> Set-CsPhoneNumberAssignmentBlock -TelephoneNumber +123456789 -AssignmentBlockedDays 30
+```
+
+The above example shows how to set an assignment block to a +123456789 number for 30 days. ***This feature is currently not available.***
+
+## PARAMETERS
+
+### -TelephoneNumber
+Indicates the phone number for the assignment block to be assigned.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AssignmentBlockedForever
+Sets an indefinite block on assignment for the telephone number.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AssignmentBlockedDays
+Sets a duration based assignment block on the telephone number. ***This feature is currently not available.***
+
+```yaml
+Type: System.Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
These cmdlets allows a Teams Phone Admin to set assignment blocking on any telephone number.