### PR TITLE
Update Notes parameter description in documentation

### DIFF
--- a/exchange/exchange-ps/ExchangePowerShell/New-TenantAllowBlockListItems.md
+++ b/exchange/exchange-ps/ExchangePowerShell/New-TenantAllowBlockListItems.md
@@ -288,7 +288,7 @@ Accept wildcard characters: False
 
 > Applicable: Exchange Online, Security & Compliance, Built-in security add-on for on-premises mailboxes
 
-The Notes parameters specifies additional information about the object. If the value contains spaces, enclose the value in quotation marks (").
+The Notes parameters specifies additional information about the object. If the value contains spaces, enclose the value in quotation marks ("). If the value contains quotation marks, add a backslash (\) before the quotation mark.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Clarified handling of quotation marks in Notes parameter.

Based on ICM:
1. In my note section if I input not "note" into the Notes section it fails to save with a validation error
2. If instead in my notes section I escape the double quote (not \"note\") it will save successfully and with the double quote in the output