### PR TITLE
Fix TMP error for Remote Log Collection documentation

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsRemoteLogCollectionDevice.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsRemoteLogCollectionDevice.md
@@ -35,13 +35,12 @@ TeamsRemoteLogCollectionConfiguration is updated with a list of devices when an 
 
 ## EXAMPLES
 
-Each Identity, userId and deviceId must be a valid GUID
 ### Example 1
 ```powershell
 PS C:\> New-CsTeamsRemoteLogCollectionDevice -UserId "765267a2-aa73-4984-a37e-43470f5e21a7" -DeviceId "765267a2-aa73-4984-a37e-43470f5e21a7" -ExpireAfter "06/07/2025 15:30:45"
 ```
 
-Creates a new instance of TeamsRemoteLogCollectionDevice.
+Creates a new instance of TeamsRemoteLogCollectionDevice. Each Identity, userId and deviceId must be a valid GUID.
 
 ## PARAMETERS
 


### PR DESCRIPTION
This PR fixes an error causing TMP pipeline errors by removing an unexpected text below the Examples header.
https://dev.azure.com/skype/SBS/_build/results?buildId=72931803&view=logs&j=8515a029-22a6-5510-9e17-f5665af94c87&t=e14103c0-b8a4-5bd1-f3db-b1a3a894b46e&l=209