### PR TITLE
Remove unsupported GPA content from GPA-excluded policy cmdlets (TeamsAppPermissionPolicy, TeamsUpgradePolicy)

### DIFF
--- a/skype/skype-ps/SkypeForBusiness/Grant-CsTeamsUpgradePolicy.md
+++ b/skype/skype-ps/SkypeForBusiness/Grant-CsTeamsUpgradePolicy.md
@@ -32,13 +32,6 @@ Grant-CsTeamsUpgradePolicy [-MigrateMeetingsToTeams <Boolean>] [-PassThru] [[-Po
  [-MsftInternalProcessingMode <String>] [-Force] [-Global] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
-### GrantToGroup
-```
-Grant-CsTeamsUpgradePolicy [-MigrateMeetingsToTeams <Boolean>] [-PassThru] [[-PolicyName] <String>]
- [-MsftInternalProcessingMode <String>] -Group <String> [-Rank <Int32>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
-```
-
 ## DESCRIPTION
 
 TeamsUpgradePolicy allows administrators to manage the transition from Skype for Business to Teams. As an organization with Skype for Business starts to adopt Teams, administrators can manage the user experience in their organization using the concept of coexistence "mode".  Mode defines in which client incoming chats and calls land as well as in what service (Teams or Skype for Business) new meetings are scheduled in. Mode also governs what functionality is available in the Teams client. Finally, prior to upgrading to TeamsOnly mode administrators can use TeamsUpgradePolicy to trigger notifications in the Skype for Business client to inform users of the pending upgrade.
@@ -203,21 +196,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Group
-Specifies the group used for the group policy assignment.
-
-```yaml
-Type: String
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
 
 > Applicable: Skype for Business Online, Skype for Business Server 2019, Skype for Business Server 2015
@@ -281,21 +259,6 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Rank
-The rank of the policy assignment, relative to other group policy assignments for the same policy type.
-
-```yaml
-Type: Int32
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/teams/teams-ps/MicrosoftTeams/Grant-CsTeamsAppPermissionPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Grant-CsTeamsAppPermissionPolicy.md
@@ -29,12 +29,6 @@ Grant-CsTeamsAppPermissionPolicy [<CommonParameters>]
 Grant-CsTeamsAppPermissionPolicy [-Identity] <String> [[-PolicyName] <String>] [<CommonParameters>]
 ```
 
-### GrantToGroup
-```
-Grant-CsTeamsAppPermissionPolicy [[-PolicyName] <String>] [-Group] <String> [-Rank] <Int32>
- [<CommonParameters>]
-```
-
 ### GrantToTenant
 ```
 Grant-CsTeamsAppPermissionPolicy [[-PolicyName] <String>] [-Global] [-Force] [<CommonParameters>]
@@ -103,21 +97,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Group
-Specifies the group used for the group policy assignment.
-
-```yaml
-Type: String
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
 The user to whom the policy should be assigned.
 
@@ -158,22 +137,6 @@ Aliases:
 
 Required: True
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Rank
-The rank of the policy assignment, relative to other group policy assignments for the same policy type.
-
-```yaml
-Type: Int32
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: True
-Position: Named
-
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/teams/teams-ps/MicrosoftTeams/Grant-CsTeamsUpgradePolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Grant-CsTeamsUpgradePolicy.md
@@ -31,13 +31,6 @@ Grant-CsTeamsUpgradePolicy [-MigrateMeetingsToTeams <Boolean>] [-PassThru] [[-Po
  [-MsftInternalProcessingMode <String>] [-Force] [-Global] [<CommonParameters>]
 ```
 
-### GrantToGroup
-```powershell
-Grant-CsTeamsUpgradePolicy [-MigrateMeetingsToTeams <Boolean>] [-PassThru] [[-PolicyName] <String>]
- [-MsftInternalProcessingMode <String>] -Group <String> [-Rank <Int32>]
- [<CommonParameters>]
-```
-
 ## DESCRIPTION
 
 TeamsUpgradePolicy allows administrators to manage the transition from Skype for Business to Teams. As an organization with Skype for Business starts to adopt Teams, administrators can manage the user experience in their organization using the concept of coexistence "mode".  Mode defines in which client incoming chats and calls land as well as in what service (Teams or Skype for Business) new meetings are scheduled in. Mode also governs what functionality is available in the Teams client. Finally, prior to upgrading to TeamsOnly mode administrators can use TeamsUpgradePolicy to trigger notifications in the Skype for Business client to inform users of the pending upgrade.
@@ -190,21 +183,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Group
-Specifies the group used for the group policy assignment.
-
-```yaml
-Type: String
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Identity
 
 The user you want to grant policy to. This can be specified as SIP address, UserPrincipalName, or ObjectId.
@@ -264,21 +242,6 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Rank
-The rank of the policy assignment, relative to other group policy assignments for the same policy type.
-
-```yaml
-Type: Int32
-Parameter Sets: GrantToGroup
-Aliases:
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
## Summary
Group policy assignment (GPA) is not supported for `TeamsAppPermissionPolicy` or `TeamsUpgradePolicy` (both are absent from the accepted values of [Get-CsGroupPolicyAssignment](https://learn.microsoft.com/powershell/module/microsoftteams/get-csgrouppolicyassignment) `-PolicyType` and are listed as unsupported in the group policy assignment guidance). The Grant cmdlet reference pages still advertise a `GrantToGroup` parameter set with `-Group` and `-Rank`, which misleads admins into attempting group assignment that isn't supported.

## Changes
Removed the `GrantToGroup` syntax block and the `-Group` and `-Rank` parameters from:
- `Grant-CsTeamsAppPermissionPolicy` (MicrosoftTeams)
- `Grant-CsTeamsUpgradePolicy` (MicrosoftTeams)
- `Grant-CsTeamsUpgradePolicy` (SkypeForBusiness — duplicate reference page)

This mirrors the companion fix for `Grant-CsDialoutPolicy` (#13691) and the exclusion-list correction in `New-CsGroupPolicyAssignment` (#13692). Admins should continue to use per-user (`-Identity`) or tenant global (`-Global`) assignment for these policies.
