### PR TITLE
Deprecate Get-CsSharedCallQueueHistoryTemplate

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallQueueHistoryTemplate.md
@@ -13,77 +13,21 @@ title: Get-CsSharedCallQueueHistoryTemplate
 # Get-CsSharedCallQueueHistoryTemplate
 
 ## SYNOPSIS
-This PowerShell cmdlet is being deprecated, please use the new version [Get-CsSharedCallHistoryTemplate](./Get-CsSharedCallHistoryTemplate.md) instead
 
-## SYNTAX
-
-```
-Get-CsSharedCallQueueHistoryTemplate [-Id <string>] [<CommonParameters>]
-```
-
-## DESCRIPTION
-Use the Get-CsSharedCallQueueHistory cmdlet to list the Shared Call Queue History templates.
-
-## EXAMPLES
-
-### Example 1
-```
-Get-CsSharedCallQueueHistoryTemplate -Id 3a4b3d9b-91d8-4fbf-bcff-6907f325842c
-```
-
-This example retrieves the Shared Call Queue History Template with the Id `3a4b3d9b-91d8-4fbf-bcff-6907f325842c`
-
-### Example 2
-```
-Get-CsSharedCallQueueHistoryTemplate
-```
-
-This example retrieves all the Shared Call Queue History Templates
-
-## PARAMETERS
-
-### -Id
-
-The Id of  the shared call queue history template.
-
-```yaml
-Type: System.String
-Parameter Sets: (All)
-Aliases:
-
-Required: false
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### Microsoft.Rtc.Management.OAA.Models.AutoAttendant
-
-## NOTES
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Get-CsSharedCallHistoryTemplate](./Get-CsSharedCallHistoryTemplate.md) instead
 
 ## RELATED LINKS
 
-[New-CsSharedCallQueueHistoryTemplate](./New-CsSharedCallQueueHistoryTemplate.md)
+[New-CsSharedCallHistoryTemplate](New-CsSharedCallHistoryTemplate.md)
 
-[Set-CsSharedCallQueueHistoryTemplate](./Set-CsSharedCallQueueHistoryTemplate.md)
+[Set-CsSharedCallHistoryTemplate](Set-CsSharedCallHistoryTemplate.md)
 
-[Remove-CsSharedCallQueueHistoryTemplate](./Remove-CsSharedCallQueueHistoryTemplate.md)
+[Remove-CsSharedCallHistoryTemplate](Remove-CsSharedCallHistoryTemplate.md)
 
-[Get-CsCallQueue](./Get-CsCallQueue.md)
+[Get-CsCallQueue](Get-CsCallQueue.md)
 
-[New-CsCallQueue](./New-CsCallQueue.md)
+[New-CsCallQueue](New-CsCallQueue.md)
 
-[Set-CsCallQueue](./Set-CsCallQueue.md)
+[Set-CsCallQueue](Set-CsCallQueue.md)
 
-[Remove-CsCallQueue](./Remove-CsCallQueue.md)
+[Remove-CsCallQueue](Remove-CsCallQueue.md)

--- a/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallQueueHistoryTemplate.md
@@ -14,7 +14,7 @@ title: Get-CsSharedCallQueueHistoryTemplate
 
 ## SYNOPSIS
 
->[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Get-CsSharedCallHistoryTemplate](./Get-CsSharedCallHistoryTemplate.md) instead
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Get-CsSharedCallHistoryTemplate](Get-CsSharedCallHistoryTemplate.md) instead
 
 ## RELATED LINKS
 

--- a/teams/teams-ps/MicrosoftTeams/New-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsSharedCallQueueHistoryTemplate.md
@@ -15,129 +15,24 @@ title: New-CsSharedCallQueueHistoryTemplate
 
 ## SYNOPSIS
 
-This PowerShell cmdlet is being deprecated, please use the new version [New-CsSharedCallHistoryTemplate](./New-CsSharedCallHistoryTemplate.md) instead
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [New-CsSharedCallHistoryTemplate](./New-CsSharedCallHistoryTemplate.md) instead
 
-> [!IMPORTANT]
->This PowerShell cmdlet is being deprecated, please use the new version [New-CsSharedCallHistoryTemplate](./New-CsSharedCallHistoryTemplate.md) instead
-
-## SYNTAX
-
-```
-New-CsSharedCallQueueHistoryTemplate -Name <String> -Description <String>
- [-IncomingMissedCalls <Object>] [-AnsweredAndOutboundCalls <Object>] [<CommonParameters>]
-```
-
-## DESCRIPTION
-Use the New-CsSharedCallQueueHistoryTemplate cmdlet to create a Shared Call Queue History template.
-
-## EXAMPLES
-
-### Example 1
-```
-New-CsSharedCallQueueHistoryTemplate -Name "Customer Service" -Description "Missed:All Answered:Auth" -IncomingMissedCall AuthorizedUsersAndAgents -AnsweredAndOutboundCalls AuthorizedUsersOnly
-```
-
-This example creates a new Shared CallQueue History template where incoming missed calls are shown to authorized users and agents and, answered and outbound calls are shown to authorized users only.
-
-## PARAMETERS
-
-### -AnsweredAndOutboundCalls
-
-Who sees answered and outbound calls in the shared call queue history.
-
-PARAMVALUE: None | AuthorizedUsersOnly | AuthorizedUsersAndAgents
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Description
-
-A description for the shared call queue history template.
-
-```yaml
-Type: System.String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -IncomingMissedCalls
-
-Who sees incoming missed calls in the shared call queue history.
-
-PARAMVALUE: None | AuthorizedUsersOnly | AuthorizedUsersAndAgents
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Name
-
-The name of the shared call queue history template.
-
-```yaml
-Type: System.String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### Microsoft.Rtc.Management.OAA.Models.AutoAttendant
-
-## NOTES
 
 ## RELATED LINKS
 
-[Get-CsSharedCallQueueHistoryTemplate](./Get-CsSharedCallQueueHistoryTemplate.md)
+[Get-CsSharedCallHistoryTemplate](Get-CsSharedCallHistoryTemplate.md)
 
-[Set-CsSharedCallQueueHistoryTemplate](./Set-CsSharedCallQueueHistoryTemplate.md)
+[Set-CsSharedCallHistoryTemplate](Set-CsSharedCallHistoryTemplate.md)
 
-[Remove-CsSharedCallQueueHistoryTemplate](./Remove-CsSharedCallQueueHistoryTemplate.md)
+[Remove-CsSharedCallHistoryTemplate](Remove-CsSharedCallHistoryTemplate.md)
 
-[New-CsCallQueue](./New-CsCallQueue.md)
+[New-CsCallQueue](New-CsCallQueue.md)
 
-[Get-CsCallQueue](./Get-CsCallQueue.md)
+[Get-CsCallQueue](Get-CsCallQueue.md)
 
-[Set-CsCallQueue](./Set-CsCallQueue.md)
+[Set-CsCallQueue](Set-CsCallQueue.md)
 
-[Remove-CsCallQueue](./Remove-CsCallQueue.md)
+[Remove-CsCallQueue](Remove-CsCallQueue.md)
 
 
 

--- a/teams/teams-ps/MicrosoftTeams/New-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsSharedCallQueueHistoryTemplate.md
@@ -15,7 +15,7 @@ title: New-CsSharedCallQueueHistoryTemplate
 
 ## SYNOPSIS
 
->[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [New-CsSharedCallHistoryTemplate](./New-CsSharedCallHistoryTemplate.md) instead
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [New-CsSharedCallHistoryTemplate](New-CsSharedCallHistoryTemplate.md) instead
 
 
 ## RELATED LINKS

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallHistoryTemplate.md
@@ -14,78 +14,29 @@ title: Remove-CsSharedCallHistoryTemplate
 # Remove-CsSharedCallHistoryTemplate
 
 ## SYNOPSIS
-Deletes a Shared Call  History template.
 
-## SYNTAX
-
-```
-Remove-CsSharedCallHistoryTemplate -Id <String> [<CommonParameters>]
-```
-
-## DESCRIPTION
-Use the Remove-CsSharedCallHistoryTemplate cmdlet to delete a Shared Call History template. 
-
-## EXAMPLES
-
-### Example 1
-```
-Remove-CsSharedCallHistoryTemplate -Id 5e3a575e-1faa-49ff-83c2-5cf1c36c0e01
-```
-
-This example deletes the Shared Call  History template with the identity 5e3a575e-1faa-49ff-83c2-5cf1c36c0e01. If no Shared Call  History template exists with the identity 5e3a575e-1faa-49ff-83c2-5cf1c36c0e01, then this example generates an error.
-
-## PARAMETERS
-
-### -Id
-
-The Id parameter is the unique identifier assigned to the Shared Call  History template.
-
-```yaml
-Type: System.String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### Microsoft.Rtc.Management.OAA.Models.AutoAttendant
-
-## NOTES
+>[!CAUTION] This 
 
 ## RELATED LINKS
 
