### PR TITLE
Add missing docfx validation rules

### DIFF
--- a/exchange/docfx.json
+++ b/exchange/docfx.json
@@ -110,6 +110,38 @@
       }
     },
     "template": [],
-    "dest": "exchange-ps"
+    "dest": "exchange-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/inkcanvas/docfx.json
+++ b/inkcanvas/docfx.json
@@ -97,6 +97,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "inkcanvas-ps"
+    "dest": "inkcanvas-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/ms-commerce/docfx.json
+++ b/ms-commerce/docfx.json
@@ -57,6 +57,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "ms-commerce"
+    "dest": "ms-commerce",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/officewebapps/docfx.json
+++ b/officewebapps/docfx.json
@@ -94,6 +94,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "officewebapps-ps"
+    "dest": "officewebapps-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/skype/docfx.json
+++ b/skype/docfx.json
@@ -103,6 +103,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "skype-ps"
+    "dest": "skype-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/spmt/docfx.json
+++ b/spmt/docfx.json
@@ -94,6 +94,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "spmt-ps"
+    "dest": "spmt-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/teams/docfx.json
+++ b/teams/docfx.json
@@ -90,6 +90,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "teams-ps"
+    "dest": "teams-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }

--- a/whiteboard/docfx.json
+++ b/whiteboard/docfx.json
@@ -79,6 +79,38 @@
     ],
     "fileMetadata": {},
     "template": [],
-    "dest": "whiteboard-ps"
+    "dest": "whiteboard-ps",
+    "rules": {
+        "filename-incomplete": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        },
+        "image-name-incomplete": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "image-structure-incorrect": {
+            "exclude": [
+                "**/*.gif",
+                "**/*.jpeg",
+                "**/*.jpg",
+                "**/*.png",
+                "**/*.svg"
+            ]
+        },
+        "include-structure-incorrect": {
+            "exclude": [
+                "**/*.md",
+                "**/*.yml"
+            ]
+        }
+    }
   }
 }


### PR DESCRIPTION
This PR adds any missing docfx validation rules among the following four:

- `filename-incomplete`
- `image-name-incomplete`
- `image-structure-incorrect`
- `include-structure-incorrect`

The rules and their excludes mirror the configuration in `microsoft-365-docs-pr/microsoft-365/docfx.json`.