### PR TITLE
Revise Get-TenantPrivateChannelMigrationStatus to adhere to schema

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Get-TenantPrivateChannelMigrationStatus.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-TenantPrivateChannelMigrationStatus.md
@@ -30,11 +30,11 @@ The `Get-TenantPrivateChannelMigrationStatus` cmdlet allows tenant administrator
 
 ### Example 1
 
+This example gets the migration status for a tenant where all channels have been migrated.
+
 ```powershell
 Get-TenantPrivateChannelMigrationStatus
 ```
-
-This example gets the migration status for a tenant where all channels have been migrated.
 
 ```Output
 TenantId                     : 12345678-1234-1234-1234-123456789abc
@@ -46,11 +46,11 @@ Details                      : {"totalChannels":10,"migratedChannels":10,"failed
 
 ### Example 2
 
+This example gets the migration status for a tenant where some channels require admin attention.
+
 ```powershell
 Get-TenantPrivateChannelMigrationStatus
 ```
-
-This example gets the migration status for a tenant where some channels require admin attention.
 
 ```Output
 TenantId                     : 94d200e4-2df1-45b9-bc3e-53cfa7cf4997
@@ -62,14 +62,14 @@ Details                      : {"totalChannels":10,"migratedChannels":6,"failedC
 
 ### Example 3
 
+This example parses the Details JSON and lists ownerless channels in a table.
+
 ```powershell
 $result = Get-TenantPrivateChannelMigrationStatus
 $details = $result.Details | ConvertFrom-Json
 Write-Host "Total: $($details.totalChannels), Migrated: $($details.migratedChannels), Failed: $($details.failedChannels), Ownerless: $($details.ownerlessChannels)"
 if ($details.ownerlessChannelsDetails) { $details.ownerlessChannelsDetails | Format-Table channelThreadId, teamId }
 ```
-
-This example parses the Details JSON and lists ownerless channels in a table.
 
 ## PARAMETERS
 

--- a/teams/teams-ps/MicrosoftTeams/Get-TenantPrivateChannelMigrationStatus.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-TenantPrivateChannelMigrationStatus.md
@@ -22,7 +22,7 @@ Get-TenantPrivateChannelMigrationStatus [<CommonParameters>]
 
 ## DESCRIPTION
 
-The `Get-TenantPrivateChannelMigrationStatus` cmdlet allows tenant administrators to track the status of the private channel migration for their Microsoft Teams organization. More details about the migration can be found [here](https://techcommunity.microsoft.com/blog/microsoftteamsblog/new-enhancements-in-private-channels-in-microsoft-teams-unlock-their-full-potent/4438767#)
+The `Get-TenantPrivateChannelMigrationStatus` cmdlet allows tenant administrators to track the status of the private channel migration for their Microsoft Teams organization. More details about the migration can be found in the Microsoft Teams blog in [New enhancements in Private Channels in Microsoft Teams unlock their full potentia](https://techcommunity.microsoft.com/blog/microsoftteamsblog/new-enhancements-in-private-channels-in-microsoft-teams-unlock-their-full-potent/4438767#).
 
 **Note:** This cmdlet requires tenant administrator permissions to execute.
 


### PR DESCRIPTION
After PR https://github.com/MicrosoftDocs/office-docs-powershell/pull/13541, the PowerShell build pipeline choked on the content, as identified in [Pipelines - Run 2.260504.1 logs](https://skype.visualstudio.com/SBS/_build/results?buildId=77615794&view=logs&j=8515a029-22a6-5510-9e17-f5665af94c87&t=db7825c4-9775-5e3f-45c3-db682c04e204&s=8ae4f91c-4458-5562-6de2-21d31ca24a26).

> WARNING: Error encountered: Schema exception. This can occur when there are multiple code blocks in one example. 

That actual problem is that the documentation pipeline for Teams uses the [old version](https://github.com/PowerShell/platyPS/blob/v1/docs/platyPS.schema.md) of [PlatyPS](https://learn.microsoft.com/en-us/powershell/utility-modules/platyps/overview?view=ps-modules&viewFallbackFrom=powershell-7.6), which requires that "Example" sections consist of the following:

```
### Example title

0 or more parapgraphs
1 or more code blocks
0 or more paragraphs
```
So, this PR moves the paragraphs that were between code blocks (and one paragraph that was at the end of "Example 3" instead of at the start, where it could describe the content) to the top of their respective sections.

I've also made a blind link explicit by naming the target.

@rohanbharadwaj @ashajoshidu