### PR TITLE
Mount-Database example identity parameter does not include servername

### DIFF
--- a/exchange/exchange-ps/ExchangePowerShell/Mount-Database.md
+++ b/exchange/exchange-ps/ExchangePowerShell/Mount-Database.md
@@ -37,7 +37,7 @@ You need to be assigned permissions before you can run this cmdlet. Although thi
 
 ### Example 1
 ```powershell
-Mount-Database -Identity ExchangeServer1.Contoso.com\MyDatabase
+Mount-Database -Identity MyDatabase
 ```
 
 This example mounts the database MyDatabase.


### PR DESCRIPTION
Updated the Mount-Database command example 
It does not include the server name

This is how it is in my lab:
<img width="963" height="290" alt="image" src="https://github.com/user-attachments/assets/6b61971f-6dca-4ba3-8908-b915208b6716" />
