### PR TITLE
Update Get-CsTeamsAIPolicy

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/Get-CsTeamsAIPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/Get-CsTeamsAIPolicy.md
@@ -24,7 +24,7 @@ Get-CsTeamsAIPolicy [[-Identity] <String>] [-Filter <String>] [<CommonParameters
 
 ## DESCRIPTION
 
-The new csTeamsAIPolicy will replace the existing enrollment settings in csTeamsMeetingPolicy, providing enhanced flexibility and control for Teams meeting administrators. Unlike the current single setting, EnrollUserOverride, which applies to both face and voice enrollment, the new policy introduces two distinct settings: EnrollFace and EnrollVoice. These can be individually set to Enabled or Disabled, offering more granular control over biometric enrollments. A new setting, SpeakerAttributionBYOD, is also being added to csTeamsAIPolicy. This allows IT admins to turn off speaker attribution in BYOD scenarios, giving them greater control over how voice data is managed in such environments. This setting can be set to Enabled or Disabled, and will be Enabled by default. In addition to improving the management of face and voice data, the csTeamsAIPolicy is designed to support future AI-related settings in Teams, making it a scalable solution for evolving needs.
+The new csTeamsAIPolicy will replace the existing enrollment settings in csTeamsMeetingPolicy, providing enhanced flexibility and control for Teams meeting administrators. Unlike the current single setting, EnrollUserOverride, which applies to both face and voice enrollment, the new policy introduces two distinct settings: EnrollFace and EnrollVoice. These can be individually set to Enabled or Disabled, offering more granular control over biometric enrollments. A new setting, SpeakerAttributionForBYOD, is also being added to csTeamsAIPolicy. This allows IT admins to turn off speaker attribution in BYOD scenarios, giving them greater control over how voice data is managed in such environments. This setting can be set to Enabled or Disabled, and will be Enabled by default. In addition to improving the management of face and voice data, the csTeamsAIPolicy is designed to support future AI-related settings in Teams, making it a scalable solution for evolving needs.
 
 This cmdlet retrieves all Teams AI policies for the tenant.
 
@@ -35,7 +35,7 @@ This cmdlet retrieves all Teams AI policies for the tenant.
 PS C:\> Get-CsTeamsAIPolicy
 ```
 
-Retrieves Teams AI policies and shows "EnrollFace", "EnrollVoice" and "SpeakerAttributionBYOD" values.
+Retrieves Teams AI policies and shows "EnrollFace", "EnrollVoice" and "SpeakerAttributionForBYOD" values.
 
 ## PARAMETERS
 


### PR DESCRIPTION
By checking the actual parameters of the Teams Set-CsTeamsAIPolicy command, we confirmed that the parameter used to enable speaker recognition was incorrect.