### PR TITLE
Document EnableSearchOnlySession requirement for compliance search cmdlets in SCC PowerShell connection guide

### DIFF
--- a/exchange/docs-conceptual/connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/connect-to-scc-powershell.md
@@ -43,6 +43,18 @@ Import-Module ExchangeOnlineManagement
 > [!NOTE]
 > Connect commands likely fail if the profile path of the account that you used to connect contains special PowerShell characters (for example, `$`). The workaround is to connect using a different account that doesn't have special characters in the profile path.
 
+> [!IMPORTANT]
+> If you plan to run any of the compliance search cmdlets used for eDiscovery (for example, `New-ComplianceSearch`, `Start-ComplianceSearch`, `Get-ComplianceSearch`, `New-ComplianceSearchAction`), you must:
+>
+> - Use **version 3.9.0 or later** of the Exchange Online PowerShell module (released August 2025).
+> - Include the `-EnableSearchOnlySession` parameter on **Connect-IPPSSession**.
+>
+> For example: `Connect-IPPSSession -UserPrincipalName navin@contoso.onmicrosoft.com -EnableSearchOnlySession`
+>
+> If you connect without this parameter, compliance search cmdlets fail with an error similar to: *"Please close the current PowerShell session and open a new session using Connect-IPPSSession with the -EnableSearchOnlySession flag. This requires using ExchangeOnlineManagement v3.9.0 or higher."*
+>
+> You only need this parameter when running compliance search cmdlets. For all other Security & Compliance PowerShell tasks, omit it. For more information, see [Connect-IPPSSession](/powershell/module/exchangepowershell/connect-ippssession), [New-ComplianceSearch](/powershell/module/exchangepowershell/new-compliancesearch), and [Start-ComplianceSearch](/powershell/module/exchangepowershell/start-compliancesearch).
+
 The command that you need to run uses the following syntax:
 
 ```powershell

--- a/exchange/docs-conceptual/connect-to-scc-powershell.md
+++ b/exchange/docs-conceptual/connect-to-scc-powershell.md
@@ -1,6 +1,6 @@
 ---
 title: Connect to Security & Compliance PowerShell
-ms.date: 12/05/2025
+ms.date: 06/04/2026
 ms.audience: Admin
 ms.topic: article
 ms.reviewer:
@@ -41,24 +41,21 @@ Import-Module ExchangeOnlineManagement
 ## Step 2: Connect and authenticate
 
 > [!NOTE]
-> Connect commands likely fail if the profile path of the account that you used to connect contains special PowerShell characters (for example, `$`). The workaround is to connect using a different account that doesn't have special characters in the profile path.
-
-> [!IMPORTANT]
-> If you plan to run any of the compliance search cmdlets used for eDiscovery (for example, `New-ComplianceSearch`, `Start-ComplianceSearch`, `Get-ComplianceSearch`, `New-ComplianceSearchAction`), you must:
 >
-> - Use **version 3.9.0 or later** of the Exchange Online PowerShell module (released August 2025).
-> - Include the `-EnableSearchOnlySession` parameter on **Connect-IPPSSession**.
+> - Connect commands likely fail if the profile path of the account that you used to connect contains special PowerShell characters (for example, `$`). The workaround is to connect using a different account that doesn't have special characters in the profile path.
 >
-> For example: `Connect-IPPSSession -UserPrincipalName navin@contoso.onmicrosoft.com -EnableSearchOnlySession`
+> - If you plan on running eDiscovery cmdlets (**\*-ComplianceSearch** or **New-ComplianceSearchAction**), the connection must meet the following requirements:
+>   - Version 3.9.0 (August 2025) or later of the Exchange Online PowerShell module.
+>   - The connect command must include the _EnableSearchOnlySession_ switch.
 >
-> If you connect without this parameter, compliance search cmdlets fail with an error similar to: *"Please close the current PowerShell session and open a new session using Connect-IPPSSession with the -EnableSearchOnlySession flag. This requires using ExchangeOnlineManagement v3.9.0 or higher."*
+>     If your Security & Compliance PowerShell connection doesn't meet these requirements, you receive the following error when you try to run eDiscovery cmdlets:
 >
-> You only need this parameter when running compliance search cmdlets. For all other Security & Compliance PowerShell tasks, omit it. For more information, see [Connect-IPPSSession](/powershell/module/exchangepowershell/connect-ippssession), [New-ComplianceSearch](/powershell/module/exchangepowershell/new-compliancesearch), and [Start-ComplianceSearch](/powershell/module/exchangepowershell/start-compliancesearch).
+>     `Please close the current PowerShell session and open a new session using Connect-IPPSSession with the -EnableSearchOnlySession flag. This requires using ExchangeOnlineManagement v3.9.0 or higher.`
 
 The command that you need to run uses the following syntax:
 
 ```powershell
