### PR TITLE
Correct GPA-supported policy list in New-CsGroupPolicyAssignment (add Dialout, remove Emergency Call Routing)

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/New-CsGroupPolicyAssignment.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsGroupPolicyAssignment.md
@@ -30,7 +30,7 @@ New-CsGroupPolicyAssignment -GroupId <String> -PolicyType <String> -PolicyName <
 > - Teams Network Roaming Policy
 > - Teams Voice Applications Policy
 > - Teams Upgrade Policy
-> - Dialout Policy (outbound calling restriction policy)
+> - Dialout Policy
 >
 > This cmdlet will be deprecated in the future. Going forward, group policy assignment can be performed by using the corresponding Grant-Cs[PolicyType] cmdlet with the '-Group' parameter.
 

--- a/teams/teams-ps/MicrosoftTeams/New-CsGroupPolicyAssignment.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsGroupPolicyAssignment.md
@@ -28,9 +28,9 @@ New-CsGroupPolicyAssignment -GroupId <String> -PolicyType <String> -PolicyName <
 > As of May 2023, group policy assignment functionality in Teams PowerShell Module has been extended to support all policy types used in Teams except for the following:
 > - Teams App Permission Policy
 > - Teams Network Roaming Policy
-> - Teams Emergency Call Routing Policy
 > - Teams Voice Applications Policy
 > - Teams Upgrade Policy
+> - Dialout Policy (outbound calling restriction policy)
 >
 > This cmdlet will be deprecated in the future. Going forward, group policy assignment can be performed by using the corresponding Grant-Cs[PolicyType] cmdlet with the '-Group' parameter.
 


### PR DESCRIPTION
## Summary
Corrects the list of policy types that group policy assignment (GPA) does **not** support, in the `New-CsGroupPolicyAssignment` DESCRIPTION note.

## Changes
- **Add `Dialout Policy` (`OnlineDialOutPolicy`, the outbound calling restriction policy)** to the unsupported list. GPA does not support this policy type — it is absent from the accepted values of [Get-CsGroupPolicyAssignment](https://learn.microsoft.com/powershell/module/microsoftteams/get-csgrouppolicyassignment) `-PolicyType` while its sibling voice policies (`OnlineVoiceRoutingPolicy`, `OnlineVoicemailPolicy`, `OnlineAudioConferencingRoutingPolicy`, `TeamsSharedCallingRoutingPolicy`, `CallingLineIdentity`, `TenantDialPlan`) are all present. This aligns with the companion fix in `Grant-CsDialoutPolicy` (#13691).
- **Remove `Teams Emergency Call Routing Policy`** from the unsupported list. This policy is now supported for group policy assignment — `TeamsEmergencyCallRoutingPolicy` is an accepted value of `Get-CsGroupPolicyAssignment -PolicyType`. The exclusion dated from the original "As of May 2023" note and is stale.

## Net effect on the list
```diff
  > - Teams App Permission Policy
  > - Teams Network Roaming Policy
- > - Teams Emergency Call Routing Policy
  > - Teams Voice Applications Policy
  > - Teams Upgrade Policy
+ > - Dialout Policy
```
