### PR TITLE
Bring inkcanvas-ps cmdlet .md files into build scope

### DIFF
--- a/inkcanvas/docfx.json
+++ b/inkcanvas/docfx.json
@@ -45,6 +45,14 @@
         "src": "inkcanvas-ps",
         "version": "inkcanvas-ps",
         "dest": "module/inkcanvas-ps"
+      },
+      {
+        "files": [
+          "**/*.md"
+        ],
+        "src": "virtual-folder",
+        "version": "inkcanvas-ps",
+        "dest": "module"
       }
     ],
     "resource": [


### PR DESCRIPTION
Adds a content block to `inkcanvas/docfx.json` mirroring the pattern already used in `teams/docfx.json` and `exchange/docfx.json`, so that cmdlet reference Markdown files under `inkcanvas/inkcanvas-ps/` (`InkCanvas/`, `InkCanvasAdmin/`) are part of the build scope.

This resolves the `link-out-of-scope` build warnings reported in #13563 for Markdown files in `inkcanvas/inkcanvas-ps/InkCanvasAdmin/`.

### Change
Added to the `build.content` array:

```json
{
  "files": ["**/*.md"],
  "src": "virtual-folder",
  "version": "inkcanvas-ps",
  "dest": "module"
}
```