### PR TITLE
Add "PickUpHeldCalls" and "JoinActiveCalls" info on UserCallingDelegate related CMDLETs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
-}

--- a/teams/teams-ps/MicrosoftTeams/Get-CsUserCallingSettings.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsUserCallingSettings.md
@@ -148,10 +148,12 @@ GroupNotificationOverride : Ring
 (Get-CsUserCallingSettings -Identity user7@contoso.com).Delegates
 ```
 ```output
-Id             : sip:user8@contoso.com
-MakeCalls      : True
-ManageSettings : True
-ReceiveCalls   : True
+Id              : sip:user8@contoso.com
+MakeCalls       : True
+ManageSettings  : True
+ReceiveCalls    : True
+PickUpHeldCalls : True
+JoinActiveCalls : True
 ```
 
 This example shows that user7@contoso.com has simultaneous ringing set to his/her delegates (ForwardingTargetType). User8@contoso.com is the only delegate
@@ -182,10 +184,12 @@ GroupNotificationOverride : Ring
 (Get-CsUserCallingSettings -Identity user9@contoso.com).Delegators
 ```
 ```output
-Id             : sip:user10@contoso.com
-MakeCalls      : True
-ManageSettings : True
-ReceiveCalls   : True
+Id              : sip:user10@contoso.com
+MakeCalls       : True
+ManageSettings  : True
+ReceiveCalls    : True
+PickUpHeldCalls : True
+JoinActiveCalls : True
 ```
 
 This example shows that user9@contoso.com is a delegate of user10@contoso.com (Delegators) and that user10@contoso.com has given user9@contoso.com all the

--- a/teams/teams-ps/MicrosoftTeams/New-CsUserCallingDelegate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsUserCallingDelegate.md
@@ -19,7 +19,7 @@ This cmdlet will add a new delegate for calling in Microsoft Teams.
 
 ```
 New-CsUserCallingDelegate -Identity <String> -Delegate <String> -MakeCalls <Boolean> -ManageSettings <Boolean>
- -ReceiveCalls <Boolean> [-HttpPipelinePrepend <SendAsyncStep[]>] [<CommonParameters>]
+ -ReceiveCalls <Boolean> -PickUpHeldCalls <Boolean> -JoinActiveCalls <Boolean> [-HttpPipelinePrepend <SendAsyncStep[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,7 +29,7 @@ This cmdlet adds a new delegate with given permissions for the specified user.
 
 ### Example 1
 ```powershell
-New-CsUserCallingDelegate -Identity user1@contoso.com -Delegate user2@contoso.com -MakeCalls $true -ReceiveCalls $true -ManageSettings $true
+New-CsUserCallingDelegate -Identity user1@contoso.com -Delegate user2@contoso.com -MakeCalls $true -ReceiveCalls $true -ManageSettings $true -PickUpHeldCalls $true -JoinActiveCalls $true
 ```
 
 ## PARAMETERS
@@ -116,6 +116,44 @@ Accept wildcard characters: False
 ### -ReceiveCalls
 
 Specifies whether delegate is allowed to receive calls on behalf of the specified user.
+
+```yaml
+Type: System.Boolean
+Parameter Sets: All
+Aliases:
+
+Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PickUpHeldCalls
+
+Specifies whether delegate is allowed to pick up calls on behalf of the specified user.
+
+>[!NOTE]
+>This parameter is currently in development and changing it does not change the behavior of the User Delegate.
+
+```yaml
+Type: System.Boolean
+Parameter Sets: All
+Aliases:
+
+Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JoinActiveCalls
+
+Specifies whether delegate is allowed to join active calls on behalf of the specified user.
+
+>[!NOTE]
+>This parameter is currently in development and changing it does not change the behavior of the User Delegate.
 
 ```yaml
 Type: System.Boolean

