### PR TITLE
Fix typo in shared call history documentation

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/New-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsSharedCallHistoryTemplate.md
@@ -92,7 +92,7 @@ Accept wildcard characters: False
 
 ### -IncomingRedirectedCalls
 
-Who sees AutoAttendant Shared Voicemails events in the shared call  history. 
+Who sees Auto Attendant Shared Voicemails events in the shared call history. 
 
 PARAMVALUE: None | AuthorizedUsersOnly | AuthorizedUsersAndGroupMembers
 


### PR DESCRIPTION
Corrected spacing in the description of Auto Attendant Shared Voicemails events.