### PR TITLE
PS Metadate Hygiene & MicrosoftTeams.md Check

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Export-CsAutoAttendantHolidays.md
+++ b/teams/teams-ps/MicrosoftTeams/Export-CsAutoAttendantHolidays.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Export-CsOnlineAudioFile.md
+++ b/teams/teams-ps/MicrosoftTeams/Export-CsOnlineAudioFile.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/export-csonlineaudiofile
 schema: 2.0.0
 title: Export-CsOnlineAudioFile

--- a/teams/teams-ps/MicrosoftTeams/Find-CsOnlineApplicationInstance.md
+++ b/teams/teams-ps/MicrosoftTeams/Find-CsOnlineApplicationInstance.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/find-csonlineapplicationinstance
 schema: 2.0.0
 title: Find-CsOnlineApplicationInstance
@@ -19,7 +20,7 @@ Use the Find-CsOnlineApplicationInstance cmdlet to find application instances th
 ## SYNTAX
 
 ```
-Find-CsOnlineApplicationInstance [-SearchQuery] <string> [[-MaxResults <uint>] [-ExactMatchOnly] [-AssociatedOnly] [-UnAssociatedOnly] [-Force] [<CommonParameters>]
+Find-CsOnlineApplicationInstance [-SearchQuery] <string> [[-MaxResults] <uint>] [-ExactMatchOnly] [-AssociatedOnly] [-UnAssociatedOnly] [-Force] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -117,7 +118,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -133,7 +134,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendant.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendant.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantHolidays.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantHolidays.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantStatus.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantStatus.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantSupportedLanguage.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantSupportedLanguage.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantSupportedTimeZone.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantSupportedTimeZone.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantTenantInformation.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoAttendantTenantInformation.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsAutoRecordingTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsAutoRecordingTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsComplianceRecordingForCallQueueTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsComplianceRecordingForCallQueueTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantAppointmentBookingFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantAppointmentBookingFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendantappointmentbookingflow
 schema: 2.0.0
 title: Get-CsMainlineAttendantAppointmentBookingFlow

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendantflow
 schema: 2.0.0
 title: Get-CsMainlineAttendantFlow

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantQuestionAnswerFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantQuestionAnswerFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendantquestionanswerflow
 schema: 2.0.0
 title: Get-CsMainlineAttendantQuestionAnswerFlow

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSpamDetectionTemplate.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendantspamdetectiontemplate
 schema: 2.0.0
 title: Get-CsMainlineAttendantSpamDetectionTemplate

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSupportedLanguages.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSupportedLanguages.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendantsupportedlanguages
 schema: 2.0.0
 title: Get-CsMainlineAttendantSupportedLanguages

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSupportedVoices.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantSupportedVoices.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendantsupportedvoices
 schema: 2.0.0
 title: Get-CsMainlineAttendantSupportedVoices

--- a/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantTenantInformation.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsMainlineAttendantTenantInformation.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csmainlineattendanttenantinformation
 schema: 2.0.0
 title: Get-CsMainlineAttendantTenantInformation

--- a/teams/teams-ps/MicrosoftTeams/Get-CsOnlineApplicationInstance.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsOnlineApplicationInstance.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csonlineapplicationinstance
 schema: 2.0.0
 title: Get-CsOnlineApplicationInstance

--- a/teams/teams-ps/MicrosoftTeams/Get-CsOnlineApplicationInstanceAssociation.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsOnlineApplicationInstanceAssociation.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsOnlineApplicationInstanceAssociationStatus.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsOnlineApplicationInstanceAssociationStatus.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsOnlineAudioFile.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsOnlineAudioFile.md
@@ -3,8 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csonlineaudiofile
 schema: 2.0.0
 title: Get-CsOnlineAudioFile

--- a/teams/teams-ps/MicrosoftTeams/Get-CsOnlineVoicemailPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsOnlineVoicemailPolicy.md
@@ -1,11 +1,12 @@
 ---
 applicable: Microsoft Teams
-author: officedocspr
+author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
-ms.author: odocspr
+ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csonlinevoicemailpolicy
 schema: 2.0.0
 title: Get-CsOnlineVoicemailPolicy

--- a/teams/teams-ps/MicrosoftTeams/Get-CsOnlineVoicemailUserSettings.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsOnlineVoicemailUserSettings.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csonlinevoicemailusersettings
 schema: 2.0.0
 title: Get-CsOnlineVoicemailUserSettings

--- a/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallHistoryTemplate.md
@@ -3,8 +3,9 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
-ms.author: vijurtse
+ms.author: colongma
 ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-cssharedcallhistorytemplate
 schema: 2.0.0

--- a/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsSharedCallQueueHistoryTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Get-CsTeamsVoiceApplicationsPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsTeamsVoiceApplicationsPolicy.md
@@ -1,7 +1,12 @@
 ---
+applicable: Microsoft Teams
+author: clyvr
 external help file: MicrosoftTeams-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
+ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/get-csteamsvoiceapplicationspolicy
 schema: 2.0.0
 title: Get-CsTeamsVoiceApplicationsPolicy

--- a/teams/teams-ps/MicrosoftTeams/Grant-CsOnlineVoicemailPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Grant-CsOnlineVoicemailPolicy.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/grant-csonlinevoicemailpolicy
 schema: 2.0.0
 title: Grant-CsOnlineVoicemailPolicy

--- a/teams/teams-ps/MicrosoftTeams/Grant-CsTeamsVoiceApplicationsPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Grant-CsTeamsVoiceApplicationsPolicy.md
@@ -1,7 +1,12 @@
 ---
+applicable: Microsoft Teams
+author: clyvr
 external help file: MicrosoftTeams-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
+ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/grant-csteamsvoiceapplicationspolicy
 schema: 2.0.0
 title: Grant-CsTeamsVoiceApplicationsPolicy

--- a/teams/teams-ps/MicrosoftTeams/Import-CsAutoAttendantHolidays.md
+++ b/teams/teams-ps/MicrosoftTeams/Import-CsAutoAttendantHolidays.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Import-CsOnlineAudioFile.md
+++ b/teams/teams-ps/MicrosoftTeams/Import-CsOnlineAudioFile.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/import-csonlineaudiofile
 schema: 2.0.0
 title: Import-CsOnlineAudioFile

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendant.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendant.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantCallFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantCallFlow.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantCallHandlingAssociation.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantCallHandlingAssociation.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantCallableEntity.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantCallableEntity.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantDialScope.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantDialScope.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantMenu.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantMenu.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantMenuOption.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantMenuOption.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantPrompt.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoAttendantPrompt.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsAutoRecordingTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsAutoRecordingTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsComplianceRecordingForCallQueueTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsComplianceRecordingForCallQueueTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantAppointmentBookingFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantAppointmentBookingFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csmainlineattendantappointmentbookingflow
 schema: 2.0.0
 title: New-CsMainlineAttendantAppointmentBookingFlow

--- a/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantQuestionAnswerFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantQuestionAnswerFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csmainlineattendantquestionanswerflow
 schema: 2.0.0
 title: New-CsMainlineAttendantQuestionAnswerFlow

--- a/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsMainlineAttendantSpamDetectionTemplate.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csmainlineattendantspamdetectiontemplate
 schema: 2.0.0
 title: New-CsMainlineAttendantSpamDetectionTemplate

--- a/teams/teams-ps/MicrosoftTeams/New-CsOnlineApplicationInstance.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsOnlineApplicationInstance.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csonlineapplicationinstance
 schema: 2.0.0
 title: New-CsOnlineApplicationInstance

--- a/teams/teams-ps/MicrosoftTeams/New-CsOnlineApplicationInstanceAssociation.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsOnlineApplicationInstanceAssociation.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsOnlineDateTimeRange.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsOnlineDateTimeRange.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsOnlineSchedule.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsOnlineSchedule.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsOnlineTimeRange.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsOnlineTimeRange.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsOnlineVoicemailPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsOnlineVoicemailPolicy.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csonlinevoicemailpolicy
 schema: 2.0.0
 title: New-CsOnlineVoicemailPolicy

--- a/teams/teams-ps/MicrosoftTeams/New-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsSharedCallHistoryTemplate.md
@@ -1,10 +1,11 @@
 ---
 applicable: Microsoft Teams
-author: vijurtse
+author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
-ms.author: vijurtse
+ms.author: colongma
 ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-cssharedcallhistorytemplate
 schema: 2.0.0

--- a/teams/teams-ps/MicrosoftTeams/New-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsSharedCallQueueHistoryTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsVoiceApplicationsPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsVoiceApplicationsPolicy.md
@@ -1,7 +1,12 @@
 ---
+applicable: Microsoft Teams
+author: clyvr
 external help file: MicrosoftTeams-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
+ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/new-csteamsvoiceapplicationspolicy
 ROBOTS: NOINDEX
 schema: 2.0.0

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsAutoAttendant.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsAutoAttendant.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsAutoRecordingTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsAutoRecordingTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsComplianceRecordingForCallQueueTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsComplianceRecordingForCallQueueTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantAppointmentBookingFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantAppointmentBookingFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/remove-csmainlineattendantappointmentbookingflow
 schema: 2.0.0
 title: Remove-CsMainlineAttendantAppointmentBookingFlow

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantQuestionAnswerFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantQuestionAnswerFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/remove-csmainlineattendantquestionanswerflow
 schema: 2.0.0
 title: Remove-CsMainlineAttendantQuestionAnswerFlow

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsMainlineAttendantSpamDetectionTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsOnlineApplicationInstanceAssociation.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsOnlineApplicationInstanceAssociation.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsOnlineAudioFile.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsOnlineAudioFile.md
@@ -3,8 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/remove-csonlineaudiofile
 schema: 2.0.0
 title: Remove-CsOnlineAudioFile

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsOnlineVoicemailPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsOnlineVoicemailPolicy.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/remove-csonlinevoicemailpolicy
 schema: 2.0.0
 title: Remove-CsOnlineVoicemailPolicy

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallHistoryTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsSharedCallQueueHistoryTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Remove-CsTeamsVoiceApplicationsPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Remove-CsTeamsVoiceApplicationsPolicy.md
@@ -1,7 +1,12 @@
 ---
+applicable: Microsoft Teams
+author: clyvr
 external help file: MicrosoftTeams-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
+ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/remove-csteamsvoiceapplicationspolicy
 schema: 2.0.0
 title: Remove-CsTeamsVoiceApplicationsPolicy

--- a/teams/teams-ps/MicrosoftTeams/Set-CsAutoAttendant.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsAutoAttendant.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Set-CsAutoRecordingTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsAutoRecordingTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Set-CsComplianceRecordingForCallQueueTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsComplianceRecordingForCallQueueTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Set-CsMainlineAttendantAppointmentBookingFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsMainlineAttendantAppointmentBookingFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csmainlineattendantappointmentbookingflow
 schema: 2.0.0
 title: Set-CsMainlineAttendantAppointmentBookingFlow

--- a/teams/teams-ps/MicrosoftTeams/Set-CsMainlineAttendantQuestionAnswerFlow.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsMainlineAttendantQuestionAnswerFlow.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csmainlineattendantquestionanswerflow
 schema: 2.0.0
 title: Set-CsMainlineAttendantQuestionAnswerFlow

--- a/teams/teams-ps/MicrosoftTeams/Set-CsMainlineAttendantSpamDetectionTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsMainlineAttendantSpamDetectionTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Set-CsOnlineApplicationInstance.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsOnlineApplicationInstance.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csonlineapplicationinstance
 schema: 2.0.0
 title: Set-CsOnlineApplicationInstance

--- a/teams/teams-ps/MicrosoftTeams/Set-CsOnlineVoicemailPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsOnlineVoicemailPolicy.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csonlinevoicemailpolicy
 schema: 2.0.0
 title: Set-CsOnlineVoicemailPolicy

--- a/teams/teams-ps/MicrosoftTeams/Set-CsOnlineVoicemailUserSettings.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsOnlineVoicemailUserSettings.md
@@ -3,9 +3,10 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csonlinevoicemailusersettings
 schema: 2.0.0
 title: Set-CsOnlineVoicemailUserSettings

--- a/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallHistoryTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallQueueHistoryTemplate.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsSharedCallQueueHistoryTemplate.md
@@ -3,6 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsVoiceApplicationsPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsVoiceApplicationsPolicy.md
@@ -1,7 +1,12 @@
 ---
+applicable: Microsoft Teams
+author: clyvr
 external help file: MicrosoftTeams-help.xml
 Locale: en-US
+manager: roykuntz
 Module Name: MicrosoftTeams
+ms.author: colongma
+ms.reviewer: colongma
 online version: https://learn.microsoft.com/powershell/module/microsoftteams/set-csteamsvoiceapplicationspolicy
 schema: 2.0.0
 title: Set-CsTeamsVoiceApplicationsPolicy

--- a/teams/teams-ps/MicrosoftTeams/Update-CsAutoAttendant.md
+++ b/teams/teams-ps/MicrosoftTeams/Update-CsAutoAttendant.md
@@ -3,7 +3,7 @@ applicable: Microsoft Teams
 author: clyvr
 external help file: Microsoft.Rtc.Management.Hosted.dll-help.xml
 Locale: en-US
-manager: bulenteg
+manager: roykuntz
 Module Name: MicrosoftTeams
 ms.author: colongma
 ms.reviewer: colongma


### PR DESCRIPTION
Ensuring all headers are standard for all VoiceApps related PS cmdlets - and that they're in the right order in MicrosoftTeams.md