--- a/teams/teams-ps/MicrosoftTeams/New-CsUserCallingDelegate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsUserCallingDelegate.md
@@ -19,7 +19,7 @@ This cmdlet will add a new delegate for calling in Microsoft Teams.
 
 ```
 New-CsUserCallingDelegate -Identity <String> -Delegate <String> -MakeCalls <Boolean> -ManageSettings <Boolean>
- -ReceiveCalls <Boolean> -PickUpHeldCalls <Boolean> -JoinActiveCalls <Boolean> [-HttpPipelinePrepend <SendAsyncStep[]>] [<CommonParameters>]
+ -ReceiveCalls <Boolean> -PickUpHeldCalls <Boolean> -JoinActiveCalls <Boolean> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,21 +45,6 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -HttpPipelinePrepend
-{{ Fill HttpPipelinePrepend Description }}
-
-```yaml
-Type: Microsoft.Teams.ConfigAPI.Cmdlets.Generated.Runtime.SendAsyncStep[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/teams/teams-ps/MicrosoftTeams/Set-CsUserCallingDelegate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsUserCallingDelegate.md
@@ -19,7 +19,7 @@ This cmdlet will change permissions for a delegate for calling in Microsoft Team
 
 ```
 Set-CsUserCallingDelegate -Identity <String> -Delegate <String> [-MakeCalls <Boolean>]
- [-ManageSettings <Boolean>] [-ReceiveCalls <Boolean>] [-HttpPipelinePrepend <SendAsyncStep[]>]
+ [-ManageSettings <Boolean>] [-ReceiveCalls <Boolean>] [-PickUpHeldCalls <Boolean>] [-JoinActiveCalls <Boolean>] [-HttpPipelinePrepend <SendAsyncStep[]>]
  [<CommonParameters>]
 ```
 
@@ -30,7 +30,7 @@ This cmdlet can change the permissions assigned to a delegate for the specified 
 
 ### Example 1
 ```powershell
-Set-CsUserCallingDelegate -Identity user1@contoso.com -Delegate user2@contoso.com -MakeCalls $false -ReceiveCalls $true -ManageSettings $false
+Set-CsUserCallingDelegate -Identity user1@contoso.com -Delegate user2@contoso.com -MakeCalls $false -ReceiveCalls $true -ManageSettings $false -PickUpHeldCalls $true -JoinActiveCalls $true
 ```
 This example shows setting the permissions for user1@contoso.com's delegate user2@contoso.com.
 
@@ -129,6 +129,44 @@ Specifies whether delegate is allowed to receive calls on behalf of the specifie
 ```yaml
 Type: System.Boolean
 Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PickUpHeldCalls
+
+Specifies whether delegate is allowed to pick up calls on behalf of the specified user.
+
+>[!NOTE]
+>This parameter is currently in development and changing it does not change the behavior of the User Delegate.
+
+```yaml
+Type: System.Boolean
+Parameter Sets: All
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JoinActiveCalls
+
+Specifies whether delegate is allowed to join active calls on behalf of the specified user.
+
+>[!NOTE]
+>This parameter is currently in development and changing it does not change the behavior of the User Delegate.
+
+```yaml
+Type: System.Boolean
+Parameter Sets: All
 Aliases:
 
 Required: False

--- a/teams/teams-ps/MicrosoftTeams/Set-CsUserCallingDelegate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsUserCallingDelegate.md
@@ -19,8 +19,7 @@ This cmdlet will change permissions for a delegate for calling in Microsoft Team
 
 ```
 Set-CsUserCallingDelegate -Identity <String> -Delegate <String> [-MakeCalls <Boolean>]
- [-ManageSettings <Boolean>] [-ReceiveCalls <Boolean>] [-PickUpHeldCalls <Boolean>] [-JoinActiveCalls <Boolean>] [-HttpPipelinePrepend <SendAsyncStep[]>]
- [<CommonParameters>]
+ [-ManageSettings <Boolean>] [-ReceiveCalls <Boolean>] [-PickUpHeldCalls <Boolean>] [-JoinActiveCalls <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,21 +53,6 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -HttpPipelinePrepend
-{{ Fill HttpPipelinePrepend Description }}
-
-```yaml
-Type: Microsoft.Teams.ConfigAPI.Cmdlets.Generated.Runtime.SendAsyncStep[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
We are adding new parameters to New-CsUserCallingDelegate and Set-CsUserCallingDelegate with a "note" saying it is still under development since we haven't fully rolled them out.

Once we roll out the changes we will remove this note.

In addition we improved the examples in Get-CsUserVallindSettings to show these two new parameters.

We are also removing -HttpPipelinePrepend parameter doc since this is an internal parameter.