-[New-CsSharedCallHistoryTemplate](./New-CsSharedCallHistoryTemplate.md)
+[New-CsSharedCallHistoryTemplate](New-CsSharedCallHistoryTemplate.md)
 
-[Set-CsSharedCallHistoryTemplate](./Set-CsSharedCallHistoryTemplate.md)
+[Set-CsSharedCallHistoryTemplate](Set-CsSharedCallHistoryTemplate.md)
 
-[Get-CsSharedCallHistoryTemplate](./Get-CsSharedCallHistoryTemplate.md)
+[Get-CsSharedCallHistoryTemplate](Get-CsSharedCallHistoryTemplate.md)
 
-[Get-CsCallQueue](./Get-CsCallQueue.md)
+[Get-CsCallQueue](Get-CsCallQueue.md)
 
-[New-CsCallQueue](./New-CsCallQueue.md)
+[New-CsCallQueue](New-CsCallQueue.md)
 
-[Set-CsCallQueue](./Set-CsCallQueue.md)
+[Set-CsCallQueue](Set-CsCallQueue.md)
 
-[Remove-CsCallQueue](./Remove-CsCallQueue.md)
+[Remove-CsCallQueue](Remove-CsCallQueue.md)
 
-[New-CsAutoAttendant](https://learn.microsoft.com/powershell/module/microsoftteams/new-csautoattendant)
+[New-CsAutoAttendant](new-csautoattendant.md)
 
-[Get-CsAutoAttendant](https://learn.microsoft.com/powershell/module/microsoftteams/get-csautoattendant)
+[Get-CsAutoAttendant](get-csautoattendant.md)
 
-[Set-CsAutoAttendant](https://learn.microsoft.com/powershell/module/microsoftteams/set-csautoattendant)
+[Set-CsAutoAttendant](set-csautoattendant.md)
 
-[Remove-CsAutoAttendant](https://learn.microsoft.com/powershell/module/microsoftteams/remove-csautoattendant)
+[Remove-CsAutoAttendant](remove-csautoattendant.md)

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallHistoryTemplate.md
@@ -15,7 +15,7 @@ title: Remove-CsSharedCallHistoryTemplate
 
 ## SYNOPSIS
 
->[!CAUTION] This 
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Remove-CsSharedCallHistoryTemplate](Remove-CsSharedCallHistoryTemplate.md) instead
 
 ## RELATED LINKS
 

--- a/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallQueueHistoryTemplate.md
@@ -15,7 +15,7 @@ title: Set-CsSharedCallQueueHistoryTemplate
 
 ## SYNOPSIS
 
->[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Set-CsSharedCallHistoryTemplate](./Set-CsSharedCallHistoryTemplate.md) instead
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Set-CsSharedCallHistoryTemplate](Set-CsSharedCallHistoryTemplate.md) instead
 
 ## RELATED LINKS
 

--- a/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallQueueHistoryTemplate.md
@@ -14,78 +14,24 @@ title: Set-CsSharedCallQueueHistoryTemplate
 # Set-CsSharedCallQueueHistoryTemplate
 
 ## SYNOPSIS
-This PowerShell cmdlet is being deprecated, please use the new version [Set-CsSharedCallHistoryTemplate](./Set-CsSharedCallHistoryTemplate.md) instead
 
-> [!IMPORTANT]
->This PowerShell cmdlet is being deprecated, please use the new version [Set-CsSharedCallHistoryTemplate](./Set-CsSharedCallHistoryTemplate.md) instead
-
-## SYNTAX
-
-```
-Set-CsSharedCallQueueHistoryTemplate -Instance <instance> [<CommonParameters>]
-```
-
-## DESCRIPTION
-Use the Set-SharedCallQueueHistoryTemplate cmdlet to change a Shared Call Queue History template.
-
-## EXAMPLES
-
-### Example 1
-```
-$SharedCQHistory = Get-CsSharedCallQueueHistoryTemplate -Id 66f0dc32-d344-4bb1-b524-027d4635515c
-$SharedCQHisotry.AnsweredAndOutboundCalls = "AuthorizedUsersAndAgents"
-Set-CsSharedCallQueueHistoryTemplate -Instance $SharedCQHistory
-```
-
-This example sets the AnsweredOutboundCalls value in the Shared Call History Template with the Id `66f0dc32-d344-4bb1-b524-027d4635515c`
-
-## PARAMETERS
-
-### -Instance
-
-The instance of the shared call queue history template to change.
-
-```yaml
-Type: System.String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### CommonParameters
-
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### Microsoft.Rtc.Management.OAA.Models.AutoAttendant
-
-## NOTES
+>[!CAUTION] This PowerShell cmdlet has been deprecated, please use the new version [Set-CsSharedCallHistoryTemplate](./Set-CsSharedCallHistoryTemplate.md) instead
 
 ## RELATED LINKS
 
-[New-CsSharedCallQueueHistoryTemplate](./New-CsSharedCallQueueHistoryTemplate.md)
+[New-CsSharedCallHistoryTemplate](./New-CsSharedCallHistoryTemplate.md)
 
-[Get-CsSharedCallQueueHistoryTemplate](./Get-CsSharedCallQueueHistoryTemplate.md)
+[Get-CsSharedCallHistoryTemplate](./Get-CsSharedCallHistoryTemplate.md)
 
-[Remove-CsSharedCallQueueHistoryTemplate](./Remove-CsSharedCallQueueHistoryTemplate.md)
+[Remove-CsSharedCallHistoryTemplate](./Remove-CsSharedCallHistoryTemplate.md)
 
-[Get-CsCallQueue](./Get-CsCallQueue.md)
+[Get-CsCallQueue](Get-CsCallQueue.md)
 
-[New-CsCallQueue](./New-CsCallQueue.md)
+[New-CsCallQueue](New-CsCallQueue.md)
 
-[Set-CsCallQueue](./Set-CsCallQueue.md)
+[Set-CsCallQueue](Set-CsCallQueue.md)
 
-[Remove-CsCallQueue](./Remove-CsCallQueue.md)
+[Remove-CsCallQueue](Remove-CsCallQueue.md)
 
 
 


### PR DESCRIPTION
Updated documentation to indicate deprecation of Get-CsSharedCallQueueHistoryTemplate in favor of Get-CsSharedCallHistoryTemplate.