### PR TITLE
Update New-HostedContentFilterPolicy.md

### DIFF
--- a/exchange/exchange-ps/ExchangePowerShell/New-HostedContentFilterPolicy.md
+++ b/exchange/exchange-ps/ExchangePowerShell/New-HostedContentFilterPolicy.md
@@ -1251,6 +1251,7 @@ The RedirectToRecipients parameter specifies the email addresses of replacement 
 - BulkSpamAction
 - HighConfidenceSpamAction
 - PhishSpamAction
+- HighConfidencePhishAction
 - SpamAction
 
 You can specify multiple email addresses separated by commas.


### PR DESCRIPTION
correction as per test results and https://learn.microsoft.com/en-us/defender-office-365/secure-by-default#:~:text=The%20Redirect%20message%20to%20email%20address%20action%20for%20high%20confidence%20phishing%20messages%20is%20unaffected.