### PR TITLE
Document EnableExternalRecordingDetection for TeamsMeetingPolicy

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsMeetingPolicy.md
@@ -83,6 +83,7 @@ New-CsTeamsMeetingPolicy [-Identity] <XdsIdentity>
  [-DesignatedPresenterRoleMode <String>]
  [-DetectSensitiveContentDuringScreenSharing <Boolean>]
  [-DisableAudioAnnouncementsForResourceAccounts <Boolean>]
+ [-EnableExternalRecordingDetection <Boolean>]
  [-EnrollUserOverride <String>]
  [-ExplicitRecordingConsent <String>]
  [-ExternalMeetingJoin <String>]
@@ -2145,6 +2146,27 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableExternalRecordingDetection
+
+Controls whether Teams detects third-party applications, such as screen recorders, audio recorders, and AI note-takers, capturing audio on the user's device during a meeting.
+
+Possible values are:
+
+- **$true**: The user's client runs external recording detection and participants are notified when a third-party application is detected capturing audio.
+- **$false**: External recording detection does not run. This is the default value.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Set-CsTeamsMeetingPolicy.md
@@ -89,6 +89,7 @@ Set-CsTeamsMeetingPolicy [[-Identity] <XdsIdentity>]
  [-DesignatedPresenterRoleMode <String>]
  [-DetectSensitiveContentDuringScreenSharing <Boolean>]
  [-DisableAudioAnnouncementsForResourceAccounts <Boolean>]
+ [-EnableExternalRecordingDetection <Boolean>]
  [-EnrollUserOverride <String>]
  [-ExplicitRecordingConsent <String>]
  [-ExternalMeetingJoin <String>]
@@ -2402,6 +2403,27 @@ Aliases:
 Required: False
 Position: Named
 Default value: Everyone
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableExternalRecordingDetection
+
+Controls whether Teams detects third-party applications, such as screen recorders, audio recorders, and AI note-takers, capturing audio on the user's device during a meeting.
+
+Possible values are:
+
+- **$true**: The user's client runs external recording detection and participants are notified when a third-party application is detected capturing audio.
+- **$false**: External recording detection does not run. This is the default value.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
[PubOps Review Feedback](https://github.com/MicrosoftDocs/office-docs-powershell/pull/13777#issuecomment-5359459667)

## Summary
- Adds the `EnableExternalRecordingDetection` parameter to `New-CsTeamsMeetingPolicy`.
- Adds the `EnableExternalRecordingDetection` parameter to `Set-CsTeamsMeetingPolicy`.
- Documents the Boolean behavior and default value of `False`.

## Related change
- [Policy definition PR 1478493](https://dev.azure.com/skype/SBS/_git/infrastructure_web_interfaces-policydef/pullrequest/1478493)

## Validation
- Confirmed the parameter type and default against the TeamsMeetingPolicy schema.
- Verified each cmdlet page contains one syntax entry and one parameter section.
- `git diff --check` passes.