-Connect-IPPSSession -UserPrincipalName <UPN> [-ConnectionUri <URL>] [-AzureADAuthorizationEndpointUri <URL>] [-DelegatedOrganization <String>] [-PSSessionOption $ProxyOptions]
+Connect-IPPSSession -UserPrincipalName <UPN> [-ConnectionUri <URL>] [-AzureADAuthorizationEndpointUri <URL>] [-DelegatedOrganization <String>] [-PSSessionOption $ProxyOptions] [-EnableSearchOnlySession]
 ```
 
 For detailed syntax and parameter information, see [Connect-IPPSSession](/powershell/module/exchangepowershell/connect-ippssession).


### PR DESCRIPTION
## Summary

Adds an `[!IMPORTANT]` callout to **Step 2: Connect and authenticate** in the [Connect to Security & Compliance PowerShell](https://learn.microsoft.com/powershell/exchange/connect-to-scc-powershell) guide, documenting the requirement (introduced August 2025 with ExchangeOnlineManagement v3.9.0) that running compliance search cmdlets needs `Connect-IPPSSession -EnableSearchOnlySession`.

## Why

The individual cmdlet reference pages (`New-ComplianceSearch`, `Start-ComplianceSearch`, `Connect-IPPSSession`) already mention this requirement, but the **connection how-to guide that customers actually use to learn how to connect** does not. As a result, admins follow the guide, connect successfully, then hit a runtime error the first time they try a search cmdlet — generating repeated support escalations.

Most recent example: **Microsoft Support escalation 21000001022683** (Sev 2, May 2026) — a customer attempted `New-ComplianceSearch` / `Start-ComplianceSearch` after their tenant was migrated to the new eDiscovery experience and received: *"Please close the current PowerShell session and open a new session using Connect-IPPSSession with the -EnableSearchOnlySession flag. This requires using ExchangeOnlineManagement v3.9.0 or higher."* The error message itself is excellent, but proactively documenting the requirement in the connection guide would have avoided the escalation entirely.

## What changed

One file: `exchange/docs-conceptual/connect-to-scc-powershell.md`

Added an `[!IMPORTANT]` block right after the existing `[!NOTE]` in Step 2 (before the syntax example) that:

- Lists the affected cmdlets (`New-/Get-/Start-/Set-/Remove-ComplianceSearch`, `*-ComplianceSearchAction`)
- States the v3.9.0 module requirement
- Provides a complete example command using `-EnableSearchOnlySession`
- Quotes the exact error message users see (so anyone searching for it lands here)
- Clarifies the flag is only needed for compliance search cmdlets, not all SCC PS tasks
- Cross-links to the three cmdlet reference pages

No other changes; existing examples and prose untouched.

## Validation

- Docs-only change; no behavior change.
- Markdown structure mirrors the existing `[!NOTE]` callout immediately above.
- Cmdlet list and version requirement (v3.9.0, Aug 2025) match what's already published on the [`New-ComplianceSearch`](https://learn.microsoft.com/powershell/module/exchangepowershell/new-compliancesearch) and [`Start-ComplianceSearch`](https://learn.microsoft.com/powershell/module/exchangepowershell/start-compliancesearch) reference pages.

cc page owners — happy to iterate on wording.
