### PR TITLE
Update documents to better describe the SpeakerAttributionMode policy value

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
@@ -1820,14 +1820,14 @@ Accept wildcard characters: False
 ```
 
 ### -SpeakerAttributionMode
-Determines if users are identified in transcriptions and if they can change the value of the _Automatically identify me in meeting captions and transcripts_ setting.
+Determines if users are identified in captions and transcriptions (both persisted and non-persisted) and if they can change the value of the _Automatically identify me in meeting captions and transcripts_ setting.
 
 Possible values:
 
-- **Enabled**: Speakers are identified in meeting captions and transcripts.
-- **EnabledUserOverride**: By default, speakers are identified in meeting captions and transcripts. Users can override this setting and choose not to be identified in their Teams profile settings.
-- **DisabledUserOverride**: By default, speakers are not identified in meeting captions and transcripts. Users can override this setting and choose to be identified in their Teams profile settings.
-- **Disabled**: Speakers are not identified in meeting captions and transcripts.
+- **Enabled**: Speakers are identified in meeting captions and transcriptions.
+- **EnabledUserOverride**: By default, speakers are identified in meeting captions and transcriptions. Users can override this setting and choose not to be identified in their Teams profile settings.
+- **DisabledUserOverride**: By default, speakers are not identified in meeting captions and transcriptions. Users can override this setting and choose to be identified in their Teams profile settings.
+- **Disabled**: Speakers are not identified in meeting captions and transcriptions.
 
 ```yaml
 Type: String

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
@@ -1824,10 +1824,10 @@ Determines if users are identified in transcriptions and if they can change the 
 
 Possible values:
 
-- **Enabled**: Speakers are identified in transcription.
-- **EnabledUserOverride**: Speakers are identified in transcription. If enabled, users can override this setting and choose not to be identified in their Teams profile settings.
-- **DisabledUserOverride**: Speakers are not identified in transcription. If enabled, users can override this setting and choose to be identified in their Teams profile settings.
-- **Disabled**: Speakers are not identified in transcription.
+- **Enabled**: Speakers are identified in meeting captions and transcripts.
+- **EnabledUserOverride**: By default, speakers are identified in meeting captions and transcripts. Users can override this setting and choose not to be identified in their Teams profile settings.
+- **DisabledUserOverride**: By default, speakers are not identified in meeting captions and transcripts. Users can override this setting and choose to be identified in their Teams profile settings.
+- **Disabled**: Speakers are not identified in meeting captions and transcripts.
 
 ```yaml
 Type: String
@@ -1836,7 +1836,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: EnabledUserOverride
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
We are the owner of Teams transcription/captions feature.

We found that the current documentation of SpeakerAttributionMode may be confusing and I have updated the document to better reflect the followings:
* All setting values apply to captions and transcripts (including copilot-only transcript).
* The default value of this meeting policy is **EnabledUserOverride**. Users by default will be identified in transcripts and captions.

Please help review it. Thanks.