### PR TITLE
Rename '-Id' parameter to '-Identity' in documentation

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSpamDetectionTemplate.md
@@ -20,7 +20,7 @@ The Get-CsMainlineAttendantSpamDetectionTemplate cmdlet returns a list of spam d
 ## SYNTAX
 
 ```
-Get-CsMainlineAttendantSpamDetectionTemplate [-Id <string>]
+Get-CsMainlineAttendantSpamDetectionTemplate [-Identity <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -48,7 +48,7 @@ This example retrieves the Spam Detection Template with the Identity 3a4b3d9b-91
 
 ## Parameters
 
-### -Id
+### -Identity
 
 Represents the unique identifier of a spam detection template.
 

--- a/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantSpamDetectionTemplate.md
@@ -136,7 +136,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InclusionList
+### -InclusionScope
 
 A list of e.164 formatted phone numbers that will always be considered as spam.
 
@@ -152,7 +152,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ExclusionList
+### -ExclusionScope
 
 A list of e.164 formatted phone numbers that will never be considered as spam.
 

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantSpamDetectionTemplate.md
@@ -19,7 +19,7 @@ Deletes a Teams Phone Agent (Mainline Attendant) Spam Detection template.
 ## SYNTAX
 
 ```
-Remove-CsMainlineAttendantSpamDetectionTemplate -Id <Guid> [<CommonParameters>]
+Remove-CsMainlineAttendantSpamDetectionTemplate -Identity <Guid> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ This example deletes the Teams Phone Agent (Mainline Attendant) template with th
 
 ## PARAMETERS
 
-### -Id
+### -Identity
 
 The Id parameter is the unique identifier assigned to the Spam Detection template.
 


### PR DESCRIPTION
Updated parameter name from '-Id' to '-Identity' in documentation.