### PR TITLE
fix: mitigate command injection risk in background tasks workflow

### DIFF
--- a/.github/workflows/BackgroundTasks.yml
+++ b/.github/workflows/BackgroundTasks.yml
@@ -20,7 +20,7 @@ jobs:
           AccessToken: ${{ github.token }}
         run: |
           mkdir -p ./pr
-          echo $PayloadJson > ./pr/PayloadJson.json
+          printenv PayloadJson > ./pr/PayloadJson.json
           sed -i -e "s/$AccessToken/XYZ/g" ./pr/PayloadJson.json
       - uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
In the GitHub Actions workflow `BackgroundTasks.yml`, the `Save payload data` step expands the `PayloadJson` environment variable directly in a bash command via `echo $PayloadJson`. Because this workflow is triggered on `pull_request_target`, an external contributor can control properties within the `github` context (such as pull request titles, descriptions, or branch names). If any of these fields contain special characters like semicolons, backticks, or shell evaluation sequences, they are evaluated by the shell, leading to a command injection vulnerability. This is resolved by writing the environment variable directly using `printenv PayloadJson > ./pr/PayloadJson.json`, which avoids shell evaluation of the variable's contents.