### PR TITLE
Update New-CsTeamsComplianceRecordingPolicy

### DIFF
--- a/teams/teams-ps/MicrosoftTeams/New-CsTeamsComplianceRecordingPolicy.md
+++ b/teams/teams-ps/MicrosoftTeams/New-CsTeamsComplianceRecordingPolicy.md
@@ -115,8 +115,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -CustomPromptsEnabled
-Indicates whether compliance recording custom prompts feature is enabled for this tenant / user.
+### -CustomPromptsEnabled 
+Indicates whether compliance recording custom prompts feature in 1:1 calls is enabled for this tenant / user. Currently only available in private preview.
 
 ```yaml
 Type: Boolean
@@ -131,7 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -CustomPromptsPackageId
-Reference to custom prompts package.
+Reference to custom prompts package. Currently only available in private preview.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Adding information that Custom Prompts for Compliance Recording is not available in public, only in private preview.